### PR TITLE
feat(FR): polish department + region metadata vs data.gouv.fr (#1352 PR-B)

### DIFF
--- a/.github/fixes-docs/FIX_1352_PR_B_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1352_PR_B_SUMMARY.md
@@ -1,0 +1,157 @@
+# FIX #1352 (PR-B) — France: department + region metadata polish
+
+**Issue:** [#1352 — France data review (Option C, 4 sub-PRs)](https://github.com/dr5hn/countries-states-cities-database/issues/1352)
+**Scope of this PR:** Department + region metadata polish ONLY. Cities are PR-A; overseas city files are PR-D; PR-C is reserved for follow-up.
+**Date:** 2026-04-25
+**Authoritative source:** data.gouv.fr open feeds (INSEE-derived)
+- `departements.min.json` (101 entries: 96 metropolitan + 5 overseas DROM) — https://github.com/user-attachments/files/25721909/departements.min.json
+- `regions.min.json` (18 entries: 13 metropolitan + 5 overseas DROM) — https://github.com/user-attachments/files/25721911/regions.min.json
+
+## Problem
+
+A targeted diff of `contributions/states/states.json` (124 FR records) against the data.gouv.fr feeds surfaced two categories of stale metadata:
+
+1. **Garbage `native` values on 11 metropolitan departments.** The `native` field on records like Ain, Aude, Eure, Gard, Gers, Indre, Lot, Manche, Meuse, Haut-Rhin, and Var contained unrelated French sentence fragments ("Se faire", "entendus", "Ton", "Gardien", "Génie", "Interne", "Parcelle", "Quelques", "Notre"…) plus a typo ("Miuse" for Meuse, "Peau" for Haut-Rhin). These appear to be the residue of a translation pipeline that emitted text fragments rather than the geographic name.
+2. **Misclassified Corse + English in a `native` field.** Corse (ISO 3166-2 `FR-20R`) was tagged `metropolitan collectivity with special status`, but data.gouv.fr lists Corse in the **regions** feed, and Wikipedia/INSEE confirm it is one of France's 18 regions (with enhanced autonomy, but a region nonetheless). Its `native` was the typo `"Corsée"`. Separately, French Guiana (ISO `FR-973`, type `overseas region`) had its `native` set to the English string `"French Guiana"` instead of the French `"Guyane"`.
+
+## Tooling
+
+A new read-only diff script lives at `bin/scripts/fixes/france_states_diff.py`. It compares the data.gouv.fr feeds against repo `country_code='FR'` records and reports four sections:
+
+- **Real deltas** (department + region native names; region type)
+- **Typographical-only diffs** (advisory; differs in punctuation/hyphens only)
+- **Coverage of fields not in the feeds** (`fips_code`, `iso3166_2`, `latitude`, `longitude`, `wikiDataId`, `timezone`)
+- **Repo records outside the feed scope** (overseas collectivities, dependencies, special-status metropolitan collectivities, overseas territory)
+
+Run with:
+
+```bash
+python3 bin/scripts/fixes/france_states_diff.py
+# or with explicit paths
+python3 bin/scripts/fixes/france_states_diff.py --departements /tmp/fr1352/departements.min.json --regions /tmp/fr1352/regions.min.json
+```
+
+After this PR's edits the script reports `Department deltas: 0` and `Region deltas: 0`. Remaining output is advisory only.
+
+## Changes Applied (13 records, all in `contributions/states/states.json`)
+
+### Department `native` repairs (11)
+
+| ISO2 | `name` (English) | `native` before | `native` after |
+|------|------------------|-----------------|----------------|
+| 01   | Ain              | `Se faire`      | `Ain`          |
+| 11   | Aude             | `entendus`      | `Aude`         |
+| 27   | Eure             | `Ton`           | `Eure`         |
+| 30   | Gard             | `Gardien`       | `Gard`         |
+| 32   | Gers             | `Génie`         | `Gers`         |
+| 36   | Indre            | `Interne`       | `Indre`        |
+| 46   | Lot              | `Parcelle`      | `Lot`          |
+| 50   | Manche           | `Quelques`      | `Manche`       |
+| 55   | Meuse            | `Miuse`         | `Meuse`        |
+| 68   | Haut-Rhin        | `Peau`          | `Haut-Rhin`    |
+| 83   | Var              | `Notre`         | `Var`          |
+
+### Overseas region `native` repair (1)
+
+| ISO2 | `name` (English) | `native` before  | `native` after |
+|------|------------------|------------------|----------------|
+| 973  | French Guiana    | `French Guiana`  | `Guyane`       |
+
+### Corse reclassification + native typo (1 record, 2 fields)
+
+| ISO2 | Field    | Before                                            | After                  |
+|------|----------|---------------------------------------------------|------------------------|
+| 20R  | `type`   | `metropolitan collectivity with special status`   | `metropolitan region`  |
+| 20R  | `native` | `Corsée`                                          | `Corse`                |
+
+After this change, the FR `type` distribution becomes:
+
+| Type | Count |
+|------|------:|
+| metropolitan department | 95 |
+| metropolitan region | **13** (was 12; +Corse) |
+| overseas region | 5 |
+| overseas collectivity | 5 |
+| metropolitan collectivity with special status | **2** (was 3; −Corse, leaving Lyon Métropole + Paris) |
+| European collectivity | 1 |
+| overseas collectivity with special status | 1 |
+| overseas territory | 1 |
+| dependency | 1 |
+| **Total** | **124** (unchanged) |
+
+## Items Deliberately NOT Changed (Flagged for Review)
+
+These were surfaced by the diff but kept out of PR-B for one of three reasons: (a) they are stylistic/typographical and the canonical form is debatable, (b) they sit outside this PR's "department + region" scope, or (c) they are modeling decisions for the maintainer.
+
+### 1. Region `native` typography (3 records)
+
+Both forms appear in official French publications; data.gouv.fr drops the connecting hyphen and uses a straight apostrophe.
+
+| ISO2 | Repo `native`                  | data.gouv.fr `nom`              | Note |
+|------|--------------------------------|---------------------------------|------|
+| GES  | `Grand-Est`                    | `Grand Est`                     | INSEE prefers the unhyphenated form. |
+| PDL  | `Pays-de-la-Loire`             | `Pays de la Loire`              | INSEE prefers no hyphens. |
+| PAC  | `Provence-Alpes-Côte-d'Azur`   | `Provence-Alpes-Côte d'Azur`    | INSEE drops the hyphen before *d'Azur* and uses a straight apostrophe. |
+
+These would be safe to align with data.gouv.fr in a follow-up, but coordination with `translations.fr` is recommended.
+
+### 2. Repo records outside the data.gouv.fr feed scope
+
+The feeds only enumerate metropolitan departments, metropolitan regions, and overseas DROM regions. The following 12 FR records are not covered by the feeds and were therefore not validated against an authoritative source in this PR:
+
+| ISO2 | type                                            | name                              | Observation |
+|------|-------------------------------------------------|-----------------------------------|-------------|
+| 6AE  | European collectivity                           | Alsace                            | Special collectivity formed 2021. |
+| CP   | dependency                                      | Clipperton                        | Uninhabited Pacific atoll. |
+| 69M  | metropolitan collectivity with special status   | Métropole de Lyon                 | Replaces dept 69 in Rhône metro. |
+| 75C  | metropolitan collectivity with special status   | Paris                             | data.gouv.fr lists `code: 75 — Paris` in **departements**; we model it as a special-status metropolitan collectivity. Modeling difference, not a data error. |
+| BL   | overseas collectivity                           | Saint-Barthélemy                  | OK. |
+| MF   | overseas collectivity                           | Saint-Martin                      | OK. |
+| PF   | overseas collectivity                           | French Polynesia                  | `native` correctly French (`Polynésie française`). |
+| **PM** | overseas collectivity                         | Saint Pierre and Miquelon         | `native` is currently the English string; the official French is `Saint-Pierre-et-Miquelon`. **Not changed in PR-B** because PM is an overseas collectivity (not a department or region); flagging for PR-D scope. |
+| WF   | overseas collectivity                           | Wallis and Futuna                 | `native` is `Wallis et Futuna`; the official French is `Wallis-et-Futuna` (hyphenated). Borderline; flagging. |
+| NC   | overseas collectivity with special status       | Nouvelle-Calédonie                | `name` is in French; the canonical English is `New Caledonia`. **Not changed in PR-B** — outside dept/region scope and renaming a top-level subdivision warrants reviewer sign-off. Flag for PR-D. |
+| **TF** | overseas territory                            | French Southern and Antarctic Lands | `native` is currently `Terres du sud et de l'Antarctique français`, which is non-standard. The official French name is `Terres australes et antarctiques françaises`. Flagging for PR-D. |
+
+### 3. `fips_code` coverage gap (advisory)
+
+The diff coverage report notes only **27 of 124** FR records have a `fips_code`. data.gouv.fr does not provide FIPS codes (US standard), so this gap cannot be filled from these feeds. Out of scope for PR-B.
+
+### 4. `code: 75 — Paris` "missing" in repo iso2 index (advisory)
+
+data.gouv.fr's departements feed lists Paris with `code: 75`. Our repo stores Paris at `iso2: 75C` with `type: metropolitan collectivity with special status`. This is a deliberate modeling decision (Paris merged its dept and city/commune functions in 2019) — not a data error. Documented here for transparency.
+
+### 5. Possibly stale `timezone` on 973 (out of scope)
+
+Spot-checked while editing: French Guiana's `timezone` is `Europe/Paris`, but the territory is in `America/Cayenne` (UTC−3, no DST). Same potential issue may exist for other DROM. Not changed here — PR-B's scope is metadata polish, not timezone correction. Flag for follow-up.
+
+## Why Reclassify Corse?
+
+Corse is a **collectivité territoriale unique** (since 2018) that exercises both regional and departmental powers within its territory. Wikipedia explicitly notes Corse is "one of the 18 regions of France." data.gouv.fr lists Corse in the **regions** feed, not departments, with regional code `94`. The ISO 3166-2 sub-code `FR-20R` (where `R` indicates *région*) is also consistent with region status.
+
+The repo's previous classification — `metropolitan collectivity with special status` — better describes entities like:
+- **Métropole de Lyon** (`69M`): a metropolitan collectivity that replaces dept 69 over the Lyon urban area, while the dept territory continues to exist as `69` for the rest of Rhône. (Currently `69D — Rhône` is *not* in our list because the metro replaced the dept.)
+- **Paris** (`75C`): merged commune-and-département entity since 2019.
+
+Corse, by contrast, is a region whose departmental councils (`2A` and `2B`) were merged. The two department codes still exist (data.gouv.fr keeps them as `circonscriptions départementales`) and remain in our repo as `metropolitan department`. Reclassifying Corse as `metropolitan region` aligns with the authoritative source while preserving the dept records for `2A` and `2B`.
+
+## Validation Performed
+
+- `python3 bin/scripts/fixes/france_states_diff.py` — `Department deltas: 0`, `Region deltas: 0`.
+- `python3 -m json.tool contributions/states/states.json` — file parses as valid JSON.
+- Local FK integrity check: every FR `country_id`/`country_code` pair resolves correctly against `contributions/countries/countries.json`.
+- FR record count unchanged: 124 before, 124 after.
+- All `id` values still globally unique across `states.json`.
+- `.github/scripts/utils.js` `validateRecord(...)` against the 13 touched records: **0 errors**, identical warning footprint to untouched FR records (the warnings are pre-existing schema gaps for `iso3166_2`, `timezone`, `translations`, `population`).
+
+## Files Changed
+
+- `contributions/states/states.json` — 13 records, 14 fields touched.
+- `bin/scripts/fixes/france_states_diff.py` — new diagnostic script.
+- `.github/fixes-docs/FIX_1352_PR_B_SUMMARY.md` — this document.
+
+## Out of Scope (Other PRs)
+
+- **PR-A** — French city polish in `contributions/cities/FR.json`.
+- **PR-D** — Overseas city files (`contributions/cities/PF.json`, `BL.json`, `MF.json`, `NC.json`, `PM.json`, `WF.json`, `TF.json`).
+- **Future** — Items 1–5 in "Items Deliberately NOT Changed" above.

--- a/bin/scripts/fixes/france_states_diff.py
+++ b/bin/scripts/fixes/france_states_diff.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Diff French state-level metadata in `contributions/states/states.json` against
+the authoritative data.gouv.fr feeds (departements + regions).
+
+Purpose
+-------
+Issue #1352 asks us to polish French department/region metadata. The
+authoritative reference is the open INSEE-derived feeds published by
+data.gouv.fr:
+
+  - departements.min.json : 101 entries (96 metropolitan + 5 overseas DROM)
+  - regions.min.json      : 18 entries (13 metropolitan + 5 overseas DROM)
+
+This script compares those feeds against the FR records in our repo and reports
+deltas worth a maintainer's attention:
+
+  * Type / classification (e.g. is "Corse" classified as a region?)
+  * Native (French) names that differ from data.gouv.fr's `nom`
+  * Records that exist in our repo but not in the feed (likely overseas
+    collectivities and territories the feeds don't enumerate)
+  * Records in the feed that are missing from our repo
+
+Usage
+-----
+    python3 bin/scripts/fixes/france_states_diff.py \
+        --departements /tmp/fr1352/departements.min.json \
+        --regions /tmp/fr1352/regions.min.json
+
+Defaults to /tmp/fr1352/ if --departements / --regions are omitted.
+
+Notes
+-----
+- Repo `name` is English; `native` is French. data.gouv.fr only reports French.
+  The script therefore compares data.gouv.fr `nom` against repo `native`,
+  NOT against `name`. Native diffs are advisory; English `name` is left alone.
+- data.gouv.fr region codes (e.g. "94" = Corse, "11" = Île-de-France) are NOT
+  the same as ISO 3166-2 codes; the repo's `iso2` for regions stores the
+  alphabetic ISO sub-codes (ARA, BFC, …) for metro regions and the INSEE region
+  code for overseas regions (971…976). The script keeps these code spaces
+  separate.
+
+This script is read-only. It does not mutate states.json.
+"""
+
+import argparse
+import json
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+STATES_FILE = REPO_ROOT / "contributions" / "states" / "states.json"
+
+# Map data.gouv.fr region `code` → repo `iso2` for metropolitan regions.
+# Source: ISO 3166-2:FR (3-letter codes after FR-) cross-referenced with
+# INSEE region numbers.
+REGION_CODE_TO_ISO2_METRO: Dict[str, str] = {
+    "11": "IDF",   # Île-de-France
+    "24": "CVL",   # Centre-Val de Loire
+    "27": "BFC",   # Bourgogne-Franche-Comté
+    "28": "NOR",   # Normandie
+    "32": "HDF",   # Hauts-de-France
+    "44": "GES",   # Grand Est
+    "52": "PDL",   # Pays de la Loire
+    "53": "BRE",   # Bretagne
+    "75": "NAQ",   # Nouvelle-Aquitaine
+    "76": "OCC",   # Occitanie
+    "84": "ARA",   # Auvergne-Rhône-Alpes
+    "93": "PAC",   # Provence-Alpes-Côte d'Azur
+    "94": "20R",   # Corse (sole region with numeric ISO sub-code)
+}
+
+# Map data.gouv.fr region `code` → repo `iso2` for overseas regions.
+# data.gouv.fr uses 01..06; repo uses the INSEE department codes 971..976.
+REGION_CODE_TO_ISO2_OVERSEAS: Dict[str, str] = {
+    "01": "971",   # Guadeloupe
+    "02": "972",   # Martinique
+    "03": "973",   # Guyane / French Guiana
+    "04": "974",   # La Réunion
+    "06": "976",   # Mayotte
+}
+
+
+def load_json(path: Path) -> list:
+    """Load a JSON file from disk; raises FileNotFoundError if missing."""
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def normalize(s: Optional[str]) -> str:
+    """
+    Normalize a string for fuzzy comparison: NFC, lowercased, hyphens and
+    spaces collapsed, curly apostrophes folded to straight. Used to flag
+    typographical drift while still printing the raw values.
+    """
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFC", s)
+    s = s.replace("’", "'").replace("‘", "'")
+    s = s.replace("-", " ")
+    s = " ".join(s.split())
+    return s.casefold()
+
+
+def fr_states(states: Iterable[dict]) -> List[dict]:
+    """Filter the master states list down to FR records."""
+    return [s for s in states if s.get("country_code") == "FR"]
+
+
+def report_delta(label: str, code: str, field: str, repo_val, feed_val) -> None:
+    """Print a single discrepancy line in a consistent format."""
+    print(f"  [{label}] {code:6} {field:9} repo={repo_val!r:40} feed={feed_val!r}")
+
+
+def diff_departements(repo_fr: List[dict], feed: List[dict]) -> Tuple[int, int]:
+    """
+    Diff department-level metadata.
+
+    Returns (delta_count, missing_in_repo_count).
+    """
+    print("\n=== Departments (101 expected from data.gouv.fr) ===")
+    print(f"  feed: {len(feed)}  repo (type=metropolitan department + overseas region): see below\n")
+
+    repo_by_iso2: Dict[str, dict] = {s["iso2"]: s for s in repo_fr if s.get("iso2")}
+    deltas = 0
+    missing = 0
+
+    for entry in feed:
+        code = entry["code"]
+        nom = entry["nom"]
+        repo = repo_by_iso2.get(code)
+        if repo is None:
+            print(f"  [MISSING] code={code} nom={nom!r} not in repo iso2 index")
+            missing += 1
+            continue
+
+        # Native check
+        if normalize(repo.get("native")) != normalize(nom):
+            report_delta("NATIVE", code, "native", repo.get("native"), nom)
+            deltas += 1
+
+        # Sanity: name should NOT equal feed nom verbatim if it's supposed to
+        # be English. Flag department records where name and native differ
+        # from the feed (these are usually fine — most dept names are
+        # identical in English and French — but worth eyeballing).
+        # Skip: too noisy. We only flag native diffs.
+
+    return deltas, missing
+
+
+def diff_regions(repo_fr: List[dict], feed: List[dict]) -> Tuple[int, int]:
+    """
+    Diff region-level metadata.
+
+    Reports:
+      * Native-name drift vs data.gouv.fr `nom`.
+      * Type/classification: Corse should be `metropolitan region` per
+        data.gouv.fr; other entries should already match.
+      * Records in the feed missing from our repo.
+    """
+    print("\n=== Regions (18 expected from data.gouv.fr: 13 metro + 5 overseas) ===")
+    print(f"  feed: {len(feed)}\n")
+
+    repo_by_iso2: Dict[str, dict] = {s["iso2"]: s for s in repo_fr if s.get("iso2")}
+
+    deltas = 0
+    missing = 0
+    metro_codes = set(REGION_CODE_TO_ISO2_METRO)
+    overseas_codes = set(REGION_CODE_TO_ISO2_OVERSEAS)
+
+    for entry in feed:
+        code = entry["code"]
+        nom = entry["nom"]
+
+        if code in metro_codes:
+            iso2 = REGION_CODE_TO_ISO2_METRO[code]
+            expected_type = "metropolitan region"
+        elif code in overseas_codes:
+            iso2 = REGION_CODE_TO_ISO2_OVERSEAS[code]
+            expected_type = "overseas region"
+        else:
+            print(f"  [UNKNOWN-CODE] feed code={code} nom={nom!r} not mapped")
+            continue
+
+        repo = repo_by_iso2.get(iso2)
+        if repo is None:
+            print(f"  [MISSING] feed code={code} → expected iso2={iso2} ({nom!r}) not found")
+            missing += 1
+            continue
+
+        if repo.get("type") != expected_type:
+            report_delta("TYPE", iso2, "type", repo.get("type"), expected_type)
+            deltas += 1
+
+        if normalize(repo.get("native")) != normalize(nom):
+            report_delta("NATIVE", iso2, "native", repo.get("native"), nom)
+            deltas += 1
+
+    return deltas, missing
+
+
+def report_typography(repo_fr: List[dict], regs_feed: List[dict]) -> None:
+    """
+    Surface region/department records where the *normalized* native string
+    matches the feed but the *raw* string differs (curly vs straight quotes,
+    hyphens vs spaces, etc.). These are advisory: the repo and feed disagree
+    only on typography, and which form is canonical is a maintainer call.
+    """
+    print("\n=== Typographical-only native diffs (advisory) ===")
+    metro = REGION_CODE_TO_ISO2_METRO
+    overseas = REGION_CODE_TO_ISO2_OVERSEAS
+    repo_by_iso2 = {s["iso2"]: s for s in repo_fr if s.get("iso2")}
+    flagged = 0
+    for entry in regs_feed:
+        iso2 = metro.get(entry["code"]) or overseas.get(entry["code"])
+        if not iso2:
+            continue
+        repo = repo_by_iso2.get(iso2)
+        if not repo:
+            continue
+        repo_native = repo.get("native") or ""
+        feed_nom = entry["nom"]
+        if repo_native == feed_nom:
+            continue
+        if normalize(repo_native) != normalize(feed_nom):
+            continue  # already reported as a real delta
+        print(f"  [TYPO]   {iso2:6} repo={repo_native!r:40} feed={feed_nom!r}")
+        flagged += 1
+    if flagged == 0:
+        print("  (none)")
+
+
+def report_coverage(repo_fr: List[dict]) -> None:
+    """
+    Coverage stats for fields data.gouv.fr does not provide (fips_code,
+    iso3166_2, latitude, longitude). Useful to surface gaps even though
+    they cannot be filled from these feeds alone.
+    """
+    print("\n=== Coverage of fields not in data.gouv.fr feeds ===")
+    fields = ("fips_code", "iso3166_2", "latitude", "longitude", "wikiDataId", "timezone")
+    total = len(repo_fr)
+    for f in fields:
+        filled = sum(1 for s in repo_fr if s.get(f) not in (None, ""))
+        print(f"  {f:12} filled: {filled:3}/{total}")
+
+
+def report_extras(repo_fr: List[dict]) -> None:
+    """
+    List FR repo records that are *not* covered by either feed: overseas
+    collectivities, dependencies, special-status metropolitan collectivities,
+    and the overseas territory (TF). Listed as advisory; the feeds do not
+    cover these.
+    """
+    feed_covered_types = {"metropolitan department", "metropolitan region", "overseas region"}
+    extras = [s for s in repo_fr if s.get("type") not in feed_covered_types]
+    if not extras:
+        return
+    print("\n=== Repo records NOT covered by data.gouv.fr feeds (advisory only) ===")
+    print("  These are intentionally outside the metropolitan/DROM scope of the feeds.\n")
+    for s in sorted(extras, key=lambda x: (x.get("type", ""), x.get("iso2", ""))):
+        print(
+            f"  [EXTRA] {s.get('iso2',''):6} type={s.get('type',''):50}"
+            f" name={s.get('name',''):35} native={s.get('native','')}"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "--departements",
+        type=Path,
+        default=Path("/tmp/fr1352/departements.min.json"),
+        help="Path to departements.min.json from data.gouv.fr",
+    )
+    parser.add_argument(
+        "--regions",
+        type=Path,
+        default=Path("/tmp/fr1352/regions.min.json"),
+        help="Path to regions.min.json from data.gouv.fr",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point. Returns 0 if no fatal errors occurred."""
+    args = parse_args()
+
+    for path in (args.departements, args.regions, STATES_FILE):
+        if not path.exists():
+            print(f"ERROR: required file missing: {path}", file=sys.stderr)
+            return 2
+
+    deps_feed = load_json(args.departements)
+    regs_feed = load_json(args.regions)
+    states = load_json(STATES_FILE)
+    repo_fr = fr_states(states)
+
+    print(f"FR repo records: {len(repo_fr)}")
+    print(f"Departements feed: {len(deps_feed)}")
+    print(f"Regions feed:      {len(regs_feed)}")
+
+    dep_deltas, dep_missing = diff_departements(repo_fr, deps_feed)
+    reg_deltas, reg_missing = diff_regions(repo_fr, regs_feed)
+    report_typography(repo_fr, regs_feed)
+    report_coverage(repo_fr)
+    report_extras(repo_fr)
+
+    print("\n=== Summary ===")
+    print(f"  Department deltas (native): {dep_deltas}")
+    print(f"  Department missing in repo: {dep_missing}")
+    print(f"  Region deltas (native+type): {reg_deltas}")
+    print(f"  Region missing in repo:      {reg_missing}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR-B of the four-PR Option-C plan for France data review (#1352). Polishes only **department + region** metadata in `contributions/states/states.json`, leaving cities (PR-A) and overseas city files (PR-D) untouched.

Authoritative source: data.gouv.fr open feeds (INSEE-derived):
- `departements.min.json` (101 entries) — https://github.com/user-attachments/files/25721909/departements.min.json
- `regions.min.json` (18 entries) — https://github.com/user-attachments/files/25721911/regions.min.json

A new read-only diff tool, `bin/scripts/fixes/france_states_diff.py`, compares the feeds against repo `country_code='FR'` records and reports real deltas, advisory typography, coverage gaps, and out-of-scope records.

## Changes (14 fields, 13 records — all in `contributions/states/states.json`)

**11 metropolitan department `native` repairs** — the field contained unrelated French text fragments (looked like translation-pipeline garbage) on 11 records. Repaired against data.gouv.fr `nom`:

| ISO2 | name | `native` before → after |
|------|------|-------------------------|
| 01 | Ain | `Se faire` → `Ain` |
| 11 | Aude | `entendus` → `Aude` |
| 27 | Eure | `Ton` → `Eure` |
| 30 | Gard | `Gardien` → `Gard` |
| 32 | Gers | `Génie` → `Gers` |
| 36 | Indre | `Interne` → `Indre` |
| 46 | Lot | `Parcelle` → `Lot` |
| 50 | Manche | `Quelques` → `Manche` |
| 55 | Meuse | `Miuse` → `Meuse` |
| 68 | Haut-Rhin | `Peau` → `Haut-Rhin` |
| 83 | Var | `Notre` → `Var` |

**1 overseas region `native` repair**:

| ISO2 | name | `native` before → after |
|------|------|-------------------------|
| 973 | French Guiana | `French Guiana` → `Guyane` |

**Corse (20R) reclassification + native typo** — Wikipedia/INSEE confirm Corse is one of France's 18 regions; data.gouv.fr lists it in the regions feed (regional code `94`). Reclassifying brings the metropolitan region count to 13 and the special-status collectivity count to 2 (Lyon Métropole + Paris):

| ISO2 | field | before → after |
|------|-------|----------------|
| 20R | `type` | `metropolitan collectivity with special status` → `metropolitan region` |
| 20R | `native` | `Corsée` → `Corse` |

## Out of scope (flagged for follow-up)

- Region `native` typography drift vs data.gouv.fr (`Grand-Est` vs `Grand Est`, `Pays-de-la-Loire` vs `Pays de la Loire`, PAC apostrophe — both forms in use officially).
- Overseas collectivity `native`/`name` cleanups (PM, NC, TF, WF) — PR-D scope.
- `fips_code` coverage gap (27/124 FR records have FIPS) — not in data.gouv.fr feeds.
- Likely-stale timezone on 973 (set to `Europe/Paris`, should be `America/Cayenne`).

Full audit in `.github/fixes-docs/FIX_1352_PR_B_SUMMARY.md`.

## Test plan

- [x] `python3 bin/scripts/fixes/france_states_diff.py` reports `Department deltas: 0`, `Region deltas: 0`.
- [x] `python3 -m json.tool contributions/states/states.json` — JSON valid.
- [x] FR record count unchanged: 124 before, 124 after.
- [x] All `id` values still globally unique across `states.json` (5,296 ids).
- [x] Every FR `country_id`/`country_code` resolves correctly against `contributions/countries/countries.json`.
- [x] `.github/scripts/utils.js` `validateRecord` against the 13 touched records: 0 errors, identical warning footprint to untouched FR records.
- [x] FR `type` distribution after change: 95 dept / **13 metro region** / 5 overseas region / 5 overseas collectivity / **2 metro collectivity w/ special status** / 1 European collectivity / 1 overseas collectivity w/ special status / 1 overseas territory / 1 dependency = 124.

Refs: #1352 (do not close — only PR-B of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)