### PR TITLE
fix: cast state population to integer in JSON exporter

### DIFF
--- a/bin/Commands/ExportJson.php
+++ b/bin/Commands/ExportJson.php
@@ -162,7 +162,7 @@ class ExportJson extends Command
                         $statesArray[$i]['timezone'] = $state['timezone'];
                         $statesArray[$i]['translations'] = json_decode($state['translations'], true);
                         $statesArray[$i]['wikiDataId'] = $state['wikiDataId'];
-                        $statesArray[$i]['population'] = $state['population'];
+                        $statesArray[$i]['population'] = $state['population'] !== null ? (int)$state['population'] : null;
 
                         // For Country State Array
                         $stateArr = array(


### PR DESCRIPTION
## Description

The documentation specifies that the population field should be exported as an integer.
However, in the generated JSON (and MongoDB dump), the states dataset was outputting population as a string due to a missing type cast in the exporter.

This PR updates the exporter to ensure that the population field in the states dataset is cast to an integer, aligning the output with the documented schema and improving data consistency.

## What I have done

Added integer casting for the population field in the JSON exporter.

```
$statesArray[$i]['population'] = $state['population'];
```
to
```
$statesArray[$i]['population'] = $state['population'] !== null ? (int)$state['population'] : null;
```
Behavior now matches the existing implementation for countries and cities.
Ensures that future JSON exports output the correct integer type.

## Notes
This change does not affect any other fields or datasets.

Fixs #1320 