### PR TITLE
fix: JSON export region_id type consistency

### DIFF
--- a/bin/Commands/ExportJson.php
+++ b/bin/Commands/ExportJson.php
@@ -282,7 +282,7 @@ class ExportJson extends Command
                     // Pushing it into Fresh Array
                     $subregionsArray[$s]['id'] = (int)$row['id'];
                     $subregionsArray[$s]['name'] = $row['name'];
-                    $subregionsArray[$s]['region_id'] = $row['region_id'];
+                    $subregionsArray[$s]['region_id'] = (int)$row['region_id'];
                     $subregionsArray[$s]['translations'] = json_decode($row['translations'], true);
                     $subregionsArray[$s]['wikiDataId'] = $row['wikiDataId'];
                     $s++;


### PR DESCRIPTION
Fixes #956 by making sure that the 'region_id' is stored as an int (consistent with other ids and data model).

This will ensure that the region_id in the json and yaml exports of the subregions is an int. 