### PR TITLE
fix: add missing city Shaqra to Riyadh Province, Saudi Arabia

### DIFF
--- a/contributions/cities/SA.json
+++ b/contributions/cities/SA.json
@@ -16284,5 +16284,31 @@
       "tr": "El-Kuveyiye"
     },
     "wikiDataId": "Q3545549"
+  },
+  {
+    "name": "Shaqra",
+    "state_id": 2849,
+    "state_code": "01",
+    "country_id": 194,
+    "country_code": "SA",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "25.24833333",
+    "longitude": "45.25277778",
+    "native": "شقراء",
+    "population": null,
+    "timezone": "Asia/Riyadh",
+    "translations": {
+      "ar": "شقراء",
+      "de": "Schaqrāʾ",
+      "ja": "シャクラー",
+      "nl": "Shaqra",
+      "pl": "Szakra",
+      "ru": "Шакра",
+      "tr": "Şakra",
+      "zh-CN": "舍格拉"
+    },
+    "wikiDataId": "Q97291341"
   }
 ]


### PR DESCRIPTION
Rebased version of #1362 (data-only, no US.json/schema.sql contamination). Adds Shaqra (شقراء). Closes #1362