### PR TITLE
feat(CA): add Diamond Valley, Alberta

### DIFF
--- a/contributions/cities/CA.json
+++ b/contributions/cities/CA.json
@@ -9266,6 +9266,22 @@
     "wikiDataId": "Q2105198"
   },
   {
+    "name": "Diamond Valley",
+    "state_id": 872,
+    "state_code": "AB",
+    "country_id": 39,
+    "country_code": "CA",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "50.67200000",
+    "longitude": "-114.23300000",
+    "native": "Diamond Valley",
+    "timezone": "America/Edmonton",
+    "translations": {},
+    "wikiDataId": "Q112136695"
+  },
+  {
     "id": 16372,
     "name": "Didsbury",
     "state_id": 872,


### PR DESCRIPTION
Closes #1377

## Summary
Adds the **Town of Diamond Valley**, Alberta, Canada to the cities dataset. Diamond Valley was incorporated on **2023-01-01** through the amalgamation of the former towns of Black Diamond and Turner Valley.

## Record details
- `name`: Diamond Valley
- `state_id`: 872 (Alberta) — note: issue #1377 quoted `state_id: 862`, but the actual Alberta record id in `contributions/states/states.json` is **872**; the issue value was incorrect and has been corrected here.
- `country_id`: 39 (Canada)
- `latitude`: 50.67200000, `longitude`: -114.23300000 (within Canada bbox; matches Wikidata position 50.676 N, 114.260 W)
- `timezone`: America/Edmonton (matches province record)
- `wikiDataId`: [Q112136695](https://www.wikidata.org/wiki/Q112136695) — verified P31 = "town in Alberta", P17 = Canada (Q16), P131 = Alberta
- `type`: `city` (matches neighbouring Alberta records, e.g. Devon, Didsbury, Calgary which are also legally towns but typed `city` in this dataset for consistency)
- IDs / `flag` / timestamps omitted — MySQL-managed.

## Validation performed
- JSON parses cleanly; CA city count 1079 → 1080.
- No name clash on `Diamond Valley`.
- Coordinates inside Canada bounding box (`.github/data/country-bounds.json`).
- Schema fields match neighbouring Alberta record (Devon).

## Note on PR validator duplicate detection
The 5km duplicate check will flag **Black Diamond** (3.13 km away). This is expected — Black Diamond is the historical predecessor of Diamond Valley (along with Turner Valley, which is not present in this dataset). The Black Diamond record is left unchanged in this PR; deciding whether to retire/merge it is out of scope for issue #1377 and should be tracked separately if desired.

## Source
- Issue: https://github.com/dr5hn/countries-states-cities-database/issues/1377
- Wikipedia: https://en.wikipedia.org/wiki/Diamond_Valley,_Alberta
- Wikidata: https://www.wikidata.org/wiki/Q112136695