### PR TITLE
feat(FR): diff cities against data.gouv.fr, add missing metropolitan communes (#1352 PR-A)

### DIFF
--- a/.github/fixes-docs/FIX_1352_PR_A_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1352_PR_A_SUMMARY.md
@@ -1,0 +1,190 @@
+# FIX #1352 — France: missing metropolitan communes (PR-A of 4)
+
+**Issue:** [#1352 — France data: missing cities, regions misclassified](https://github.com/dr5hn/countries-states-cities-database/issues/1352)
+**Scope:** Add missing metropolitan French communes (`contributions/cities/FR.json`).
+**Sibling PRs (separate, parallel):**
+- **PR-B** — re-classify cities currently under the wrong CSC region (this PR *flags* 1,194 candidates but does not move them).
+- **PR-C** — clean up obsolete / merged communes and quartiers stored as cities.
+- **PR-D** — overseas territories (GP, MQ, GF, RE, YT, BL, MF, PM, WF, PF, TF, NC).
+**Date:** 2026-04-25
+
+## Problem
+
+The reporter observed that `contributions/cities/FR.json` (10,079 records) is missing many metropolitan communes vs. the canonical INSEE list maintained by data.gouv.fr (~34,800 metropolitan communes). Notable absentees, all large communes-nouvelles created since 2015, are in the top 15 of this PR's additions:
+
+| Population | Commune | Created (or renamed) |
+|------------|---------|----------------------|
+| 78,258 | Cherbourg-en-Cotentin | 2016 |
+| 66,919 | Évry-Courcouronnes | 2019 |
+| 53,615 | Saint-Ouen-sur-Seine | 2018 (rename) |
+| 38,168 | Oullins-Pierre-Bénite | 2024 |
+| 31,779 | Herblay-sur-Seine | 2018 |
+| 30,689 | Le Chesnay-Rocquencourt | 2019 |
+| 25,797 | Sèvremoine | 2015 |
+| 23,989 | Beaupréau-en-Mauges | 2015 |
+| 21,999 | Chemillé-en-Anjou | 2015 |
+| 21,134 | Montaigu-Vendée | 2018 |
+
+Cities like **Ajaccio** (76 K) and **Bastia** (47 K) *are* in CSC, but stored under `20R` (the Corse collectivity) instead of `2A`/`2B` (the departments). The diff flags them as cross-region matches → **PR-B's** territory, not added here.
+
+A naïve full-import would balloon FR.json from 10K to 35K records in a single PR — unreviewable. **PR-A applies a conservative population-thresholded slice** and surfaces the rest for follow-up PRs.
+
+## Scope of THIS PR
+
+| | Before | After | Δ |
+|---|--------|-------|---|
+| `contributions/cities/FR.json` | 10,079 | **10,534** | **+455** |
+
+All additions are metropolitan-France communes with **population ≥ 2,000** (configurable in the script via `--pop-threshold`). The 2,000 floor matches the user's expected envelope (200–800) while keeping the diff reviewable.
+
+### Distribution by CSC state
+
+| state_code | added |
+|------------|-------|
+| PDL (Pays-de-la-Loire) | 82 |
+| ARA (Auvergne-Rhône-Alpes) | 78 |
+| NOR (Normandie) | 77 |
+| NAQ (Nouvelle-Aquitaine) | 56 |
+| BRE (Bretagne) | 42 |
+| OCC (Occitanie) | 31 |
+| GES (Grand-Est) | 21 |
+| CVL (Centre-Val de Loire) | 21 |
+| IDF (Île-de-France) | 16 |
+| BFC (Bourgogne-Franche-Comté) | 12 |
+| HDF (Hauts-de-France) | 10 |
+| PAC (Provence-Alpes-Côte-d'Azur) | 9 |
+
+Skew toward PDL/NOR/ARA reflects the concentration of recent commune mergers ("communes nouvelles") in those regions. **Corsica (`2A`/`2B`/`20R`) sees zero adds in this PR**: every Corsican upstream commune at pop ≥ 2,000 was matched to an existing CSC record (often under `20R`, the collectivity) — those state-code mismatches are PR-B's reclassification scope.
+
+## Methodology
+
+### Sources
+
+1. **`villes.min.json`** — the file the reporter attached to the issue
+   (`https://github.com/user-attachments/files/25721910/villes.min.json`).
+   35,029 rows of `{nom, departement, region, code}`. INSEE codes are canonical.
+2. **`geo.api.gouv.fr/communes`** — used to enrich missing communes with
+   coordinates and population (the reporter's file has neither). Same INSEE
+   codes, 34,969 rows. Fetched as
+   `https://geo.api.gouv.fr/communes?fields=nom,code,codeDepartement,codeRegion,centre,population&format=json`.
+
+Neither file is committed; both are downloaded by the script (or by the reviewer) into a temporary directory.
+
+### Matching
+
+CSC's `FR.json` does **not** carry an INSEE code, so we cannot diff by INSEE directly. Instead the script matches by `(target_state_code, normalised_name)` where:
+
+- `normalised_name` = NFKD-fold-to-ASCII + manual ligature expansion (`œ→oe`, `æ→ae`, `ß→ss`) + canonicalise toponymic prepositions (`lès → lez`) + strip non-letter characters + lowercase. The ligature/preposition handling caught four would-be duplicates that the simpler accent fold missed (`Annœullin`/`Annoeullin`, `Paimbœuf`/`Paimboeuf`, `Rœschwoog`/`Roeschwoog`, `Saint-Christol-lez-Alès`/`Saint-Christol-lès-Alès`).
+- `target_state_code` is derived from the upstream `(departement, region)` pair using:
+  - INSEE region code → CSC region iso2 (e.g., `84 → ARA`, `11 → IDF`, `94 → 2A/2B`).
+  - **Department-level overrides** for the five departments that the existing
+    FR.json stores at department-level rather than region-level: `2A`, `2B`,
+    `48`, `52`, `55`. (Discovered empirically; new records in those depts must
+    follow suit to match existing convention.)
+
+If the primary state lookup misses, the script also tries every other metropolitan CSC state code. A hit there is **not** a successful match — it's a *cross-region match*, flagged for PR-B (region reclassification), and the upstream record is still considered "missing" only if no fallback hit exists.
+
+### Conservative filter
+
+A missing upstream commune is auto-added only if **all** of:
+
+- A `target_state_code` was determined (i.e., upstream region is metropolitan and mapped).
+- `geo.api.gouv.fr` provided coordinates and a non-null `population`.
+- Coordinates lie inside the metropolitan FR bounding box from `.github/data/country-bounds.json`.
+- `population ≥ 2,000`.
+
+Anything that fails any criterion lands in the `france_cities_diff.deferred.json` artifact with structured `skip_reasons`. Future PRs can lower the threshold or re-validate the deferred entries without re-running discovery.
+
+### Field choices for new records
+
+Following the existing FR.json convention:
+
+```json
+{
+  "name": "Évry-Courcouronnes",         // INSEE official French name
+  "state_id": 4796, "state_code": "IDF",
+  "country_id": 75, "country_code": "FR",
+  "type": "city",
+  "level": null, "parent_id": null,
+  "latitude": "48.62870000", "longitude": "2.43130000",
+  "native": "Évry-Courcouronnes",        // identical to name (no English exonym for ~all communes)
+  "population": 66919,                   // from geo.api.gouv.fr
+  "timezone": "Europe/Paris"
+}
+```
+
+Auto-managed fields (`id`, `created_at`, `updated_at`, `flag`) are deliberately omitted — the JSON-first import will assign them. Translations and `wikiDataId` are intentionally not generated; we'd rather leave them empty than synthesise low-quality values.
+
+## Validation
+
+Run locally against the modified FR.json:
+
+| Check | Result |
+|-------|--------|
+| JSON valid + canonical 2-space indent | OK |
+| Schema (required fields, types, ranges, no auto-managed) | **0 errors** (455 records) |
+| Cross-reference (state_id/country_id exist, codes match) | OK |
+| Coordinates inside FR metropolitan bounding box | OK |
+| Exact-name + same-state duplicates | **0** |
+| Fuzzy duplicates (Levenshtein ≤ 2 + < 5km) | **1** (Bréhan vs Rohan, dept 56 — genuinely two different communes 4.3km apart, INSEE 56025 vs 56196) |
+| Schema warnings | 2,275 (`unknown field` for `type`/`level`/`parent_id`/`native`/`population` — same warnings the existing 10,079 records produce; warnings, not errors) |
+
+Re-validation:
+
+```bash
+python3 bin/scripts/fixes/france_cities_diff.py \
+  --upstream /path/to/villes.min.json \
+  --geo /path/to/geo-api-communes.json
+```
+
+## Diagnostic output (not auto-applied — for follow-up PRs)
+
+The diff also surfaces issues that are out-of-scope for PR-A but relevant to the broader #1352 plan. Counts in `bin/scripts/fixes/france_cities_diff.report.json`:
+
+| Category | Count | Owner |
+|----------|-------|-------|
+| `missing` total (all metro communes upstream not in CSC) | 24,118 | PR-A.2+ (lower the population threshold) |
+| `missing` with population ≥ 2,000 (auto-applied here) | 455 | **THIS PR** |
+| `cross_region_matches` (CSC city under wrong region) | 1,194 | **PR-B** |
+| `coord_mismatches` > 1km (homonym-filtered, single-name only) | 4,836 | **PR-C** (still includes intra-region homonyms; see caveat below) |
+| `extra` (CSC city with no metro upstream match) | 643 | **PR-C** (largely obsolete-merged communes, quartiers, or department names mistakenly stored as cities) |
+
+### Notable `extra` findings worth flagging for PR-C
+
+- **Department names stored as cities**: `Alpes-Maritimes`, `Alpes-de-Haute-Provence`, `Ardennes` — these are dept-level admin units, not communes.
+- **Obsolete/merged communes**: `Aime`, `Aigueblanche`, `Albens` (merged into `Aime-la-Plagne`); `Annecy-le-Vieux` (merged into Annecy in 2017); `Ancenis` (merged into `Ancenis-Saint-Géréon` in 2019); `Antrain` (merged into Val-Couesnon).
+- **Quartiers stored as cities**: `Arenc`, `Bonsecours`, `Montolivet`, `Saint-Barnabé`, `La Villette` — most of the top "PAC coord-mismatch" hits are Marseille neighbourhoods coincidentally sharing names with unrelated communes elsewhere.
+- **Spelling variants**: `Argelers` (Catalan/Occitan; standard French is `Argelès-sur-Mer`).
+
+### Coordinate-mismatch caveat
+
+The coord-mismatch column is a *report*, not a fix. It triggers when a CSC city's `(state, name)` matches a single-named upstream commune more than 1 km away. The 1,978 entries where the same name occurs multiple times in the metro upstream were skipped to avoid spurious flags. **Even after that filter, intra-region homonyms can produce false-positive mismatches** — e.g., the top PAC entries (`La Villette`, `Saint-Barnabé`, `Vieille-Chapelle`, `Bonsecours`) are Marseille quartiers being matched against unrelated communes elsewhere in PAC. Real coord errors will need INSEE-coded ground truth, which is partly what PR-C will add.
+
+## Edge cases handled
+
+1. **`œ`/`æ` ligatures** — NFKD does not decompose these. Manually mapped in `normalise_name`.
+2. **`lès` ↔ `lez` preposition** — both are valid orthographies; canonicalised to `lez` for matching.
+3. **Corsica** — INSEE region 94 (`Corse`) covers two depts, `2A` and `2B`. CSC has *three* states for it: `2A` (id 4996), `2B` (id 4997), and `20R` (id 4806, the *collectivity*). Our existing data is split across all three (104 / 229 / 28 records). New records use the dept code (`2A`/`2B`) since that's the dominant pattern (333 vs 28). Existing `20R` records were correctly recognised as cross-region matches against upstream `2A`/`2B`, not as "extras".
+4. **Dept-coded depts inside region-coded regions** — five depts (`2A`, `2B`, `48`, `52`, `55`) are stored at dept-level in existing FR.json; the rest of their parent regions are stored at region-level. The `DEPT_OVERRIDES` constant codifies this so new records line up with existing convention.
+5. **Bas-Rhin/Haut-Rhin (Alsace, dept 67/68)** — `states.json` has both `GES` (Grand-Est, the region) and `6AE` (Alsace, the European Collectivity). All 514+366 existing Alsatian cities use `GES`; **none** use `6AE`. New records likewise go under `GES` to match upstream's region mapping (depts 67/68 → region 44 → `GES`).
+6. **Paris** — present once as `state_code=IDF, type=capital, id=44856`. No arrondissements in CSC, none in upstream `villes.min.json` either. Untouched.
+7. **Métropole de Lyon (`69M`)** — `states.json` has it as a separate state, but no cities reference it; existing Rhône cities (dept 69) use `ARA`. New records continue that pattern.
+
+## Out of scope (handled by sibling PRs)
+
+- **Region reclassification (1,194 cross-region matches)** — PR-B.
+- **Obsolete/merged commune cleanup, quartiers stored as cities, department-as-city records (~643 extras)** — PR-C.
+- **Lower-population missing communes (~23,663 deferred)** — future PR-A.2 with a tighter source review.
+- **Overseas territories (GP, MQ, GF, RE, YT, BL, MF, PM, WF, PF, TF, NC)** — PR-D. The script's `METRO_REGIONS` set excludes upstream regions `01`/`02`/`03`/`04`/`06`/`975`/`977`/`978`/`984`/`986`/`987`/`988`/`989`.
+- **Translations / wikiDataId for new records** — left empty rather than synthesised; can be backfilled in a later pass.
+
+## Files in this PR
+
+| Path | Status |
+|------|--------|
+| `contributions/cities/FR.json` | +455 records appended |
+| `bin/scripts/fixes/france_cities_diff.py` | new |
+| `bin/scripts/fixes/france_cities_diff.report.json` | new (diff summary; useful audit trail) |
+| `.github/fixes-docs/FIX_1352_PR_A_SUMMARY.md` | new (this file) |
+
+`france_cities_diff.merge.json` (the proposed-records artifact) and `france_cities_diff.deferred.json` (skipped-records artifact, ~7 MB) are intentionally **not** committed — `merge.json` content is now in FR.json and the deferred set is regeneratable on demand.

--- a/bin/scripts/fixes/france_cities_diff.py
+++ b/bin/scripts/fixes/france_cities_diff.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""france_cities_diff.py
+
+Diff contributions/cities/FR.json against the canonical commune list from
+data.gouv.fr (INSEE) and produce a conservative merge proposal.
+
+Inputs (all required):
+  --upstream PATH     villes.min.json  (https://github.com/user-attachments/files/25721910/villes.min.json)
+                      Schema: [{nom, departement, region, code}, ...]   (no coords/population)
+  --geo PATH          geo.api.gouv.fr communes dump fetched with:
+                        https://geo.api.gouv.fr/communes?fields=nom,code,
+                          codeDepartement,codeRegion,centre,population&format=json
+                      Used to enrich missing communes with coordinates and population.
+  --our PATH          contributions/cities/FR.json (default)
+  --states PATH       contributions/states/states.json (default)
+
+Outputs:
+  --report-out PATH   JSON report listing missing / extra / cross-region matches.
+  --merge-out  PATH   JSON list of proposed new city records (NOT applied unless --apply).
+
+Modes:
+  default             dry-run; writes report + merge proposal, leaves FR.json unchanged.
+  --apply             rewrite contributions/cities/FR.json with the merge applied
+                      (appends new records, preserves all existing IDs and ordering).
+
+Scope: METROPOLITAN FRANCE ONLY. Overseas departments (971-989) are out of scope
+for this script (PR-D in the #1352 plan handles them).
+
+This script never reaches the network; both upstream and geo files must be
+downloaded ahead of time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+from pathlib import Path
+
+# ---- Static reference data ------------------------------------------------
+
+# INSEE region codes that are metropolitan (incl. Corsica = 94)
+METRO_REGIONS = {"11", "24", "27", "28", "32", "44", "52", "53", "75", "76", "84", "93", "94"}
+
+# INSEE region code -> CSC state iso2 (region-level state)
+# Corsica (94) intentionally absent: communes use their dept code (2A/2B) per
+# the existing FR.json convention (337 of 361 Corsican rows are dept-coded).
+REGION_TO_CSC = {
+    "11": "IDF",  # Île-de-France
+    "24": "CVL",  # Centre-Val de Loire
+    "27": "BFC",  # Bourgogne-Franche-Comté
+    "28": "NOR",  # Normandie
+    "32": "HDF",  # Hauts-de-France
+    "44": "GES",  # Grand-Est
+    "52": "PDL",  # Pays-de-la-Loire
+    "53": "BRE",  # Bretagne
+    "75": "NAQ",  # Nouvelle-Aquitaine
+    "76": "OCC",  # Occitanie
+    "84": "ARA",  # Auvergne-Rhône-Alpes
+    "93": "PAC",  # Provence-Alpes-Côte-d'Azur
+}
+
+# Departments that the existing FR.json stores at department-level rather than
+# region-level (i.e. cities in dept 55 have state_code="55", not "GES").
+# Discovered empirically; all new records in these depts must follow suit.
+DEPT_OVERRIDES = {"2A", "2B", "48", "52", "55"}
+
+# CSC state codes that count as "metropolitan" for the purposes of cross-region
+# fallback and "extra"-detection. Includes 20R (Corse collectivity) which holds
+# a small number of historical Corsican cities that should match upstream 2A/2B.
+METRO_CSC_CODES = set(REGION_TO_CSC.values()) | DEPT_OVERRIDES | {"20R"}
+
+# France metropolitan bounding box (matches .github/data/country-bounds.json).
+FR_BOUNDS = {"minLat": 41.36, "maxLat": 51.09, "minLon": -5.14, "maxLon": 9.56}
+
+# Coordinate divergence threshold (km) for the coord-mismatch report.
+COORD_MISMATCH_KM = 1.0
+
+# ---- Helpers --------------------------------------------------------------
+
+
+_LIGATURE_MAP = str.maketrans({"œ": "oe", "Œ": "oe", "æ": "ae", "Æ": "ae", "ß": "ss"})
+
+# Common French toponymic prepositions that vary across sources. Map them to a
+# canonical token so e.g. "Saint-Christol-lez-Alès" and "Saint-Christol-lès-Alès"
+# collide as the same key.
+_TOPONYM_VARIANTS = [
+    (re.compile(r"\bles\b"), "lez"),
+    (re.compile(r"\bsur\b"), "sur"),
+]
+
+
+def normalise_name(name: str) -> str:
+    """Return an accent/punctuation-insensitive comparison key for a commune name.
+
+    Handles:
+      - Latin accents (NFKD + ASCII fold).
+      - oe/ae ligatures (manual map; NFKD doesn't decompose them).
+      - "lez"/"lès" preposition variation common in French place names.
+    """
+    s = name.translate(_LIGATURE_MAP)
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii").lower()
+    for pattern, replacement in _TOPONYM_VARIANTS:
+        s = pattern.sub(replacement, s)
+    return re.sub(r"[^a-z]+", "", s)
+
+
+def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in kilometres."""
+    r = 6371.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def load_json(path: Path):
+    """Read a JSON file or exit with a useful error."""
+    if not path.exists():
+        sys.exit(f"ERROR: input file not found: {path}")
+    try:
+        with path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"ERROR: invalid JSON in {path}: {exc}")
+
+
+def build_csc_state_lookup(states: list[dict]) -> dict[str, dict]:
+    """Build {state_iso2: state_record} for FR states only."""
+    return {s["iso2"]: s for s in states if s.get("country_code") == "FR" and s.get("iso2")}
+
+
+def determine_target_state(rec: dict) -> str | None:
+    """Map an upstream commune to the CSC state_code where new records should land.
+
+    Returns None for non-metropolitan or unmapped (caller should skip).
+    """
+    dept = rec["departement"]
+    region = rec["region"]
+    if dept in DEPT_OVERRIDES:
+        return dept
+    if region == "94":  # Corsica — should already be DEPT_OVERRIDE; defensive
+        return dept if dept in DEPT_OVERRIDES else None
+    return REGION_TO_CSC.get(region)
+
+
+# ---- Diff -----------------------------------------------------------------
+
+
+def run_diff(upstream: list[dict], geo: list[dict], ours: list[dict]) -> dict:
+    """Compute missing / extra / cross-region / coord-mismatch records.
+
+    Match key: (target_state_code, normalise_name(name)).
+    Falls back to scanning *all* metropolitan CSC state codes (incl. 20R and
+    dept-coded depts) for the same name; cross-state hits are flagged as
+    cross-region matches, which signal possible misclassifications.
+    """
+    geo_by_code = {g["code"]: g for g in geo}
+
+    # Build CSC index by (state_code, norm_name)
+    ours_index: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for c in ours:
+        ours_index[(c["state_code"], normalise_name(c["name"]))].append(c)
+
+    # Multiplicity index for unambiguous coord-mismatch reporting:
+    # how many upstream metro communes share each normalised name?
+    upstream_name_count: dict[str, int] = defaultdict(int)
+    for r in upstream:
+        if r["region"] in METRO_REGIONS:
+            upstream_name_count[normalise_name(r["nom"])] += 1
+
+    # Set of (state_code, norm_name) that we've matched, used to compute "extra"
+    matched_keys: set[tuple[str, str]] = set()
+
+    # Filter upstream to metropolitan
+    metro_upstream = [r for r in upstream if r["region"] in METRO_REGIONS]
+
+    missing: list[dict] = []
+    cross_region_matches: list[dict] = []  # in CSC but under a different state than expected
+    coord_mismatches: list[dict] = []
+    coord_mismatches_skipped_homonym = 0
+    matched_count = 0
+
+    for rec in metro_upstream:
+        name_n = normalise_name(rec["nom"])
+        primary = determine_target_state(rec)
+
+        # Try primary state
+        match = None
+        match_state = None
+        if primary and (primary, name_n) in ours_index:
+            match = ours_index[(primary, name_n)][0]
+            match_state = primary
+
+        # Fallback: another metropolitan CSC state code
+        if match is None:
+            for sc in METRO_CSC_CODES:
+                if sc == primary:
+                    continue
+                if (sc, name_n) in ours_index:
+                    match = ours_index[(sc, name_n)][0]
+                    match_state = sc
+                    cross_region_matches.append({
+                        "insee": rec["code"],
+                        "nom": rec["nom"],
+                        "expected_state": primary,
+                        "actual_state": sc,
+                        "csc_id": match["id"],
+                    })
+                    break
+
+        if match is None:
+            geo_rec = geo_by_code.get(rec["code"]) or {}
+            missing.append({
+                "insee": rec["code"],
+                "nom": rec["nom"],
+                "departement": rec["departement"],
+                "region": rec["region"],
+                "target_state": primary,
+                "centre": geo_rec.get("centre"),
+                "population": geo_rec.get("population"),
+            })
+            continue
+
+        matched_count += 1
+        matched_keys.add((match_state, name_n))
+
+        # Coord mismatch — only meaningful when the commune name is unique
+        # in the upstream metro list. Otherwise the match could be a homonym
+        # in a different department and the distance is meaningless.
+        if upstream_name_count[name_n] != 1:
+            coord_mismatches_skipped_homonym += 1
+            continue
+        geo_rec = geo_by_code.get(rec["code"])
+        if not (geo_rec and geo_rec.get("centre")):
+            continue
+        up_lon, up_lat = geo_rec["centre"]["coordinates"]
+        try:
+            our_lat = float(match["latitude"])
+            our_lon = float(match["longitude"])
+        except (TypeError, ValueError):
+            continue
+        dist = haversine_km(up_lat, up_lon, our_lat, our_lon)
+        if dist > COORD_MISMATCH_KM:
+            coord_mismatches.append({
+                "insee": rec["code"],
+                "nom": rec["nom"],
+                "csc_id": match["id"],
+                "csc_state": match_state,
+                "ours": [our_lat, our_lon],
+                "upstream": [up_lat, up_lon],
+                "distance_km": round(dist, 2),
+            })
+
+    # "Extra in our data": records present in CSC but not in upstream metro list,
+    # filtered to records whose state_code is a metropolitan CSC code so that
+    # overseas-territory cities aren't reported as extras here.
+    extra = []
+    for c in ours:
+        if c.get("state_code") not in METRO_CSC_CODES:
+            continue
+        key = (c["state_code"], normalise_name(c["name"]))
+        if key in matched_keys:
+            continue
+        extra.append({
+            "csc_id": c["id"],
+            "name": c["name"],
+            "state_code": c["state_code"],
+            "latitude": c["latitude"],
+            "longitude": c["longitude"],
+        })
+
+    return {
+        "stats": {
+            "upstream_metro_total": len(metro_upstream),
+            "ours_total": len(ours),
+            "matched": matched_count,
+            "missing": len(missing),
+            "extra": len(extra),
+            "cross_region_matches": len(cross_region_matches),
+            "coord_mismatches": len(coord_mismatches),
+            "coord_mismatches_skipped_homonym": coord_mismatches_skipped_homonym,
+        },
+        "missing": missing,
+        "extra": extra,
+        "cross_region_matches": cross_region_matches,
+        "coord_mismatches": coord_mismatches,
+    }
+
+
+# ---- Merge proposal -------------------------------------------------------
+
+
+def build_merge_proposal(missing: list[dict], csc_states: dict[str, dict],
+                         pop_threshold: int) -> tuple[list[dict], list[dict]]:
+    """Filter missing entries to those safe to auto-add and shape them into
+    CSC city records.
+
+    Returns (proposed_records, deferred_records).
+    Deferred = entries we *won't* auto-apply (no coords, low population, or
+    target state unmapped).
+    """
+    proposed: list[dict] = []
+    deferred: list[dict] = []
+    for m in missing:
+        target = m["target_state"]
+        state = csc_states.get(target) if target else None
+        centre = m.get("centre") or {}
+        pop = m.get("population")
+        coords = centre.get("coordinates") if isinstance(centre, dict) else None
+        skip_reasons = []
+        if not state:
+            skip_reasons.append("unmapped_state")
+        if not coords:
+            skip_reasons.append("no_coords")
+        if pop is None:
+            skip_reasons.append("no_population")
+        elif pop < pop_threshold:
+            skip_reasons.append(f"pop<{pop_threshold}")
+        if not coords or not state:
+            deferred.append({**m, "skip_reasons": skip_reasons})
+            continue
+
+        lon, lat = coords
+        # Defensive bounds check (Corsica & metro mainland)
+        if not (FR_BOUNDS["minLat"] <= lat <= FR_BOUNDS["maxLat"]
+                and FR_BOUNDS["minLon"] <= lon <= FR_BOUNDS["maxLon"]):
+            deferred.append({**m, "skip_reasons": skip_reasons + ["out_of_bounds"]})
+            continue
+
+        if pop is None or pop < pop_threshold:
+            deferred.append({**m, "skip_reasons": skip_reasons})
+            continue
+
+        record = {
+            "name": m["nom"],
+            "state_id": state["id"],
+            "state_code": state["iso2"],
+            "country_id": 75,
+            "country_code": "FR",
+            "type": "city",
+            "level": None,
+            "parent_id": None,
+            "latitude": f"{lat:.8f}",
+            "longitude": f"{lon:.8f}",
+            "native": m["nom"],
+            "population": pop,
+            "timezone": "Europe/Paris",
+        }
+        proposed.append(record)
+    # Stable sort: by name (case-insensitive) so the diff is reviewable
+    proposed.sort(key=lambda r: r["name"].lower())
+    deferred.sort(key=lambda d: d["nom"].lower())
+    return proposed, deferred
+
+
+# ---- Apply ----------------------------------------------------------------
+
+
+def apply_merge(our_path: Path, ours: list[dict], proposed: list[dict]) -> int:
+    """Append new records to FR.json without disturbing existing ones."""
+    # Defensive: drop any record whose key collides with an existing one
+    existing_keys = {(c["state_code"], normalise_name(c["name"])) for c in ours}
+    safe = [r for r in proposed if (r["state_code"], normalise_name(r["name"])) not in existing_keys]
+    if len(safe) != len(proposed):
+        print(f"WARNING: dropped {len(proposed) - len(safe)} proposed records "
+              f"that collided with existing keys")
+    merged = ours + safe
+    with our_path.open("w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    return len(safe)
+
+
+# ---- Main -----------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(__file__).resolve().parents[3]
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--upstream", required=True, type=Path,
+                        help="path to villes.min.json")
+    parser.add_argument("--geo", required=True, type=Path,
+                        help="path to geo.api.gouv.fr communes dump")
+    parser.add_argument("--our", type=Path,
+                        default=repo_root / "contributions" / "cities" / "FR.json",
+                        help="path to FR.json (default: repo's contributions/cities/FR.json)")
+    parser.add_argument("--states", type=Path,
+                        default=repo_root / "contributions" / "states" / "states.json",
+                        help="path to states.json")
+    parser.add_argument("--report-out", type=Path,
+                        default=repo_root / "bin" / "scripts" / "fixes"
+                        / "france_cities_diff.report.json",
+                        help="where to write the diff report")
+    parser.add_argument("--merge-out", type=Path,
+                        default=repo_root / "bin" / "scripts" / "fixes"
+                        / "france_cities_diff.merge.json",
+                        help="where to write the merge proposal (always written)")
+    parser.add_argument("--deferred-out", type=Path,
+                        default=repo_root / "bin" / "scripts" / "fixes"
+                        / "france_cities_diff.deferred.json",
+                        help="where to write deferred (skipped) candidates for review")
+    parser.add_argument("--pop-threshold", type=int, default=2000,
+                        help="minimum population to auto-include in the merge "
+                             "(conservative default keeps PR scope reviewable)")
+    parser.add_argument("--apply", action="store_true",
+                        help="rewrite FR.json with the merge applied")
+    args = parser.parse_args(argv)
+
+    upstream = load_json(args.upstream)
+    geo = load_json(args.geo)
+    ours = load_json(args.our)
+    states = load_json(args.states)
+
+    if not isinstance(upstream, list) or not isinstance(geo, list) \
+            or not isinstance(ours, list) or not isinstance(states, list):
+        sys.exit("ERROR: all four input files must be JSON arrays.")
+
+    csc_states = build_csc_state_lookup(states)
+
+    diff = run_diff(upstream, geo, ours)
+    proposed, deferred = build_merge_proposal(
+        diff["missing"], csc_states, args.pop_threshold)
+
+    # Write reports
+    args.report_out.write_text(json.dumps({
+        "stats": diff["stats"],
+        "pop_threshold": args.pop_threshold,
+        "proposed_count": len(proposed),
+        "deferred_count": len(deferred),
+        "samples": {
+            "missing_top_by_population": sorted(
+                [m for m in diff["missing"] if m.get("population") is not None],
+                key=lambda x: -x["population"],
+            )[:50],
+            "cross_region_matches": diff["cross_region_matches"][:50],
+            "coord_mismatches_top": sorted(
+                diff["coord_mismatches"], key=lambda x: -x["distance_km"]
+            )[:50],
+            "extra_sample": diff["extra"][:30],
+        },
+    }, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    args.merge_out.write_text(
+        json.dumps(proposed, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8")
+    args.deferred_out.write_text(
+        json.dumps(deferred, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8")
+
+    s = diff["stats"]
+    print(f"upstream metro total : {s['upstream_metro_total']:,}")
+    print(f"ours total           : {s['ours_total']:,}")
+    print(f"matched              : {s['matched']:,}")
+    print(f"missing              : {s['missing']:,}")
+    print(f"extra (in CSC only)  : {s['extra']:,}")
+    print(f"cross-region matches : {s['cross_region_matches']:,}  (flagged for PR-B)")
+    print(f"coord mismatches >{COORD_MISMATCH_KM}km: {s['coord_mismatches']:,}  "
+          f"({s['coord_mismatches_skipped_homonym']:,} ambiguous homonyms skipped)")
+    print(f"merge proposal       : {len(proposed):,} records (pop ≥ {args.pop_threshold})")
+    print(f"deferred (skipped)   : {len(deferred):,} records")
+    print(f"report  -> {args.report_out}")
+    print(f"merge   -> {args.merge_out}")
+    print(f"deferred-> {args.deferred_out}")
+
+    if args.apply:
+        added = apply_merge(args.our, ours, proposed)
+        print(f"\nAPPLIED: appended {added:,} records to {args.our}")
+    else:
+        print("\nDry run — re-run with --apply to write FR.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/scripts/fixes/france_cities_diff.report.json
+++ b/bin/scripts/fixes/france_cities_diff.report.json
@@ -1,0 +1,2085 @@
+{
+  "stats": {
+    "upstream_metro_total": 34806,
+    "ours_total": 10079,
+    "matched": 10688,
+    "missing": 24118,
+    "extra": 643,
+    "cross_region_matches": 1194,
+    "coord_mismatches": 4836,
+    "coord_mismatches_skipped_homonym": 1978
+  },
+  "pop_threshold": 2000,
+  "proposed_count": 455,
+  "deferred_count": 23663,
+  "samples": {
+    "missing_top_by_population": [
+      {
+        "insee": "50129",
+        "nom": "Cherbourg-en-Cotentin",
+        "departement": "50",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.6356,
+            49.6277
+          ]
+        },
+        "population": 78258
+      },
+      {
+        "insee": "91228",
+        "nom": "Évry-Courcouronnes",
+        "departement": "91",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.4313,
+            48.6287
+          ]
+        },
+        "population": 66919
+      },
+      {
+        "insee": "93070",
+        "nom": "Saint-Ouen-sur-Seine",
+        "departement": "93",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.3329,
+            48.9118
+          ]
+        },
+        "population": 53615
+      },
+      {
+        "insee": "69149",
+        "nom": "Oullins-Pierre-Bénite",
+        "departement": "69",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            4.8112,
+            45.708
+          ]
+        },
+        "population": 38168
+      },
+      {
+        "insee": "95306",
+        "nom": "Herblay-sur-Seine",
+        "departement": "95",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.1556,
+            49.0052
+          ]
+        },
+        "population": 31779
+      },
+      {
+        "insee": "78158",
+        "nom": "Le Chesnay-Rocquencourt",
+        "departement": "78",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.1188,
+            48.8285
+          ]
+        },
+        "population": 30689
+      },
+      {
+        "insee": "49301",
+        "nom": "Sèvremoine",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.0968,
+            47.0878
+          ]
+        },
+        "population": 25797
+      },
+      {
+        "insee": "49023",
+        "nom": "Beaupréau-en-Mauges",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.9844,
+            47.2028
+          ]
+        },
+        "population": 23989
+      },
+      {
+        "insee": "49092",
+        "nom": "Chemillé-en-Anjou",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.6964,
+            47.2211
+          ]
+        },
+        "population": 21999
+      },
+      {
+        "insee": "85146",
+        "nom": "Montaigu-Vendée",
+        "departement": "85",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.2923,
+            46.9741
+          ]
+        },
+        "population": 21134
+      },
+      {
+        "insee": "49244",
+        "nom": "Mauges-sur-Loire",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.9351,
+            47.3435
+          ]
+        },
+        "population": 18695
+      },
+      {
+        "insee": "49331",
+        "nom": "Segré-en-Anjou Bleu",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.854,
+            47.7111
+          ]
+        },
+        "population": 17667
+      },
+      {
+        "insee": "14762",
+        "nom": "Vire Normandie",
+        "departement": "14",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.87,
+            48.8199
+          ]
+        },
+        "population": 17457
+      },
+      {
+        "insee": "22093",
+        "nom": "Lamballe-Armor",
+        "departement": "22",
+        "region": "53",
+        "target_state": "BRE",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -2.5201,
+            48.4859
+          ]
+        },
+        "population": 17241
+      },
+      {
+        "insee": "49307",
+        "nom": "Loire-Authion",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.3734,
+            47.4695
+          ]
+        },
+        "population": 16765
+      },
+      {
+        "insee": "01033",
+        "nom": "Valserhône",
+        "departement": "01",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            5.7944,
+            46.1234
+          ]
+        },
+        "population": 16712
+      },
+      {
+        "insee": "53062",
+        "nom": "Château-Gontier-sur-Mayenne",
+        "departement": "53",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.701,
+            47.821
+          ]
+        },
+        "population": 16584
+      },
+      {
+        "insee": "49218",
+        "nom": "Montrevault-sur-Èvre",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.0204,
+            47.2494
+          ]
+        },
+        "population": 15726
+      },
+      {
+        "insee": "69019",
+        "nom": "Belleville-en-Beaujolais",
+        "departement": "69",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            4.7291,
+            46.1145
+          ]
+        },
+        "population": 14016
+      },
+      {
+        "insee": "77316",
+        "nom": "Moret-Loing-et-Orvanne",
+        "departement": "77",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.8233,
+            48.3545
+          ]
+        },
+        "population": 12810
+      },
+      {
+        "insee": "33366",
+        "nom": "Saint-André-de-Cubzac",
+        "departement": "33",
+        "region": "75",
+        "target_state": "NAQ",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.4378,
+            44.9945
+          ]
+        },
+        "population": 12626
+      },
+      {
+        "insee": "56078",
+        "nom": "Guidel",
+        "departement": "56",
+        "region": "53",
+        "target_state": "BRE",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -3.4906,
+            47.7938
+          ]
+        },
+        "population": 12338
+      },
+      {
+        "insee": "12176",
+        "nom": "Onet-le-Château",
+        "departement": "12",
+        "region": "76",
+        "target_state": "OCC",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.5614,
+            44.3824
+          ]
+        },
+        "population": 12080
+      },
+      {
+        "insee": "44003",
+        "nom": "Ancenis-Saint-Géréon",
+        "departement": "44",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.1681,
+            47.382
+          ]
+        },
+        "population": 11600
+      },
+      {
+        "insee": "50041",
+        "nom": "La Hague",
+        "departement": "50",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.8214,
+            49.6546
+          ]
+        },
+        "population": 11484
+      },
+      {
+        "insee": "49125",
+        "nom": "Doué-en-Anjou",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.3053,
+            47.1988
+          ]
+        },
+        "population": 11029
+      },
+      {
+        "insee": "49050",
+        "nom": "Brissac Loire Aubance",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.4087,
+            47.3392
+          ]
+        },
+        "population": 10878
+      },
+      {
+        "insee": "24053",
+        "nom": "Boulazac Isle Manoire",
+        "departement": "24",
+        "region": "75",
+        "target_state": "NAQ",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            0.7878,
+            45.1385
+          ]
+        },
+        "population": 10759
+      },
+      {
+        "insee": "76476",
+        "nom": "Port-Jérôme-sur-Seine",
+        "departement": "76",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            0.5834,
+            49.5062
+          ]
+        },
+        "population": 10617
+      },
+      {
+        "insee": "66008",
+        "nom": "Argelès-sur-Mer",
+        "departement": "66",
+        "region": "76",
+        "target_state": "OCC",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            3.0234,
+            42.53
+          ]
+        },
+        "population": 10616
+      },
+      {
+        "insee": "50099",
+        "nom": "Carentan-les-Marais",
+        "departement": "50",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.2118,
+            49.3061
+          ]
+        },
+        "population": 10218
+      },
+      {
+        "insee": "74282",
+        "nom": "Fillière",
+        "departement": "74",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            6.2275,
+            46.0057
+          ]
+        },
+        "population": 10075
+      },
+      {
+        "insee": "14431",
+        "nom": "Mézidon Vallée d'Auge",
+        "departement": "14",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.0169,
+            49.086
+          ]
+        },
+        "population": 9766
+      },
+      {
+        "insee": "49267",
+        "nom": "Saint-Barthélemy-d'Anjou",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.4826,
+            47.4741
+          ]
+        },
+        "population": 9720
+      },
+      {
+        "insee": "76618",
+        "nom": "Petit-Caux",
+        "departement": "76",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            1.2343,
+            49.9612
+          ]
+        },
+        "population": 9513
+      },
+      {
+        "insee": "34079",
+        "nom": "Clermont-l'Hérault",
+        "departement": "34",
+        "region": "76",
+        "target_state": "OCC",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            3.4017,
+            43.6323
+          ]
+        },
+        "population": 9461
+      },
+      {
+        "insee": "01313",
+        "nom": "Prévessin-Moëns",
+        "departement": "01",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            6.0722,
+            46.2594
+          ]
+        },
+        "population": 9153
+      },
+      {
+        "insee": "74112",
+        "nom": "Epagny Metz-Tessy",
+        "departement": "74",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            6.0934,
+            45.943
+          ]
+        },
+        "population": 8925
+      },
+      {
+        "insee": "76305",
+        "nom": "Gonfreville-l'Orcher",
+        "departement": "76",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            0.2223,
+            49.487
+          ]
+        },
+        "population": 8916
+      },
+      {
+        "insee": "49248",
+        "nom": "Ombrée d'Anjou",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.1086,
+            47.7232
+          ]
+        },
+        "population": 8813
+      },
+      {
+        "insee": "59143",
+        "nom": "La Chapelle-d'Armentières",
+        "departement": "59",
+        "region": "32",
+        "target_state": "HDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.8944,
+            50.6641
+          ]
+        },
+        "population": 8754
+      },
+      {
+        "insee": "49080",
+        "nom": "Les Hauts-d'Anjou",
+        "departement": "49",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.5499,
+            47.697
+          ]
+        },
+        "population": 8751
+      },
+      {
+        "insee": "63193",
+        "nom": "Lempdes",
+        "departement": "63",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            3.192,
+            45.7719
+          ]
+        },
+        "population": 8709
+      },
+      {
+        "insee": "93039",
+        "nom": "L'Île-Saint-Denis",
+        "departement": "93",
+        "region": "11",
+        "target_state": "IDF",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            2.3204,
+            48.9465
+          ]
+        },
+        "population": 8696
+      },
+      {
+        "insee": "35334",
+        "nom": "Thorigné-Fouillard",
+        "departement": "35",
+        "region": "53",
+        "target_state": "BRE",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.5866,
+            48.1524
+          ]
+        },
+        "population": 8667
+      },
+      {
+        "insee": "14061",
+        "nom": "Souleuvre en Bocage",
+        "departement": "14",
+        "region": "28",
+        "target_state": "NOR",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.84,
+            48.9616
+          ]
+        },
+        "population": 8629
+      },
+      {
+        "insee": "79079",
+        "nom": "Mauléon",
+        "departement": "79",
+        "region": "75",
+        "target_state": "NAQ",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -0.7565,
+            46.943
+          ]
+        },
+        "population": 8573
+      },
+      {
+        "insee": "38524",
+        "nom": "Varces-Allières-et-Risset",
+        "departement": "38",
+        "region": "84",
+        "target_state": "ARA",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            5.6699,
+            45.0884
+          ]
+        },
+        "population": 8542
+      },
+      {
+        "insee": "56251",
+        "nom": "Theix-Noyalo",
+        "departement": "56",
+        "region": "53",
+        "target_state": "BRE",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -2.6472,
+            47.6304
+          ]
+        },
+        "population": 8500
+      },
+      {
+        "insee": "85288",
+        "nom": "Talmont-Saint-Hilaire",
+        "departement": "85",
+        "region": "52",
+        "target_state": "PDL",
+        "centre": {
+          "type": "Point",
+          "coordinates": [
+            -1.6299,
+            46.4775
+          ]
+        },
+        "population": 8492
+      }
+    ],
+    "cross_region_matches": [
+      {
+        "insee": "01011",
+        "nom": "Apremont",
+        "expected_state": "ARA",
+        "actual_state": "PDL",
+        "csc_id": 39445
+      },
+      {
+        "insee": "01061",
+        "nom": "Brens",
+        "expected_state": "ARA",
+        "actual_state": "OCC",
+        "csc_id": 40275
+      },
+      {
+        "insee": "01063",
+        "nom": "Brion",
+        "expected_state": "ARA",
+        "actual_state": "48",
+        "csc_id": 40319
+      },
+      {
+        "insee": "01068",
+        "nom": "Cerdon",
+        "expected_state": "ARA",
+        "actual_state": "CVL",
+        "csc_id": 40643
+      },
+      {
+        "insee": "01331",
+        "nom": "Saint-Alban",
+        "expected_state": "ARA",
+        "actual_state": "OCC",
+        "csc_id": 45734
+      },
+      {
+        "insee": "01349",
+        "nom": "Saint-Éloi",
+        "expected_state": "ARA",
+        "actual_state": "BFC",
+        "csc_id": 46636
+      },
+      {
+        "insee": "01369",
+        "nom": "Saint-Just",
+        "expected_state": "ARA",
+        "actual_state": "NOR",
+        "csc_id": 46150
+      },
+      {
+        "insee": "01371",
+        "nom": "Saint-Marcel",
+        "expected_state": "ARA",
+        "actual_state": "CVL",
+        "csc_id": 46241
+      },
+      {
+        "insee": "01385",
+        "nom": "Saint-Rémy",
+        "expected_state": "ARA",
+        "actual_state": "NOR",
+        "csc_id": 46508
+      },
+      {
+        "insee": "01387",
+        "nom": "Saint-Sulpice",
+        "expected_state": "ARA",
+        "actual_state": "HDF",
+        "csc_id": 46559
+      },
+      {
+        "insee": "01419",
+        "nom": "Thoiry",
+        "expected_state": "ARA",
+        "actual_state": "IDF",
+        "csc_id": 47243
+      },
+      {
+        "insee": "01446",
+        "nom": "Villeneuve",
+        "expected_state": "ARA",
+        "actual_state": "OCC",
+        "csc_id": 47759
+      },
+      {
+        "insee": "02036",
+        "nom": "Augy",
+        "expected_state": "HDF",
+        "actual_state": "BFC",
+        "csc_id": 39606
+      },
+      {
+        "insee": "02043",
+        "nom": "Bagneux",
+        "expected_state": "HDF",
+        "actual_state": "IDF",
+        "csc_id": 39709
+      },
+      {
+        "insee": "02088",
+        "nom": "Bièvres",
+        "expected_state": "HDF",
+        "actual_state": "IDF",
+        "csc_id": 40040
+      },
+      {
+        "insee": "02122",
+        "nom": "Brie",
+        "expected_state": "HDF",
+        "actual_state": "NAQ",
+        "csc_id": 40305
+      },
+      {
+        "insee": "02142",
+        "nom": "Castres",
+        "expected_state": "HDF",
+        "actual_state": "OCC",
+        "csc_id": 40595
+      },
+      {
+        "insee": "02145",
+        "nom": "Caumont",
+        "expected_state": "HDF",
+        "actual_state": "NOR",
+        "csc_id": 40607
+      },
+      {
+        "insee": "02165",
+        "nom": "Charmes",
+        "expected_state": "HDF",
+        "actual_state": "52",
+        "csc_id": 40806
+      },
+      {
+        "insee": "02175",
+        "nom": "Chavigny",
+        "expected_state": "HDF",
+        "actual_state": "GES",
+        "csc_id": 40862
+      },
+      {
+        "insee": "02198",
+        "nom": "Clamecy",
+        "expected_state": "HDF",
+        "actual_state": "BFC",
+        "csc_id": 41040
+      },
+      {
+        "insee": "02270",
+        "nom": "Douchy",
+        "expected_state": "HDF",
+        "actual_state": "CVL",
+        "csc_id": 41548
+      },
+      {
+        "insee": "02277",
+        "nom": "Épagny",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 48069
+      },
+      {
+        "insee": "02302",
+        "nom": "Faverolles",
+        "expected_state": "HDF",
+        "actual_state": "52",
+        "csc_id": 155743
+      },
+      {
+        "insee": "02316",
+        "nom": "Fleury",
+        "expected_state": "HDF",
+        "actual_state": "GES",
+        "csc_id": 41845
+      },
+      {
+        "insee": "02356",
+        "nom": "Grisolles",
+        "expected_state": "HDF",
+        "actual_state": "OCC",
+        "csc_id": 42215
+      },
+      {
+        "insee": "02498",
+        "nom": "Montaigu",
+        "expected_state": "HDF",
+        "actual_state": "PDL",
+        "csc_id": 44169
+      },
+      {
+        "insee": "02505",
+        "nom": "Montfaucon",
+        "expected_state": "HDF",
+        "actual_state": "OCC",
+        "csc_id": 44230
+      },
+      {
+        "insee": "02523",
+        "nom": "Mont-Saint-Martin",
+        "expected_state": "HDF",
+        "actual_state": "GES",
+        "csc_id": 44157
+      },
+      {
+        "insee": "02530",
+        "nom": "Moulins",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 44394
+      },
+      {
+        "insee": "02573",
+        "nom": "Orgeval",
+        "expected_state": "HDF",
+        "actual_state": "IDF",
+        "csc_id": 44763
+      },
+      {
+        "insee": "02600",
+        "nom": "Pierrepont",
+        "expected_state": "HDF",
+        "actual_state": "GES",
+        "csc_id": 44961
+      },
+      {
+        "insee": "02610",
+        "nom": "Pommiers",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 45152
+      },
+      {
+        "insee": "02636",
+        "nom": "Regny",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 45687
+      },
+      {
+        "insee": "02647",
+        "nom": "Ribeauville",
+        "expected_state": "HDF",
+        "actual_state": "GES",
+        "csc_id": 45490
+      },
+      {
+        "insee": "02671",
+        "nom": "Saint-Aubin",
+        "expected_state": "HDF",
+        "actual_state": "BFC",
+        "csc_id": 45780
+      },
+      {
+        "insee": "02674",
+        "nom": "Saint-Clément",
+        "expected_state": "HDF",
+        "actual_state": "BFC",
+        "csc_id": 45869
+      },
+      {
+        "insee": "02682",
+        "nom": "Saint-Mard",
+        "expected_state": "HDF",
+        "actual_state": "IDF",
+        "csc_id": 46252
+      },
+      {
+        "insee": "02694",
+        "nom": "Saint-Simon",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 46553
+      },
+      {
+        "insee": "02712",
+        "nom": "Sergy",
+        "expected_state": "HDF",
+        "actual_state": "ARA",
+        "csc_id": 46955
+      },
+      {
+        "insee": "02729",
+        "nom": "Soucy",
+        "expected_state": "HDF",
+        "actual_state": "BFC",
+        "csc_id": 47061
+      },
+      {
+        "insee": "02813",
+        "nom": "Villers-le-Sec",
+        "expected_state": "HDF",
+        "actual_state": "55",
+        "csc_id": 156994
+      },
+      {
+        "insee": "03009",
+        "nom": "Aubigny",
+        "expected_state": "ARA",
+        "actual_state": "PDL",
+        "csc_id": 39579
+      },
+      {
+        "insee": "03015",
+        "nom": "Bagneux",
+        "expected_state": "ARA",
+        "actual_state": "IDF",
+        "csc_id": 39709
+      },
+      {
+        "insee": "03042",
+        "nom": "Le Breuil",
+        "expected_state": "ARA",
+        "actual_state": "BFC",
+        "csc_id": 43144
+      },
+      {
+        "insee": "03047",
+        "nom": "La Celle",
+        "expected_state": "ARA",
+        "actual_state": "PAC",
+        "csc_id": 42670
+      },
+      {
+        "insee": "03061",
+        "nom": "Charmes",
+        "expected_state": "ARA",
+        "actual_state": "52",
+        "csc_id": 40806
+      },
+      {
+        "insee": "03062",
+        "nom": "Charroux",
+        "expected_state": "ARA",
+        "actual_state": "NAQ",
+        "csc_id": 40817
+      },
+      {
+        "insee": "03069",
+        "nom": "Châtillon",
+        "expected_state": "ARA",
+        "actual_state": "IDF",
+        "csc_id": 40991
+      },
+      {
+        "insee": "03162",
+        "nom": "Marigny",
+        "expected_state": "ARA",
+        "actual_state": "NOR",
+        "csc_id": 43840
+      }
+    ],
+    "coord_mismatches_top": [
+      {
+        "insee": "62851",
+        "nom": "Vieille-Chapelle",
+        "csc_id": 47674,
+        "csc_state": "PAC",
+        "ours": [
+          43.24963,
+          5.38048
+        ],
+        "upstream": [
+          50.5936,
+          2.7198
+        ],
+        "distance_km": 841.09
+      },
+      {
+        "insee": "22275",
+        "nom": "Saint-Barnabé",
+        "csc_id": 45802,
+        "csc_state": "PAC",
+        "ours": [
+          43.3,
+          5.41667
+        ],
+        "upstream": [
+          48.1387,
+          -2.6995
+        ],
+        "distance_km": 827.75
+      },
+      {
+        "insee": "14756",
+        "nom": "La Villette",
+        "csc_id": 42916,
+        "csc_state": "PAC",
+        "ours": [
+          43.31181,
+          5.37391
+        ],
+        "upstream": [
+          48.9089,
+          -0.5428
+        ],
+        "distance_km": 771.09
+      },
+      {
+        "insee": "76103",
+        "nom": "Bonsecours",
+        "csc_id": 40109,
+        "csc_state": "PAC",
+        "ours": [
+          43.31923,
+          5.38426
+        ],
+        "upstream": [
+          49.4251,
+          1.1353
+        ],
+        "distance_km": 752.84
+      },
+      {
+        "insee": "77314",
+        "nom": "Montolivet",
+        "csc_id": 44296,
+        "csc_state": "PAC",
+        "ours": [
+          43.31715,
+          5.4235
+        ],
+        "upstream": [
+          48.8274,
+          3.4318
+        ],
+        "distance_km": 631.62
+      },
+      {
+        "insee": "68282",
+        "nom": "Romagny",
+        "csc_id": 45571,
+        "csc_state": "NOR",
+        "ours": [
+          48.63931,
+          -0.96605
+        ],
+        "upstream": [
+          47.6091,
+          7.0642
+        ],
+        "distance_km": 606.65
+      },
+      {
+        "insee": "25437",
+        "nom": "Osse",
+        "csc_id": 44791,
+        "csc_state": "BRE",
+        "ours": [
+          48.05542,
+          -1.45029
+        ],
+        "upstream": [
+          47.2718,
+          6.2115
+        ],
+        "distance_km": 580.1
+      },
+      {
+        "insee": "34149",
+        "nom": "Margon",
+        "csc_id": 43836,
+        "csc_state": "CVL",
+        "ours": [
+          48.33568,
+          0.83454
+        ],
+        "upstream": [
+          43.4877,
+          3.3048
+        ],
+        "distance_km": 571.86
+      },
+      {
+        "insee": "04200",
+        "nom": "Salignac",
+        "csc_id": 46750,
+        "csc_state": "NAQ",
+        "ours": [
+          45.01607,
+          -0.37964
+        ],
+        "upstream": [
+          44.1546,
+          5.9889
+        ],
+        "distance_km": 513.22
+      },
+      {
+        "insee": "71584",
+        "nom": "Viré",
+        "csc_id": 47857,
+        "csc_state": "NOR",
+        "ours": [
+          48.83849,
+          -0.88929
+        ],
+        "upstream": [
+          46.4437,
+          4.8483
+        ],
+        "distance_km": 505.45
+      },
+      {
+        "insee": "42166",
+        "nom": "Parigny",
+        "csc_id": 44853,
+        "csc_state": "NOR",
+        "ours": [
+          48.5945,
+          -1.07925
+        ],
+        "upstream": [
+          45.9892,
+          4.093
+        ],
+        "distance_km": 485.71
+      },
+      {
+        "insee": "25267",
+        "nom": "Gennes",
+        "csc_id": 42067,
+        "csc_state": "PDL",
+        "ours": [
+          47.3401,
+          -0.23149
+        ],
+        "upstream": [
+          47.2481,
+          6.1305
+        ],
+        "distance_km": 479.77
+      },
+      {
+        "insee": "69281",
+        "nom": "Marennes",
+        "csc_id": 43822,
+        "csc_state": "NAQ",
+        "ours": [
+          45.8228,
+          -1.10546
+        ],
+        "upstream": [
+          45.6248,
+          4.9097
+        ],
+        "distance_km": 467.35
+      },
+      {
+        "insee": "80225",
+        "nom": "Creuse",
+        "csc_id": 41311,
+        "csc_state": "NAQ",
+        "ours": [
+          46.07523,
+          2.05476
+        ],
+        "upstream": [
+          49.8347,
+          2.1603
+        ],
+        "distance_km": 418.11
+      },
+      {
+        "insee": "89373",
+        "nom": "Saligny",
+        "csc_id": 46752,
+        "csc_state": "PDL",
+        "ours": [
+          46.80833,
+          -1.42726
+        ],
+        "upstream": [
+          48.2169,
+          3.351
+        ],
+        "distance_km": 391.47
+      },
+      {
+        "insee": "36078",
+        "nom": "Fougerolles",
+        "csc_id": 41925,
+        "csc_state": "BFC",
+        "ours": [
+          47.88542,
+          6.40454
+        ],
+        "upstream": [
+          46.572,
+          1.8729
+        ],
+        "distance_km": 371.97
+      },
+      {
+        "insee": "38544",
+        "nom": "Vienne",
+        "csc_id": 47682,
+        "csc_state": "NAQ",
+        "ours": [
+          46.53528,
+          0.45201
+        ],
+        "upstream": [
+          45.5221,
+          4.8803
+        ],
+        "distance_km": 359.9
+      },
+      {
+        "insee": "63430",
+        "nom": "Thiers",
+        "csc_id": 47228,
+        "csc_state": "PAC",
+        "ours": [
+          43.29748,
+          5.38198
+        ],
+        "upstream": [
+          45.8653,
+          3.538
+        ],
+        "distance_km": 320.69
+      },
+      {
+        "insee": "04121",
+        "nom": "Mézel",
+        "csc_id": 44066,
+        "csc_state": "ARA",
+        "ours": [
+          45.75508,
+          3.24225
+        ],
+        "upstream": [
+          43.9979,
+          6.1799
+        ],
+        "distance_km": 302.88
+      },
+      {
+        "insee": "91619",
+        "nom": "Torfou",
+        "csc_id": 47302,
+        "csc_state": "PDL",
+        "ours": [
+          47.03682,
+          -1.11635
+        ],
+        "upstream": [
+          48.5314,
+          2.2335
+        ],
+        "distance_km": 300.39
+      },
+      {
+        "insee": "54364",
+        "nom": "Méréville",
+        "csc_id": 44481,
+        "csc_state": "IDF",
+        "ours": [
+          48.31476,
+          2.08609
+        ],
+        "upstream": [
+          48.589,
+          6.1337
+        ],
+        "distance_km": 300.03
+      },
+      {
+        "insee": "17231",
+        "nom": "Messac",
+        "csc_id": 44032,
+        "csc_state": "BRE",
+        "ours": [
+          47.82399,
+          -1.81085
+        ],
+        "upstream": [
+          45.3492,
+          -0.3147
+        ],
+        "distance_km": 297.98
+      },
+      {
+        "insee": "46207",
+        "nom": "Montredon",
+        "csc_id": 44304,
+        "csc_state": "PAC",
+        "ours": [
+          43.24016,
+          5.36629
+        ],
+        "upstream": [
+          44.6117,
+          2.1818
+        ],
+        "distance_km": 297.12
+      },
+      {
+        "insee": "10394",
+        "nom": "Vallières",
+        "csc_id": 47491,
+        "csc_state": "ARA",
+        "ours": [
+          45.90043,
+          5.93863
+        ],
+        "upstream": [
+          47.9988,
+          4.0601
+        ],
+        "distance_km": 273.43
+      },
+      {
+        "insee": "12161",
+        "nom": "Mouret",
+        "csc_id": 44400,
+        "csc_state": "PAC",
+        "ours": [
+          43.36126,
+          5.43006
+        ],
+        "upstream": [
+          44.5154,
+          2.5174
+        ],
+        "distance_km": 266.17
+      },
+      {
+        "insee": "63382",
+        "nom": "Saint-Pardoux",
+        "csc_id": 46392,
+        "csc_state": "NAQ",
+        "ours": [
+          46.57155,
+          -0.30542
+        ],
+        "upstream": [
+          46.0574,
+          3.003
+        ],
+        "distance_km": 260.42
+      },
+      {
+        "insee": "60200",
+        "nom": "Domfront",
+        "csc_id": 41516,
+        "csc_state": "NOR",
+        "ours": [
+          48.59208,
+          -0.64588
+        ],
+        "upstream": [
+          49.5983,
+          2.5563
+        ],
+        "distance_km": 258.58
+      },
+      {
+        "insee": "16100",
+        "nom": "Chirac",
+        "csc_id": 40913,
+        "csc_state": "OCC",
+        "ours": [
+          44.52289,
+          3.26652
+        ],
+        "upstream": [
+          45.9154,
+          0.6875
+        ],
+        "distance_km": 254.5
+      },
+      {
+        "insee": "17032",
+        "nom": "Ballon",
+        "csc_id": 39754,
+        "csc_state": "PDL",
+        "ours": [
+          48.17317,
+          0.23814
+        ],
+        "upstream": [
+          46.0541,
+          -0.9705
+        ],
+        "distance_km": 252.75
+      },
+      {
+        "insee": "71186",
+        "nom": "Écuelles",
+        "csc_id": 48054,
+        "csc_state": "IDF",
+        "ours": [
+          48.35636,
+          2.82335
+        ],
+        "upstream": [
+          46.9516,
+          5.0708
+        ],
+        "distance_km": 229.63
+      },
+      {
+        "insee": "17202",
+        "nom": "Landes",
+        "csc_id": 43005,
+        "csc_state": "NAQ",
+        "ours": [
+          43.97543,
+          -0.74241
+        ],
+        "upstream": [
+          45.9984,
+          -0.6012
+        ],
+        "distance_km": 225.22
+      },
+      {
+        "insee": "48108",
+        "nom": "La Panouse",
+        "csc_id": 42828,
+        "csc_state": "PAC",
+        "ours": [
+          43.25576,
+          5.42963
+        ],
+        "upstream": [
+          44.7375,
+          3.5885
+        ],
+        "distance_km": 220.98
+      },
+      {
+        "insee": "02270",
+        "nom": "Douchy",
+        "csc_id": 41548,
+        "csc_state": "CVL",
+        "ours": [
+          47.94282,
+          3.05392
+        ],
+        "upstream": [
+          49.7959,
+          3.1296
+        ],
+        "distance_km": 206.13
+      },
+      {
+        "insee": "27360",
+        "nom": "Jumelles",
+        "csc_id": 42590,
+        "csc_state": "PDL",
+        "ours": [
+          47.43511,
+          -0.1037
+        ],
+        "upstream": [
+          48.9194,
+          1.2102
+        ],
+        "distance_km": 191.65
+      },
+      {
+        "insee": "60070",
+        "nom": "Bienville",
+        "csc_id": 40011,
+        "csc_state": "GES",
+        "ours": [
+          48.57582,
+          5.04579
+        ],
+        "upstream": [
+          49.4474,
+          2.8245
+        ],
+        "distance_km": 188.77
+      },
+      {
+        "insee": "41079",
+        "nom": "Les Essarts",
+        "csc_id": 43385,
+        "csc_state": "PDL",
+        "ours": [
+          46.7744,
+          -1.22834
+        ],
+        "upstream": [
+          47.7321,
+          0.7148
+        ],
+        "distance_km": 181.23
+      },
+      {
+        "insee": "14510",
+        "nom": "La Pommeraye",
+        "csc_id": 42836,
+        "csc_state": "PDL",
+        "ours": [
+          47.35562,
+          -0.85892
+        ],
+        "upstream": [
+          48.9102,
+          -0.4163
+        ],
+        "distance_km": 175.95
+      },
+      {
+        "insee": "34236",
+        "nom": "Rouet",
+        "csc_id": 45618,
+        "csc_state": "PAC",
+        "ours": [
+          43.27808,
+          5.39158
+        ],
+        "upstream": [
+          43.8254,
+          3.8184
+        ],
+        "distance_km": 140.63
+      },
+      {
+        "insee": "69062",
+        "nom": "Coise",
+        "csc_id": 41086,
+        "csc_state": "ARA",
+        "ours": [
+          45.52822,
+          6.14389
+        ],
+        "upstream": [
+          45.6133,
+          4.4665
+        ],
+        "distance_km": 130.91
+      },
+      {
+        "insee": "18071",
+        "nom": "Contres",
+        "csc_id": 41156,
+        "csc_state": "CVL",
+        "ours": [
+          47.41754,
+          1.42849
+        ],
+        "upstream": [
+          46.8603,
+          2.4956
+        ],
+        "distance_km": 101.75
+      },
+      {
+        "insee": "60544",
+        "nom": "Rocquencourt",
+        "csc_id": 45552,
+        "csc_state": "IDF",
+        "ours": [
+          48.83783,
+          2.10228
+        ],
+        "upstream": [
+          49.6475,
+          2.4115
+        ],
+        "distance_km": 92.79
+      },
+      {
+        "insee": "27182",
+        "nom": "Courteilles",
+        "csc_id": 41267,
+        "csc_state": "NOR",
+        "ours": [
+          48.77495,
+          -0.19942
+        ],
+        "upstream": [
+          48.7421,
+          0.9987
+        ],
+        "distance_km": 87.9
+      },
+      {
+        "insee": "40271",
+        "nom": "Sainte-Marie-de-Gosse",
+        "csc_id": 46712,
+        "csc_state": "NAQ",
+        "ours": [
+          43.55,
+          -0.23333
+        ],
+        "upstream": [
+          43.5497,
+          -1.2301
+        ],
+        "distance_km": 80.33
+      },
+      {
+        "insee": "89162",
+        "nom": "Évry",
+        "csc_id": 48125,
+        "csc_state": "IDF",
+        "ours": [
+          48.6328,
+          2.44049
+        ],
+        "upstream": [
+          48.2681,
+          3.2611
+        ],
+        "distance_km": 72.85
+      },
+      {
+        "insee": "16208",
+        "nom": "Mareuil",
+        "csc_id": 43825,
+        "csc_state": "NAQ",
+        "ours": [
+          45.45,
+          0.45
+        ],
+        "upstream": [
+          45.7746,
+          -0.1348
+        ],
+        "distance_km": 58.07
+      },
+      {
+        "insee": "62869",
+        "nom": "Wailly",
+        "csc_id": 47936,
+        "csc_state": "HDF",
+        "ours": [
+          50.52287,
+          2.06792
+        ],
+        "upstream": [
+          50.248,
+          2.7197
+        ],
+        "distance_km": 55.4
+      },
+      {
+        "insee": "45258",
+        "nom": "Puiseaux",
+        "csc_id": 45320,
+        "csc_state": "CVL",
+        "ours": [
+          48.09234,
+          2.05967
+        ],
+        "upstream": [
+          48.2084,
+          2.4679
+        ],
+        "distance_km": 32.92
+      },
+      {
+        "insee": "25204",
+        "nom": "Doubs",
+        "csc_id": 41547,
+        "csc_state": "BFC",
+        "ours": [
+          47.19967,
+          6.43487
+        ],
+        "upstream": [
+          46.9321,
+          6.3651
+        ],
+        "distance_km": 30.22
+      },
+      {
+        "insee": "2B096",
+        "nom": "Corte",
+        "csc_id": 41205,
+        "csc_state": "2B",
+        "ours": [
+          42.2731881,
+          8.7394977
+        ],
+        "upstream": [
+          42.2737,
+          9.0691
+        ],
+        "distance_km": 27.12
+      },
+      {
+        "insee": "2B121",
+        "nom": "Galéria",
+        "csc_id": 155275,
+        "csc_state": "2B",
+        "ours": [
+          42.404378,
+          8.3770584
+        ],
+        "upstream": [
+          42.4048,
+          8.706
+        ],
+        "distance_km": 27.01
+      }
+    ],
+    "extra_sample": [
+      {
+        "csc_id": 39273,
+        "name": "Aigueblanche",
+        "state_code": "ARA",
+        "latitude": "45.50455000",
+        "longitude": "6.50184000"
+      },
+      {
+        "csc_id": 39280,
+        "name": "Aillant-sur-Tholon",
+        "state_code": "BFC",
+        "latitude": "47.87426000",
+        "longitude": "3.35049000"
+      },
+      {
+        "csc_id": 39285,
+        "name": "Aime",
+        "state_code": "ARA",
+        "latitude": "45.55559000",
+        "longitude": "6.65042000"
+      },
+      {
+        "csc_id": 39293,
+        "name": "Aix-en-Othe",
+        "state_code": "GES",
+        "latitude": "48.22391000",
+        "longitude": "3.73425000"
+      },
+      {
+        "csc_id": 39302,
+        "name": "Albens",
+        "state_code": "ARA",
+        "latitude": "45.78786000",
+        "longitude": "5.94528000"
+      },
+      {
+        "csc_id": 39328,
+        "name": "Allières-et-Risset",
+        "state_code": "ARA",
+        "latitude": "45.09934000",
+        "longitude": "5.67924000"
+      },
+      {
+        "csc_id": 39334,
+        "name": "Alpes-Maritimes",
+        "state_code": "PAC",
+        "latitude": "43.91307000",
+        "longitude": "7.20436000"
+      },
+      {
+        "csc_id": 39335,
+        "name": "Alpes-de-Haute-Provence",
+        "state_code": "PAC",
+        "latitude": "44.09829000",
+        "longitude": "6.26537000"
+      },
+      {
+        "csc_id": 39371,
+        "name": "Ancenis",
+        "state_code": "PDL",
+        "latitude": "47.36667000",
+        "longitude": "-1.16667000"
+      },
+      {
+        "csc_id": 39374,
+        "name": "Ancy-sur-Moselle",
+        "state_code": "GES",
+        "latitude": "49.05689000",
+        "longitude": "6.05775000"
+      },
+      {
+        "csc_id": 39378,
+        "name": "Andard",
+        "state_code": "PDL",
+        "latitude": "47.45659000",
+        "longitude": "-0.39752000"
+      },
+      {
+        "csc_id": 39389,
+        "name": "Andrezé",
+        "state_code": "PDL",
+        "latitude": "47.17155000",
+        "longitude": "-0.95239000"
+      },
+      {
+        "csc_id": 39395,
+        "name": "Anetz",
+        "state_code": "PDL",
+        "latitude": "47.38059000",
+        "longitude": "-1.10583000"
+      },
+      {
+        "csc_id": 39412,
+        "name": "Anizy-le-Château",
+        "state_code": "HDF",
+        "latitude": "49.50678000",
+        "longitude": "3.45119000"
+      },
+      {
+        "csc_id": 39415,
+        "name": "Annecy-le-Vieux",
+        "state_code": "ARA",
+        "latitude": "45.91971000",
+        "longitude": "6.14393000"
+      },
+      {
+        "csc_id": 39436,
+        "name": "Antrain",
+        "state_code": "BRE",
+        "latitude": "48.46031000",
+        "longitude": "-1.48354000"
+      },
+      {
+        "csc_id": 39466,
+        "name": "Ardennes",
+        "state_code": "GES",
+        "latitude": "49.63202000",
+        "longitude": "4.65369000"
+      },
+      {
+        "csc_id": 39470,
+        "name": "Arenc",
+        "state_code": "PAC",
+        "latitude": "43.31583000",
+        "longitude": "5.36698000"
+      },
+      {
+        "csc_id": 39474,
+        "name": "Argelers",
+        "state_code": "OCC",
+        "latitude": "42.54714000",
+        "longitude": "3.02253000"
+      },
+      {
+        "csc_id": 39480,
+        "name": "Argentat",
+        "state_code": "NAQ",
+        "latitude": "45.09325000",
+        "longitude": "1.93778000"
+      },
+      {
+        "csc_id": 39482,
+        "name": "Argenton-les-Vallées",
+        "state_code": "NAQ",
+        "latitude": "46.98333000",
+        "longitude": "-0.45000000"
+      },
+      {
+        "csc_id": 39492,
+        "name": "Armenonville-les-Gâtineaux",
+        "state_code": "CVL",
+        "latitude": "48.54365000",
+        "longitude": "1.64750000"
+      },
+      {
+        "csc_id": 39512,
+        "name": "Arrou",
+        "state_code": "CVL",
+        "latitude": "48.09768000",
+        "longitude": "1.12851000"
+      },
+      {
+        "csc_id": 39525,
+        "name": "Arthon-en-Retz",
+        "state_code": "PDL",
+        "latitude": "47.11586000",
+        "longitude": "-1.94260000"
+      },
+      {
+        "csc_id": 39547,
+        "name": "Aspach-le-Haut",
+        "state_code": "GES",
+        "latitude": "47.77653000",
+        "longitude": "7.13145000"
+      },
+      {
+        "csc_id": 39558,
+        "name": "Athis-de-l'Orne",
+        "state_code": "NOR",
+        "latitude": "48.81667000",
+        "longitude": "-0.50000000"
+      },
+      {
+        "csc_id": 39565,
+        "name": "Atur",
+        "state_code": "NAQ",
+        "latitude": "45.14086000",
+        "longitude": "0.74701000"
+      },
+      {
+        "csc_id": 39568,
+        "name": "Aube-sur-Rîle",
+        "state_code": "NOR",
+        "latitude": "48.73920000",
+        "longitude": "0.55161000"
+      },
+      {
+        "csc_id": 39575,
+        "name": "Aubevoye",
+        "state_code": "NOR",
+        "latitude": "49.17097000",
+        "longitude": "1.33537000"
+      },
+      {
+        "csc_id": 39576,
+        "name": "Aubie-et-Espessas",
+        "state_code": "NAQ",
+        "latitude": "45.01869000",
+        "longitude": "-0.40297000"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds **455 metropolitan French communes** (population ≥ 2,000) that were missing from `contributions/cities/FR.json` relative to the canonical INSEE commune list at data.gouv.fr.

This is **PR-A of 4** in the issue #1352 plan — siblings PR-B (region reclassification), PR-C (obsolete/merged commune cleanup), and PR-D (overseas territories) are tracked separately and explicitly out of scope here.

Refs #1352 — **does not close** the issue.

### What this PR does

- **+455 records** in `contributions/cities/FR.json`. All metropolitan, all population ≥ 2,000, all with coordinates and population from `geo.api.gouv.fr`. Top adds include Cherbourg-en-Cotentin (78K), Évry-Courcouronnes (66K), Saint-Ouen-sur-Seine (53K), Oullins-Pierre-Bénite (38K), Herblay-sur-Seine (32K), Le Chesnay-Rocquencourt (31K).
- **New script** `bin/scripts/fixes/france_cities_diff.py` — pure-Python, dependency-free; matches by `(state_code, normalised_name)` with œ/æ ligature and `lès`/`lez` preposition handling.
- **Diagnostic report** committed at `bin/scripts/fixes/france_cities_diff.report.json` for reviewer audit and follow-up PRs.
- **Full methodology** in `.github/fixes-docs/FIX_1352_PR_A_SUMMARY.md`.

### Diagnostic findings flagged for sibling PRs (NOT fixed here)

| Category | Count | Owner |
|----------|------:|-------|
| `cross_region_matches` (CSC city under wrong region — incl. Ajaccio/Bastia under `20R` instead of `2A`/`2B`) | 1,194 | **PR-B** |
| `extra` CSC records (obsolete/merged communes like `Aime`/`Annecy-le-Vieux`/`Ancenis`; Marseille quartiers like `Arenc`/`La Villette`; dept names mistakenly stored as cities like `Alpes-Maritimes`/`Ardennes`) | 643 | **PR-C** |
| Lower-population missing communes (deferred) | 23,663 | future PR-A.2 |
| Overseas territories | (excluded) | **PR-D** |

## Test plan

- [x] Local schema validator: **0 errors**, 2,275 warnings — all "unknown field" warnings for `type`/`level`/`parent_id`/`native`/`population`, identical to those produced by the existing 10,079 records (project convention; warnings, not blockers).
- [x] Cross-reference validator: every new record's `state_id`/`country_id` resolves; codes match.
- [x] Coordinate-bounds validator: every new record inside FR metropolitan box (lat 41.36–51.09, lon −5.14–9.56).
- [x] Duplicate detector: 0 exact-name same-state duplicates; 1 fuzzy match (`Bréhan` vs `Rohan`, dept 56) — verified to be two genuinely different communes 4.3 km apart with INSEE codes 56025 vs 56196.
- [x] JSON formatting: matches canonical 2-space indent.
- [x] No `id`/`created_at`/`updated_at`/`flag` fields on new records.
- [ ] CI PR validators (run automatically on this PR).

## Reviewer notes

- The script can be re-run by reviewers with their own `villes.min.json` and `geo.api.gouv.fr` dumps. The `--pop-threshold` arg is exposed so the threshold can be tuned without code changes.
- `france_cities_diff.merge.json` and `france_cities_diff.deferred.json` are **not** committed — the merge is now in FR.json and the deferred set (~7 MB) is regeneratable.
- Translations and `wikiDataId` are intentionally left empty for new records rather than synthesised; can be backfilled in a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)