### PR TITLE
feat(postcodes/LI): add Liechtenstein postcodes (#1039)

### DIFF
--- a/contributions/postcodes/LI.json
+++ b/contributions/postcodes/LI.json
@@ -1,0 +1,132 @@
+[
+  {
+    "code": "9485",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 451,
+    "state_code": "02",
+    "locality_name": "Nendeln",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9486",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 455,
+    "state_code": "04",
+    "locality_name": "Schaanwald",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9487",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 457,
+    "state_code": "03",
+    "locality_name": "Bendern",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9488",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 449,
+    "state_code": "08",
+    "locality_name": "Schellenberg",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9490",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 452,
+    "state_code": "11",
+    "locality_name": "Vaduz",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9491",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 453,
+    "state_code": "06",
+    "locality_name": "Ruggell",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9492",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 451,
+    "state_code": "02",
+    "locality_name": "Eschen",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9493",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 455,
+    "state_code": "04",
+    "locality_name": "Mauren",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9494",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 450,
+    "state_code": "07",
+    "locality_name": "Schaan",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9495",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 459,
+    "state_code": "09",
+    "locality_name": "Triesen",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9496",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 458,
+    "state_code": "01",
+    "locality_name": "Balzers",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9497",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 456,
+    "state_code": "10",
+    "locality_name": "Triesenberg",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "9498",
+    "country_id": 125,
+    "country_code": "LI",
+    "state_id": 454,
+    "state_code": "05",
+    "locality_name": "Planken",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

First country populated against the `postcodes` table introduced in #1398. Adds Liechtenstein's 13 postal codes (range 9485–9498) covering the country's 11 municipalities.

## Mapping

| state_code | Municipality | Postcode(s) |
|------------|--------------|-------------|
| 01 | Balzers | 9496 Balzers |
| 02 | Eschen | **9485 Nendeln**, 9492 Eschen |
| 03 | Gamprin | 9487 Bendern |
| 04 | Mauren | **9486 Schaanwald**, 9493 Mauren |
| 05 | Planken | 9498 Planken |
| 06 | Ruggell | 9491 Ruggell |
| 07 | Schaan | 9494 Schaan |
| 08 | Schellenberg | 9488 Schellenberg |
| 09 | Triesen | 9495 Triesen |
| 10 | Triesenberg | 9497 Triesenberg |
| 11 | Vaduz | 9490 Vaduz |

(Bold = secondary locality within the municipality.)

## Source

`source: "manual"` — composed from common knowledge. Liechtenstein's postcodes are universally documented and stable for decades. Subsequent country PRs will use automated pipelines (OpenPLZ for DACH, Wikidata SPARQL, Census ZCTA for US, etc.) once their adapter scripts land.

## Validation

- ✅ All 13 records pass schema rules in `.github/scripts/utils.js`
- ✅ All `country_id` / `state_id` foreign keys resolve against existing data
- ✅ All `state_code` values match the corresponding `state.iso2`
- ✅ All `code` values match `countries.postal_code_regex` for LI (`^(\d{4})$`)
- ✅ No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`) present

## Out of scope

- `latitude` / `longitude` — left null. Could be backfilled with municipality centroids in a follow-up.
- `wikiDataId` per postcode — left null. Wikidata cross-reference is a separate enhancement.
- `city_id` — left null. Most LI postcodes serve a locality that may or may not be in `cities`; resolving each is a separate sweep.

## Test plan

- [x] JSON syntax valid
- [x] FK integrity verified locally against `contributions/countries/countries.json` and `contributions/states/states.json`
- [x] Codes match country regex
- [x] PR validator runs on top of #1398's validator changes
- [ ] Reviewer confirms locality-to-municipality mapping (especially the two split cases: Eschen=9485+9492, Mauren=9486+9493)

Refs: #1039
Builds on: #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)