### PR TITLE
Fixed wrong primary divisions in Italy

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,3 @@
+Città metropolitana di Milano doesn not exist. It is not a state from Italy. 
+Città metropolitana di Roma Capitale doesn not exist. It is not a state from Italy. 
+Changed Milan to Milano, which is the original name

--- a/scripts/vendor/base.php
+++ b/scripts/vendor/base.php
@@ -13,8 +13,8 @@ $NUMBER_OF_SECONDS = 1;
 $API_KEY = ''; // Your RapidApi GeoDBCities Api Key
 
 $servername = "127.0.0.1";
-$username = "root";
-$password = "root";
+$username = "wuser";
+$password = "pass1234";
 $dbname = "world";
 $port = 3306;
 


### PR DESCRIPTION
Primary divisions in Italy are "regions", not "provinces". A province in Italy is just a city and it is the capital of the region, just like Sacramento is the capital of California. Therefore if you define a city like "Milan" like a province, it will be then duplicate as a city of Lombardy. And you end up with lot of duplicated data. I fixed them. Below the changelog of this commit. I would like to be a contrubutor of this project. And I would agree if you accept this commit. 

And check the project. You might have made the same mistake with other countries not only Italy. For example, Brazil is a very problematic one. 

Here the changelog:
Rome is not a province. Is a city. Removed id 1711 (Duplicate)
Milan is not a province. Is a city. Removed id 1698 (Duplicate)
Modena is not a province. Is a city. Removed id 1757 (Duplicate)
Messina is not a province. Is a city. Removed id 1770 (Duplicate)
Matera is not a province. Is a city. Removed id 1760 (Duplicate)
Bari is not a province. Is a city. Removed id 1772 (Duplicate)
Ascoli Piceno is not a province. Is a city. Removed id 1681 (Duplicate)
Same thing with Asti. Removed id 1780 (Duplicate)
Agrigento id 1727
Alessandria id 1783
Ancona 1672
Barletta-Adria-Trani 1686
Latina 1674
Lecce  1675
Lecco 1677 
Livorno 1745
Lodi 1747
Lucca 1749
Macerata 1750
Medio Campidiano 1761
Massa and Carrara 1759
Monza and Brianza 1769
Cagliari 1682
Belluno 1689
Benevento 1701
Bergamo 1704
Biella 1778
Brindisi 1714
Bologna 1684
Brescia 1717
Caltanissetta 1718
Campobasso 1721
Caserta 1731
Catania 1766
Catanzaro 1728
Chieti 1739
Como 1740
Cosenza 1742
Cremona 1751
Crotone 1754
Cuneo 1775
Enna 1723
Fermo 1744
Ferrara 1746
Foggia 1771
Florence 1680
Forlì-Cesena 1779
Frosinone 1776
Genoa 1699
Gorizia 1777
Grosseto 1787
Imperia 1788 
Isernia 1789
L'Aquila 1781
La Spezia 1791
Mantua 1758
Naples 1724
Novara 1774
Nuoro 1790
Oristano 1786
Padua 1665
Palermo 1668
Parma 1666
Pavia 1676
Perugia 1691
Pesaro And Urbino 1693
Pescara 1694
Piacenza 1696
Pisa 1685
Pistoia 1687
Pordenone 1690
Potenza 1697
Prato 1700
Ragusa 1729
Reggio Calabria 1671
Reggio Emilia 1708
Rieti 1712
Rimini 1713
Rovigo 1719
Salerno 1720
Sassari 1722
Savona 1732
Siena 1734
Siracusa 1667
Sondrio 1741
South Sardinia (This is not a province) 1730
South Tyrol 1767 (This is not a province)
Taranto 1743
Teramo 1752
Terni 1755
Trapani 1733
Trentino 1748 (Same thing as Trentino-South Tyrol)
Treviso 1762
Trieste 1763
Turin 1710
Udine 1764
Varese 1765
Venice 1673
Verbano-Cussio-Ossola 1726
Vercelli 1785
Verona 1736
Vibo Valentia 1737
Vicenza 1738
Viterbo 1735





