### PR TITLE
fix: add missing city Al-Quway'iyah to Riyadh Province, Saudi Arabia

### DIFF
--- a/contributions/cities/SA.json
+++ b/contributions/cities/SA.json
@@ -16,7 +16,7 @@
     "timezone": "Asia/Riyadh",
     "translations": {
       "br": "Abha",
-      "ko": "아바",
+      "ko": "아브하",
       "pt-BR": "Abha",
       "pt": "Abha",
       "nl": "Abha",
@@ -24,16 +24,20 @@
       "fa": "ابها",
       "de": "Abha",
       "es": "Abha",
-      "fr": "Abha",
-      "ja": "アブハ",
+      "fr": "Abha (Arabie saoudite)",
+      "ja": "アブハー",
       "it": "Abha",
       "zh-CN": "阿卜哈",
       "tr": "Abha",
       "ru": "Абха",
-      "uk": "Абха",
+      "uk": "Абга",
       "pl": "Abha",
       "hi": "आभा",
-      "ar": "أبها"
+      "ar": "أبها",
+      "bn": "আবহা",
+      "id": "Abha",
+      "vi": "Abha",
+      "zh": "艾卜哈"
     },
     "created_at": "2019-10-06T10:17:54",
     "updated_at": "2025-12-02T14:39:31",
@@ -16258,5 +16262,27 @@
     "updated_at": "2025-02-01T00:00:00",
     "flag": 1,
     "wikiDataId": "Q12192352"
+  },
+  {
+    "name": "Al-Quway'iyah",
+    "state_id": 2849,
+    "state_code": "01",
+    "country_id": 194,
+    "country_code": "SA",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "24.04638889",
+    "longitude": "45.26555556",
+    "native": "القويعية",
+    "population": null,
+    "timezone": "Asia/Riyadh",
+    "translations": {
+      "ar": "القويعية",
+      "fa": "شهر القویعیه",
+      "pl": "Al-Kuwajijja",
+      "tr": "El-Kuveyiye"
+    },
+    "wikiDataId": "Q3545549"
   }
 ]


### PR DESCRIPTION
## Summary
Rebased version of #1361 (conflict-free, no schema.sql contamination).

- Adds Al-Quway'iyah (القويعية) city to Riyadh Province, Saudi Arabia
- Corrects Abha translations (ko, fr, ja, uk) and adds bn, id, vi, zh
- Source: WikiData [Q3545549](https://www.wikidata.org/wiki/Q3545549)

Closes #1361