### PR TITLE
fix(IT): widen country-bounds.json minLat to include Lampedusa

### DIFF
--- a/.github/data/country-bounds.json
+++ b/.github/data/country-bounds.json
@@ -498,7 +498,7 @@
     "maxLon": 35.9
   },
   "IT": {
-    "minLat": 36.65,
+    "minLat": 35.49,
     "maxLat": 47.09,
     "minLon": 6.63,
     "maxLon": 18.52


### PR DESCRIPTION
Discovered while validating PR #1395 (Italy city remap, refs #1349).

Lampedusa is the southernmost Italian comune (lat ~35.50, part of Agrigento free municipal consortium in the Pelagie archipelago) but sits outside `country-bounds.json`'s IT box (`minLat: 36.65`). Any city record at Lampedusa or Linosa would be flagged by `validate-coordinates.js` despite being a perfectly legitimate Italian record.

Fix: lower `IT.minLat` to `35.49`. `maxLat` / `minLon` / `maxLon` are unchanged.

## Verify
- [ ] `python3 -m json.tool .github/data/country-bounds.json` → JSON valid (passes locally).
- [ ] After merge, Lampedusa city (id 139349, lat 35.50142) no longer fails the bounds check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)