### PR TITLE
fix(IT): restore corrupted native fields (#1349 follow-up)

### DIFF
--- a/bin/scripts/fixes/data/it_native_restore_report.json
+++ b/bin/scripts/fixes/data/it_native_restore_report.json
@@ -1,0 +1,183 @@
+{
+  "totals": {
+    "input": 9947,
+    "skipped_no_istat": 2499,
+    "already_correct": 6070,
+    "changed": 1378
+  },
+  "by_first_letter": {
+    "P": 148,
+    "Q": 3,
+    "R": 67,
+    "S": 157,
+    "T": 69,
+    "U": 9,
+    "V": 89,
+    "Z": 13,
+    "A": 67,
+    "B": 109,
+    "C": 226,
+    "D": 23,
+    "E": 21,
+    "F": 50,
+    "G": 54,
+    "I": 14,
+    "J": 4,
+    "L": 71,
+    "M": 114,
+    "N": 32,
+    "O": 38
+  },
+  "examples": [
+    {
+      "id": 58212,
+      "name": "Pagnona",
+      "from": "Paya",
+      "to": "Pagnona"
+    },
+    {
+      "id": 58213,
+      "name": "Pago Veiano",
+      "from": "Pagato",
+      "to": "Pago Veiano"
+    },
+    {
+      "id": 58215,
+      "name": "Paisco Loveno",
+      "from": "Paisco Louvain",
+      "to": "Paisco Loveno"
+    },
+    {
+      "id": 58216,
+      "name": "Paitone",
+      "from": "Paiotone",
+      "to": "Paitone"
+    },
+    {
+      "id": 58218,
+      "name": "Palagano",
+      "from": "Palangano",
+      "to": "Palagano"
+    },
+    {
+      "id": 58219,
+      "name": "Palagianello",
+      "from": "Palatilllo",
+      "to": "Palagianello"
+    },
+    {
+      "id": 58224,
+      "name": "Palata",
+      "from": "Ritorno",
+      "to": "Palata"
+    },
+    {
+      "id": 58238,
+      "name": "Palena",
+      "from": "Limite",
+      "to": "Palena"
+    },
+    {
+      "id": 58251,
+      "name": "Pallare",
+      "from": "Pallet",
+      "to": "Pallare"
+    },
+    {
+      "id": 58256,
+      "name": "Palmariggi",
+      "from": "Parmeriggi",
+      "to": "Palmariggi"
+    },
+    {
+      "id": 58269,
+      "name": "Paluzza",
+      "from": "Palla",
+      "to": "Paluzza"
+    },
+    {
+      "id": 58275,
+      "name": "Panchià",
+      "from": "Possono agganciare",
+      "to": "Panchià"
+    },
+    {
+      "id": 58285,
+      "name": "Pantigliate",
+      "from": "Pantiglia",
+      "to": "Pantigliate"
+    },
+    {
+      "id": 58288,
+      "name": "Paolisi",
+      "from": "Marchisi",
+      "to": "Paolisi"
+    },
+    {
+      "id": 58292,
+      "name": "Papozze",
+      "from": "Flutter",
+      "to": "Papozze"
+    },
+    {
+      "id": 58298,
+      "name": "Parcines",
+      "from": "Parcine",
+      "to": "Parcines"
+    },
+    {
+      "id": 58304,
+      "name": "Pareto",
+      "from": "Libbra",
+      "to": "Pareto"
+    },
+    {
+      "id": 58305,
+      "name": "Parghelia",
+      "from": "Paraguia",
+      "to": "Parghelia"
+    },
+    {
+      "id": 58310,
+      "name": "Paroldo",
+      "from": "Discorso",
+      "to": "Paroldo"
+    },
+    {
+      "id": 58311,
+      "name": "Parolise",
+      "from": "Parlato",
+      "to": "Parolise"
+    },
+    {
+      "id": 58315,
+      "name": "Parre",
+      "from": "Paio",
+      "to": "Parre"
+    },
+    {
+      "id": 58318,
+      "name": "Paruzzaro",
+      "from": "Parauzzero",
+      "to": "Paruzzaro"
+    },
+    {
+      "id": 58324,
+      "name": "Paspardo",
+      "from": "Strakes",
+      "to": "Paspardo"
+    },
+    {
+      "id": 58341,
+      "name": "Pasturana",
+      "from": "Pastana",
+      "to": "Pasturana"
+    },
+    {
+      "id": 58342,
+      "name": "Pasturo",
+      "from": "Pasuro",
+      "to": "Pasturo"
+    }
+  ]
+}

--- a/bin/scripts/fixes/italy_restore_native.py
+++ b/bin/scripts/fixes/italy_restore_native.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Restore the `native` field for Italian cities corrupted by past machine
+translation runs (e.g. `Pero` → native `Ma`, `Postal` → native `Postale`,
+`Petit Fenis` → native `Chiede un fieno`).
+
+Strategy:
+  1. Build a normalised lookup of ISTAT comune Italian names (and bilingual
+     alternatives) -> the canonical Italian denomination, reusing the same
+     normalisation as italy_remap_cities.py.
+  2. For each city: if `name` matches an ISTAT entry (so we know `name` is the
+     authoritative Italian form), and `native` differs from `name`, replace
+     `native` with `name`.  Cities whose `name` is not an ISTAT comune (mostly
+     frazioni) are left untouched — we have no ground truth to second-guess
+     them.
+
+Idempotent.  Only the `native` field is mutated.
+
+Usage:
+    python3 bin/scripts/fixes/italy_restore_native.py [--dry-run] [--report path]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ISTAT_CSV = REPO_ROOT / "bin/scripts/fixes/data/istat-elenco-comuni-italiani.csv"
+CITIES_JSON = REPO_ROOT / "contributions/cities/IT.json"
+
+
+def normalise_name(value: str) -> str:
+    """Same fold used by italy_remap_cities.py: lowercased, NFD-stripped diacritics,
+    apostrophe-collapsed, single-spaced, alphanumeric+apostrophe+hyphen+slash only."""
+    if not value:
+        return ""
+    text = unicodedata.normalize("NFD", value)
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+    text = text.lower()
+    text = re.sub(r"[’‘`´]", "'", text)
+    text = re.sub(r"[^a-z0-9' \-/]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def expand_keys(value: str) -> List[str]:
+    base = normalise_name(value)
+    if not base:
+        return []
+    keys = {base}
+    if "/" in base:
+        for part in base.split("/"):
+            part = part.strip()
+            if part:
+                keys.add(part)
+    keys.add(base.replace("'", " ").replace("  ", " ").strip())
+    keys.add(base.replace("'", ""))
+    return [k for k in keys if k]
+
+
+def load_istat_index() -> Dict[str, str]:
+    """Map normalised key -> canonical ISTAT Italian denomination."""
+    index: Dict[str, str] = {}
+    with ISTAT_CSV.open("r", encoding="latin-1", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter=";")
+        for row in reader:
+            ita = row["Denominazione in italiano"].strip()
+            alt = row["Denominazione altra lingua"].strip()
+            full = row["Denominazione (Italiana e straniera)"].strip()
+            if not ita:
+                continue
+            for source in (ita, alt, full):
+                for key in expand_keys(source):
+                    # Don't overwrite an Italian-name key with a bilingual alt key.
+                    index.setdefault(key, ita)
+    return index
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--report", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    index = load_istat_index()
+    cities = json.loads(CITIES_JSON.read_text(encoding="utf-8"))
+
+    examples: List[dict] = []
+    examples_kept: List[dict] = []
+    changed = 0
+    skipped_no_istat = 0
+    already_correct = 0
+    by_first_letter: Counter = Counter()
+
+    for city in cities:
+        name = city.get("name") or ""
+        native = city.get("native")
+        if not name:
+            continue
+        keys = expand_keys(name)
+        canonical: Optional[str] = None
+        for k in keys:
+            if k in index:
+                canonical = index[k]
+                break
+        if canonical is None:
+            skipped_no_istat += 1
+            continue
+        # We know `name` is the canonical Italian form (it matched ISTAT).
+        # Replace `native` with `name` when they differ.
+        if native == name:
+            already_correct += 1
+            continue
+        previous = native
+        city["native"] = name
+        changed += 1
+        by_first_letter[name[:1].upper()] += 1
+        if len(examples) < 25:
+            examples.append({"id": city.get("id"), "name": name, "from": previous, "to": name})
+
+    print(f"Total cities: {len(cities)}")
+    print(f"  unchanged (no ISTAT match for name): {skipped_no_istat}")
+    print(f"  unchanged (native already == name):  {already_correct}")
+    print(f"  native restored:                     {changed}")
+    print()
+    print("Top 25 corrupted samples (before -> after):")
+    for ex in examples:
+        print(f"  id={ex['id']:7} {ex['name']!r:35} native: {ex['from']!r:25} -> {ex['to']!r}")
+    print()
+    print("Distribution by first letter:")
+    for letter, count in by_first_letter.most_common():
+        print(f"  {letter or '?':2} {count}")
+
+    if args.report:
+        args.report.write_text(
+            json.dumps(
+                {
+                    "totals": {
+                        "input": len(cities),
+                        "skipped_no_istat": skipped_no_istat,
+                        "already_correct": already_correct,
+                        "changed": changed,
+                    },
+                    "by_first_letter": dict(by_first_letter),
+                    "examples": examples,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    if args.dry_run:
+        print("\n--dry-run: IT.json not modified.")
+        return 0
+
+    text = json.dumps(cities, ensure_ascii=False, indent=2)
+    CITIES_JSON.write_text(text, encoding="utf-8")
+    print(f"\nWrote {len(cities)} cities to {CITIES_JSON.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Stacks on top of #1395.** Targets `feat/issue-1349-italy-city-remap` so the diff stays focused; rebase to master once #1395 lands.

Refs #1349 — discovered while writing the city remap. Many `native` values in `contributions/cities/IT.json` were corrupted by a past machine-translation run, e.g.:

| name | corrupted native | meaning |
|------|------------------|---------|
| Pero | "Ma" | "but" |
| Postal | "Postale" | adjective form |
| Pareto | "Libbra" | "pound" (weight) |
| Paroldo | "Discorso" | "speech" |
| Palata | "Ritorno" | "return" |
| Papozze | "Flutter" | English word |
| Panchià | "Possono agganciare" | "they can hook up" |
| Petit Fenis | "Chiede un fieno" | "asks for hay" |
| Pollein | "Poolin" | garbled |
| Paspardo | "Strakes" | English nautical term |

The `name` field already holds the canonical Italian form for these comuni (`Pomigliano d'Arco`, `Sant'Ambrogio di Torino`, etc., all with proper apostrophes and accents). Where a city's `name` matches an ISTAT comune, this PR sets `native = name`. Cities whose `name` is not an ISTAT comune (≈2,500 frazioni) are intentionally left untouched — no authoritative replacement is available.

## Counts

```
input              9947
already correct    6070   native already == name
no ISTAT match     2499   left untouched (frazioni)
restored           1378   native rewritten to name
```

## Commits
1. `fix(IT): restore 1,378 corrupted native fields (#1349 follow-up)` — script `italy_restore_native.py` + bundled report + IT.json data diff.

## Test plan
- [ ] `python3 bin/scripts/fixes/italy_restore_native.py --dry-run` reports 0 changes after this PR (idempotent).
- [ ] `jq '[.[] | select(.name == .native)] | length' contributions/cities/IT.json` returns ≥ 7,448 (was 6,070).
- [ ] `python3 -m json.tool contributions/cities/IT.json` parses cleanly.
- [ ] CI's `validate-schema` / `validate-cross-reference` / `validate-coordinates` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)