### PR TITLE
fix(workflow): add csv/cities.csv to gzip+release upload

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -338,6 +338,10 @@ jobs:
 
           # CSV Files
           echo "📄 Compressing CSV files..."
+          if [ -f csv/cities.csv ]; then
+            gzip -9 -k -f csv/cities.csv
+            echo "  ✓ csv/cities.csv.gz"
+          fi
           if [ -f csv/translations.csv ]; then
             gzip -9 -k -f csv/translations.csv
             echo "  ✓ csv/translations.csv.gz"


### PR DESCRIPTION
## Summary

The export workflow was generating `csv/cities.csv` but not compressing or uploading it, leaving downstream consumers without a stable URL for the CSV cities export. All other formats (json, sql, xml, yml, sqlite, sqlserver, geojson, toon) already gzip the cities table — this PR adds the missing parallel block for CSV.

## Root cause

In `.github/workflows/export.yml`, the CSV compression block at lines 339–344 only handles `csv/translations.csv`:

```yaml
# CSV Files
echo "📄 Compressing CSV files..."
if [ -f csv/translations.csv ]; then
  gzip -9 -k -f csv/translations.csv
  echo "  ✓ csv/translations.csv.gz"
fi
```

Compare with the JSON block above it which correctly handles `cities.json`:

```yaml
if [ -f json/cities.json ]; then
  gzip -9 -k -f json/cities.json
  echo "  ✓ json/cities.json.gz"
fi
```

The upload pattern at line 489 (`'csv/*.gz'`) already includes anything compressed in `csv/`, so once `csv/cities.csv.gz` exists it will be uploaded automatically — no other workflow changes needed.

## Result

After merge + a workflow run, downstream consumers can again use a stable canonical URL:

```bash
curl -LO https://github.com/dr5hn/countries-states-cities-database/releases/latest/download/csv-cities.csv.gz
gunzip csv-cities.csv.gz
```

Closes #1374

## Test plan
- [x] Diff is a 4-line additive change matching the established pattern of every other format block.
- [ ] After merge, trigger `export.yml` manually to publish `csv-cities.csv.gz` to the next release.
- [ ] Verify the file appears on `releases/latest/download/csv-cities.csv.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)