### PR TITLE
Fix state_code for South Africa states Gauteng and Kwazulu-Natal

### DIFF
--- a/states.json
+++ b/states.json
@@ -26170,14 +26170,14 @@
         "name": "Gauteng",
         "country_id": 204,
         "country_code": "ZA",
-        "state_code": "GT"
+        "state_code": "GP"
     },
     {
         "id": 935,
         "name": "KwaZulu-Natal",
         "country_id": 204,
         "country_code": "ZA",
-        "state_code": "NL"
+        "state_code": "KZN"
     },
     {
         "id": 933,


### PR DESCRIPTION
ZA-GP - Gauteng
ZA-KZN - Kwazulu-Natal

https://en.wikipedia.org/wiki/ISO_3166-2:ZA