### PR TITLE
feat(postcodes/MC): add Monaco postcode (#1039)

### DIFF
--- a/contributions/postcodes/MC.json
+++ b/contributions/postcodes/MC.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "98000",
+    "country_id": 145,
+    "country_code": "MC",
+    "locality_name": "Monaco",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds Monaco's single national postcode **98000** to the postcodes table. Smallest possible country case: 1 record, 1 country, no state assignment.

## Why country-only (no state_id)

Monaco's 17 quartiers all use the same 98000 postcode in the active postal system. There is no ward-level differentiation in everyday use, so `state_id` and `city_id` are both null — the postcode is country-scoped.

This demonstrates the **country-only Tier-4 case** the schema deliberately allows (state/city FKs are nullable per #1398).

## Source

`source: "manual"` — Monaco's 98000 is universally documented and stable. Future PR could expand to ward-level codes (98001–98012 exist in French postal records for some districts) once a clean source is identified.

## Validation

- ✅ 1 record passes schema rules in `.github/scripts/utils.js`
- ✅ `country_id: 145` / `country_code: "MC"` agree with `contributions/countries/countries.json`
- ✅ `code: "98000"` matches `countries.postal_code_regex` for MC (`^(\d{5})$`)
- ✅ No auto-managed fields present

Refs: #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)