### PR TITLE
[codex] Add Paraguay cities

### DIFF
--- a/contributions/cities/PY.json
+++ b/contributions/cities/PY.json
@@ -82,6 +82,23 @@
     "wikiDataId": "Q926511"
   },
   {
+    "name": "Agua Dulce de Santa María",
+    "state_id": 2785,
+    "state_code": "16",
+    "country_id": 172,
+    "country_code": "PY",
+    "type": "locality",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-19.98378500",
+    "longitude": "-59.75844700",
+    "native": "Agua Dulce de Santa María",
+    "population": 1200,
+    "timezone": "America/Asuncion",
+    "translations": {},
+    "wikiDataId": "Q124049205"
+  },
+  {
     "id": 89718,
     "name": "Altos",
     "state_id": 2783,
@@ -2091,6 +2108,40 @@
     "wikiDataId": "Q47062"
   },
   {
+    "name": "Fortín Boquerón",
+    "state_id": 2780,
+    "state_code": "19",
+    "country_id": 172,
+    "country_code": "PY",
+    "type": "locality",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-22.78333000",
+    "longitude": "-59.95000000",
+    "native": "Fortín Boquerón",
+    "population": null,
+    "timezone": "America/Asuncion",
+    "translations": {},
+    "wikiDataId": "Q116250380"
+  },
+  {
+    "name": "Fortín General Eugenio Garay",
+    "state_id": 2780,
+    "state_code": "19",
+    "country_id": 172,
+    "country_code": "PY",
+    "type": "locality",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-20.51666670",
+    "longitude": "-62.13333330",
+    "native": "Fortín General Eugenio Garay",
+    "population": 40,
+    "timezone": "America/Asuncion",
+    "translations": {},
+    "wikiDataId": "Q124304538"
+  },
+  {
     "id": 89767,
     "name": "Fram",
     "state_id": 2778,
@@ -3237,6 +3288,34 @@
     "updated_at": "2025-12-02T14:39:31",
     "flag": 1,
     "wikiDataId": "Q47052"
+  },
+  {
+    "name": "Mariscal José Félix Estigarribia",
+    "state_id": 2780,
+    "state_code": "19",
+    "country_id": 172,
+    "country_code": "PY",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-22.03055556",
+    "longitude": "-60.61111111",
+    "native": "Mariscal José Félix Estigarribia",
+    "population": 41106,
+    "timezone": "America/Asuncion",
+    "translations": {
+      "ar": "ماريسكال استيغاريبيا",
+      "de": "Mariscal Estigarribia",
+      "es": "Mariscal José Félix Estigarribia",
+      "fr": "Mariscal José Félix Estigarribia",
+      "it": "Mariscal José Félix Estigarribia",
+      "pl": "Mariscal Estigarribia",
+      "pt": "Mariscal José Félix Estigarribia",
+      "ru": "Марискаль-Эстигаррибия",
+      "tr": "Mariscal Estigarribia",
+      "zh": "埃斯蒂加里維亞元帥鎮"
+    },
+    "wikiDataId": "Q1093167"
   },
   {
     "id": 89795,
@@ -5328,6 +5407,29 @@
     "updated_at": "2025-12-02T17:11:50",
     "flag": 1,
     "wikiDataId": "Q1092820"
+  },
+  {
+    "name": "Villa Oliva",
+    "state_id": 2781,
+    "state_code": "12",
+    "country_id": 172,
+    "country_code": "PY",
+    "type": "locality",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-26.02000000",
+    "longitude": "-57.87000000",
+    "native": "Villa Oliva",
+    "population": 990,
+    "timezone": "America/Asuncion",
+    "translations": {
+      "es": "Villa Oliva",
+      "fr": "Villa Oliva",
+      "it": "Villa Oliva (Paraguay)",
+      "pt": "Villa Oliva",
+      "zh": "奧利瓦鎮"
+    },
+    "wikiDataId": "Q1750358"
   },
   {
     "id": 89846,


### PR DESCRIPTION
Adds five Paraguay locations to `contributions/cities/PY.json`:

- Agua Dulce de Santa María
- Fortín Boquerón
- Fortín General Eugenio Garay
- Mariscal José Félix Estigarribia
- Villa Oliva

Each new record includes coordinates, `America/Asuncion`, Wikidata IDs, and the country/state references required by the dataset. I also ran the repository's translation enricher so entries with available Wikipedia language links were populated automatically.

Validation:
- JSON parse check on `contributions/cities/PY.json`
- `python3 bin/scripts/validation/translation_enricher.py --file contributions/cities/PY.json --type city`
- `git diff --cached --check`

