### PR TITLE
Update country name from Turkey to Türkiye

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -11656,7 +11656,7 @@
     },
     {
         "id": 225,
-        "name": "Turkey",
+        "name": "Türkiye",
         "iso3": "TUR",
         "iso2": "TR",
         "numeric_code": "792",


### PR DESCRIPTION
This commit updates Turkey's country name from "Turkey" to "Türkiye" in accordance with the official change made by the Turkish government via the UN in 2022.