### PR TITLE
feat(exports): wire postcodes table into all export formats (#1039)

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -150,6 +150,7 @@ jobs:
           echo "country_count=$(mysql -uroot -proot -e 'SELECT COUNT(*) FROM world.countries;' -s)" >> $GITHUB_ENV
           echo "state_count=$(mysql -uroot -proot -e 'SELECT COUNT(*) FROM world.states;' -s)" >> $GITHUB_ENV
           echo "city_count=$(mysql -uroot -proot -e 'SELECT COUNT(*) FROM world.cities;' -s)" >> $GITHUB_ENV
+          echo "postcode_count=$(mysql -uroot -proot -sN -e 'SELECT COUNT(*) FROM world.postcodes;' 2>/dev/null || echo 0)" >> $GITHUB_ENV
           echo "current_date=$(date +'%B %d, %Y')" >> $GITHUB_ENV
 
       - name: Composer Dependencies
@@ -192,6 +193,7 @@ jobs:
           mysqldump -uroot -proot --single-transaction --add-drop-table --disable-keys --set-charset --skip-add-locks world countries > sql/countries.sql
           mysqldump -uroot -proot --single-transaction --add-drop-table --disable-keys --set-charset --skip-add-locks world states > sql/states.sql
           mysqldump -uroot -proot --single-transaction --add-drop-table --disable-keys --set-charset --skip-add-locks world cities > sql/cities.sql
+          mysqldump -uroot -proot --single-transaction --add-drop-table --disable-keys --set-charset --skip-add-locks world postcodes > sql/postcodes.sql
           # Export complete world database
           mysqldump -uroot -proot --single-transaction --add-drop-table --disable-keys --set-charset --skip-add-locks world > sql/world.sql
 
@@ -200,13 +202,15 @@ jobs:
           echo "🧹 Adding DROP TABLE commands in correct order..."
           # Remove any existing DROP TABLE commands
           grep -v "DROP TABLE" sql/world.sql > sql/world_temp.sql
-          # Create new file with DROP TABLE commands in correct order (reverse of foreign key dependencies)
+          # Create new file with DROP TABLE commands in correct order (reverse of foreign key dependencies).
+          # postcodes drops first because it FKs to countries/states/cities.
           cat > sql/world.sql << 'EOF'
           -- -------------------------------------------------------------
           -- Generated from MySQL database
           -- Combined world database
           -- -------------------------------------------------------------
 
+          DROP TABLE IF EXISTS `postcodes`;
           DROP TABLE IF EXISTS `cities`;
           DROP TABLE IF EXISTS `states`;
           DROP TABLE IF EXISTS `countries`;
@@ -239,6 +243,7 @@ jobs:
           pg_dump --dbname=postgresql://postgres:postgres@localhost/world -Fp --inserts --clean --if-exists --no-owner --no-acl -t countries > psql/countries.sql
           pg_dump --dbname=postgresql://postgres:postgres@localhost/world -Fp --inserts --clean --if-exists --no-owner --no-acl -t states > psql/states.sql
           pg_dump --dbname=postgresql://postgres:postgres@localhost/world -Fp --inserts --clean --if-exists --no-owner --no-acl -t cities > psql/cities.sql
+          pg_dump --dbname=postgresql://postgres:postgres@localhost/world -Fp --inserts --clean --if-exists --no-owner --no-acl -t postcodes > psql/postcodes.sql
           pg_dump --dbname=postgresql://postgres:postgres@localhost/world -Fp --inserts --clean --if-exists --no-owner --no-acl > psql/world.sql
 
           # Remove \restrict and \unrestrict commands from all psql files
@@ -257,6 +262,7 @@ jobs:
           mysql2sqlite -d world -t countries --mysql-password root -u root -f sqlite/countries.sqlite3
           mysql2sqlite -d world -t states --mysql-password root -u root -f sqlite/states.sqlite3
           mysql2sqlite -d world -t cities --mysql-password root -u root -f sqlite/cities.sqlite3
+          mysql2sqlite -d world -t postcodes --mysql-password root -u root -f sqlite/postcodes.sqlite3
           mysql2sqlite -d world --mysql-password root -u root -f sqlite/world.sqlite3
 
       - name: Export SQL Server
@@ -281,6 +287,11 @@ jobs:
           mongoimport --host localhost:27017 --db world --collection countries --file countries.json --jsonArray
           mongoimport --host localhost:27017 --db world --collection states --file states.json --jsonArray
           mongoimport --host localhost:27017 --db world --collection cities --file cities.json --jsonArray
+          if [ -s postcodes.json ] && [ "$(jq 'length' postcodes.json)" -gt 0 ]; then
+            mongoimport --host localhost:27017 --db world --collection postcodes --file postcodes.json --jsonArray
+          else
+            echo "Skipping postcodes import — empty or missing"
+          fi
           echo "Import completed"
 
           # Create a MongoDB dump
@@ -290,7 +301,7 @@ jobs:
           tar -czvf world-mongodb-dump.tar.gz mongodb-dump
           echo "MongoDB dump created at mongodb/world-mongodb-dump.tar.gz"
 
-          rm -rf mongodb-dump regions.json subregions.json countries.json states.json cities.json
+          rm -rf mongodb-dump regions.json subregions.json countries.json states.json cities.json postcodes.json
 
       - name: Compress All Large Files
         run: |
@@ -353,6 +364,10 @@ jobs:
           gzip -9 -k -f sql/cities.sql
           echo "  ✓ sql/world.sql.gz"
           echo "  ✓ sql/cities.sql.gz"
+          if [ -f sql/postcodes.sql ]; then
+            gzip -9 -k -f sql/postcodes.sql
+            echo "  ✓ sql/postcodes.sql.gz"
+          fi
 
           # PostgreSQL SQL Files
           echo "📄 Compressing PostgreSQL SQL files..."
@@ -360,6 +375,10 @@ jobs:
           gzip -9 -k -f psql/cities.sql
           echo "  ✓ psql/world.sql.gz"
           echo "  ✓ psql/cities.sql.gz"
+          if [ -f psql/postcodes.sql ]; then
+            gzip -9 -k -f psql/postcodes.sql
+            echo "  ✓ psql/postcodes.sql.gz"
+          fi
 
           # SQLite Files
           echo "📄 Compressing SQLite files..."
@@ -403,6 +422,7 @@ jobs:
           COUNTRY_COUNT: ${{ env.country_count }}
           STATE_COUNT: ${{ env.state_count }}
           CITY_COUNT: ${{ env.city_count }}
+          POSTCODE_COUNT: ${{ env.postcode_count }}
         with:
           script: |
             const fs = require('fs');
@@ -468,6 +488,7 @@ jobs:
                 `- **Countries**: ${process.env.COUNTRY_COUNT}`,
                 `- **States**: ${process.env.STATE_COUNT}`,
                 `- **Cities**: ${process.env.CITY_COUNT}`,
+                `- **Postcodes**: ${process.env.POSTCODE_COUNT}`,
                 '',
                 '### Formats',
                 'JSON, MySQL, PostgreSQL, SQLite, SQL Server, XML, YAML, CSV, GeoJSON, Toon, MongoDB',
@@ -526,7 +547,7 @@ jobs:
           commit-message: |
             Export database formats - ${{ env.current_date }}
 
-            Total records: ${{ env.country_count }} countries, ${{ env.state_count }} states, ${{ env.city_count }} cities
+            Total records: ${{ env.country_count }} countries, ${{ env.state_count }} states, ${{ env.city_count }} cities, ${{ env.postcode_count }} postcodes
             Large files (.gz) uploaded to GitHub Releases instead of git.
           committer: Darshan Gada <gadadarshan@gmail.com>
           signoff: true
@@ -542,6 +563,7 @@ jobs:
             - **Countries**: ${{ env.country_count }}
             - **States**: ${{ env.state_count }}
             - **Cities**: ${{ env.city_count }}
+            - **Postcodes**: ${{ env.postcode_count }}
 
             ### What's in this PR
             Small export files (individual table JSON, CSV, SQL schema, etc.) that are useful in the repo.

--- a/bin/Commands/ExportCsv.php
+++ b/bin/Commands/ExportCsv.php
@@ -19,6 +19,7 @@ class ExportCsv extends Command
         'cities' => ['from' => '/json/cities.json', 'to' => '/csv/cities.csv'],
         'regions' => ['from' => '/json/regions.json', 'to' => '/csv/regions.csv'],
         'subregions' => ['from' => '/json/subregions.json', 'to' => '/csv/subregions.csv'],
+        'postcodes' => ['from' => '/json/postcodes.json', 'to' => '/csv/postcodes.csv'],
     ];
 
     private const TRANSLATION_FILES = [
@@ -57,10 +58,19 @@ class ExportCsv extends Command
                     ? file_get_contents($rootDir . $v['from'])
                     : throw new \RuntimeException("JSON file not found: {$v['from']}");
 
-                $csc = json_decode($jsonData, true)
-                    ?: throw new \RuntimeException("Invalid JSON in {$v['from']}");
+                $csc = json_decode($jsonData, true);
+                if (!is_array($csc)) {
+                    throw new \RuntimeException("Invalid JSON in {$v['from']}");
+                }
 
                 $fp = fopen($rootDir . $v['to'], 'w');
+
+                // Skip header writing for empty datasets — write empty CSV
+                if (empty($csc)) {
+                    fclose($fp);
+                    $io->note("Skipping $root (no records)");
+                    continue;
+                }
 
                 // Set headings
                 $headings = $csc[0];

--- a/bin/Commands/ExportJson.php
+++ b/bin/Commands/ExportJson.php
@@ -281,11 +281,39 @@ class ExportJson extends Command
                 }
             }
 
+            // Fetching All Postcodes (issue #1039) — graceful skip if table missing
+            $postcodesArray = array();
+            $p = 0;
+            $hasPostcodes = $db->query("SHOW TABLES LIKE 'postcodes'");
+            if ($hasPostcodes && $hasPostcodes->num_rows > 0) {
+                $sql = "SELECT * FROM postcodes ORDER BY country_code, code";
+                $result = $db->query($sql);
+                if ($result && $result->num_rows > 0) {
+                    while ($row = $result->fetch_assoc()) {
+                        $postcodesArray[$p]['id'] = (int)$row['id'];
+                        $postcodesArray[$p]['code'] = $row['code'];
+                        $postcodesArray[$p]['country_id'] = (int)$row['country_id'];
+                        $postcodesArray[$p]['country_code'] = $row['country_code'];
+                        $postcodesArray[$p]['state_id'] = $row['state_id'] !== null ? (int)$row['state_id'] : null;
+                        $postcodesArray[$p]['state_code'] = $row['state_code'];
+                        $postcodesArray[$p]['city_id'] = $row['city_id'] !== null ? (int)$row['city_id'] : null;
+                        $postcodesArray[$p]['locality_name'] = $row['locality_name'];
+                        $postcodesArray[$p]['type'] = $row['type'];
+                        $postcodesArray[$p]['latitude'] = $row['latitude'];
+                        $postcodesArray[$p]['longitude'] = $row['longitude'];
+                        $postcodesArray[$p]['source'] = $row['source'];
+                        $postcodesArray[$p]['wikiDataId'] = $row['wikiDataId'];
+                        $p++;
+                    }
+                }
+            }
+
             $io->writeln('Total Regions Count : ' . count($regionsArray));
             $io->writeln('Total Subregions Count : ' . count($subregionsArray));
             $io->writeln('Total Countries Count : ' . count($countriesArray));
             $io->writeln('Total States Count : ' . count($statesArray));
             $io->writeln('Total Cities Count : ' . count($citiesArray));
+            $io->writeln('Total Postcodes Count : ' . count($postcodesArray));
 
             // Add a Space
             $io->newLine();
@@ -296,6 +324,7 @@ class ExportJson extends Command
                 '/json/countries.json' => $countriesArray,
                 '/json/states.json' => $statesArray,
                 '/json/cities.json' => $citiesArray,
+                '/json/postcodes.json' => $postcodesArray,
                 '/json/countries+states.json' => $countryStateArray,
                 '/json/countries+cities.json' => $countryCityArray,
                 '/json/countries+states+cities.json' => $countryStateCityArray

--- a/bin/Commands/ExportMongoDB.php
+++ b/bin/Commands/ExportMongoDB.php
@@ -15,7 +15,7 @@ class ExportMongoDB extends Command
     protected static $defaultName = 'export:mongodb';
     protected static $defaultDescription = 'Export data to MongoDB format';
 
-    private const COLLECTIONS = ['regions', 'subregions', 'countries', 'states', 'cities'];
+    private const COLLECTIONS = ['regions', 'subregions', 'countries', 'states', 'cities', 'postcodes'];
     private Filesystem $filesystem;
     private array $dataCache = [];
 
@@ -67,6 +67,7 @@ class ExportMongoDB extends Command
             $this->processCountries($io, $rootDir);
             $this->processStates($io, $rootDir);
             $this->processCities($io, $rootDir);
+            $this->processPostcodes($io, $rootDir);
 
             $io->success('MongoDB export completed successfully');
             return Command::SUCCESS;
@@ -285,6 +286,56 @@ class ExportMongoDB extends Command
 
         $this->saveCollection($rootDir, 'cities', $processedCities);
         $io->info('Cities exported to MongoDB format');
+    }
+
+    private function processPostcodes(SymfonyStyle $io, string $rootDir): void
+    {
+        $io->section('Processing postcodes');
+
+        $postcodes = $this->dataCache['postcodes'] ?? [];
+        $countries = $this->dataCache['countries'] ?? [];
+        $states = $this->dataCache['states'] ?? [];
+
+        $countryById = [];
+        foreach ($countries as $c) {
+            $countryById[(int) $c['id']] = $c;
+        }
+        $stateById = [];
+        foreach ($states as $s) {
+            $stateById[(int) $s['id']] = $s;
+        }
+
+        $processed = [];
+        foreach ($postcodes as $p) {
+            $row = $p;
+            $row['_id'] = (int) $p['id'];
+            unset($row['id']);
+
+            if (!empty($p['country_id']) && isset($countryById[(int) $p['country_id']])) {
+                $row['country'] = [
+                    '$ref' => 'countries',
+                    '$id'  => (int) $p['country_id'],
+                ];
+            }
+            if (!empty($p['state_id']) && isset($stateById[(int) $p['state_id']])) {
+                $row['state'] = [
+                    '$ref' => 'states',
+                    '$id'  => (int) $p['state_id'],
+                ];
+            }
+
+            if (isset($p['latitude'], $p['longitude']) && $p['latitude'] !== null && $p['longitude'] !== null) {
+                $row['location'] = [
+                    'type'        => 'Point',
+                    'coordinates' => [(float) $p['longitude'], (float) $p['latitude']],
+                ];
+            }
+
+            $processed[] = $row;
+        }
+
+        $this->saveCollection($rootDir, 'postcodes', $processed);
+        $io->info('Postcodes exported to MongoDB format');
     }
 
     private function saveCollection(string $rootDir, string $collection, array $data): void

--- a/bin/Commands/ExportSqlServer.php
+++ b/bin/Commands/ExportSqlServer.php
@@ -15,7 +15,7 @@ class ExportSqlServer extends Command
     protected static $defaultName = 'export:sql-server';
     protected static $defaultDescription = 'Export data to SQL Server format';
 
-    private const TABLES = ['regions', 'subregions', 'countries', 'states', 'cities'];
+    private const TABLES = ['regions', 'subregions', 'countries', 'states', 'cities', 'postcodes'];
     private Filesystem $filesystem;
 
     public function __construct()
@@ -143,6 +143,29 @@ class ExportSqlServer extends Command
                 wikiDataId NVARCHAR(255) NULL,
                 CONSTRAINT FK_cities_states FOREIGN KEY (state_id) REFERENCES world.states(id),
                 CONSTRAINT FK_cities_countries FOREIGN KEY (country_id) REFERENCES world.countries(id)
+            );",
+            'postcodes' => "
+            IF OBJECT_ID('world.postcodes', 'U') IS NOT NULL DROP TABLE world.postcodes;
+            CREATE TABLE world.postcodes (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                code NVARCHAR(20) NOT NULL,
+                country_id INT NOT NULL,
+                country_code NCHAR(2) NOT NULL,
+                state_id INT NULL,
+                state_code NVARCHAR(255) NULL,
+                city_id INT NULL,
+                locality_name NVARCHAR(255) NULL,
+                type NVARCHAR(32) NULL,
+                latitude DECIMAL(10,8) NULL,
+                longitude DECIMAL(11,8) NULL,
+                source NVARCHAR(64) NULL,
+                wikiDataId NVARCHAR(255) NULL,
+                created_at DATETIME2 NOT NULL DEFAULT '2014-01-01 12:01:01',
+                updated_at DATETIME2 NOT NULL DEFAULT GETDATE(),
+                flag BIT NOT NULL DEFAULT 1,
+                CONSTRAINT FK_postcodes_countries FOREIGN KEY (country_id) REFERENCES world.countries(id),
+                CONSTRAINT FK_postcodes_states FOREIGN KEY (state_id) REFERENCES world.states(id),
+                CONSTRAINT FK_postcodes_cities FOREIGN KEY (city_id) REFERENCES world.cities(id)
             );"
         ];
 

--- a/bin/Commands/ExportXml.php
+++ b/bin/Commands/ExportXml.php
@@ -20,6 +20,7 @@ class ExportXml extends Command
         'countries' => ['from' => '/json/countries.json', 'to' => '/xml/countries.xml', 'singular' => 'country'],
         'states' => ['from' => '/json/states.json', 'to' => '/xml/states.xml', 'singular' => 'state'],
         'cities' => ['from' => '/json/cities.json', 'to' => '/xml/cities.xml', 'singular' => 'city'],
+        'postcodes' => ['from' => '/json/postcodes.json', 'to' => '/xml/postcodes.xml', 'singular' => 'postcode'],
     ];
 
     private Filesystem $filesystem;
@@ -50,8 +51,10 @@ class ExportXml extends Command
                     ? file_get_contents($rootDir . $config['from'])
                     : throw new \RuntimeException("JSON file not found: {$config['from']}");
 
-                $data = json_decode($jsonData, true)
-                    ?: throw new \RuntimeException("Invalid JSON in {$config['from']}");
+                $data = json_decode($jsonData, true);
+                if (!is_array($data)) {
+                    throw new \RuntimeException("Invalid JSON in {$config['from']}");
+                }
 
                 $xml = ArrayToXml::convert(
                     [$config['singular'] => $data],

--- a/bin/Commands/ExportYaml.php
+++ b/bin/Commands/ExportYaml.php
@@ -20,6 +20,7 @@ class ExportYaml extends Command
         'countries' => ['from' => '/json/countries.json', 'to' => '/yml/countries.yml', 'singular' => 'country'],
         'states' => ['from' => '/json/states.json', 'to' => '/yml/states.yml', 'singular' => 'state'],
         'cities' => ['from' => '/json/cities.json', 'to' => '/yml/cities.yml', 'singular' => 'city'],
+        'postcodes' => ['from' => '/json/postcodes.json', 'to' => '/yml/postcodes.yml', 'singular' => 'postcode'],
     ];
 
     private Filesystem $filesystem;
@@ -50,8 +51,10 @@ class ExportYaml extends Command
                     ? file_get_contents($rootDir . $config['from'])
                     : throw new \RuntimeException("JSON file not found: {$config['from']}");
 
-                $data = json_decode($jsonData, true)
-                    ?: throw new \RuntimeException("Invalid JSON in {$config['from']}");
+                $data = json_decode($jsonData, true);
+                if (!is_array($data)) {
+                    throw new \RuntimeException("Invalid JSON in {$config['from']}");
+                }
 
                 $yaml = Yaml::dump(
                     [$config['singular'] => $data],

--- a/bin/scripts/export/export_plist.py
+++ b/bin/scripts/export/export_plist.py
@@ -11,9 +11,13 @@ files = [
     './csv/countries.csv',
     './csv/states.csv',
     './csv/cities.csv',
+    './csv/postcodes.csv',
 ]
 
 for csv_file in files:
+    if not os.path.exists(csv_file):
+        print('PLIST: skipping missing source {}'.format(csv_file))
+        continue
     with open(csv_file, 'r', encoding='utf-8') as f:
         result = list(csv.DictReader(f))
 

--- a/bin/scripts/sync/sync_mysql_to_json.py
+++ b/bin/scripts/sync/sync_mysql_to_json.py
@@ -232,6 +232,50 @@ class MySQLToJSONSync:
         print(f"  ✓ Synced {len(subregions)} subregions to {output_file}")
         return len(subregions)
 
+    def sync_postcodes(self):
+        """Sync postcodes table to contributions/postcodes/<COUNTRY_CODE>.json files (issue #1039)."""
+        print("\n📦 Syncing postcodes...")
+
+        # Skip gracefully if the postcodes table doesn't exist (migration not run)
+        self.cursor.execute("SHOW TABLES LIKE 'postcodes'")
+        if not self.cursor.fetchone():
+            print("  ⚠ Table 'postcodes' does not exist — skipping")
+            return 0
+
+        columns = self.get_table_columns('postcodes')
+        excluded = self.get_excluded_columns()
+
+        # One file per country (mirrors the cities/ pattern)
+        self.cursor.execute("SELECT DISTINCT country_code FROM postcodes ORDER BY country_code")
+        country_codes = [row['country_code'] for row in self.cursor.fetchall()]
+
+        if not country_codes:
+            print("  ⚠ No postcodes in database — skipping file writes")
+            return 0
+
+        postcodes_dir = os.path.join('contributions', 'postcodes')
+        os.makedirs(postcodes_dir, exist_ok=True)
+
+        total = 0
+        for country_code in country_codes:
+            self.cursor.execute(
+                "SELECT * FROM postcodes WHERE country_code = %s ORDER BY id",
+                (country_code,)
+            )
+            rows = self.cursor.fetchall()
+
+            records = [self.process_row(row, columns, excluded) for row in rows]
+
+            output_file = os.path.join(postcodes_dir, f'{country_code}.json')
+            with open(output_file, 'w', encoding='utf-8') as f:
+                json.dump(records, f, ensure_ascii=False, indent=2)
+
+            print(f"  ✓ {country_code}: {len(records):,} postcodes → {output_file}")
+            total += len(records)
+
+        print(f"\n  ✓ Total: {total:,} postcodes synced to {len(country_codes)} files")
+        return total
+
     def export_schema(self):
         """Export MySQL schema to bin/db/schema.sql using mysqldump"""
         import subprocess
@@ -247,8 +291,12 @@ class MySQLToJSONSync:
         user = self.conn.user
         database = self.conn.database
 
-        # Tables to export (in correct order respecting foreign keys)
+        # Tables to export (in correct order respecting foreign keys).
+        # postcodes is included only if it exists, since older databases may not have run the migration.
         tables = ['regions', 'subregions', 'countries', 'states', 'cities']
+        self.cursor.execute("SHOW TABLES LIKE 'postcodes'")
+        if self.cursor.fetchone():
+            tables.append('postcodes')
 
         # Build mysqldump command
         # --no-data: only schema, no data
@@ -370,6 +418,7 @@ def main():
         countries_count = syncer.sync_countries()
         states_count = syncer.sync_states()
         cities_count = syncer.sync_cities()
+        postcodes_count = syncer.sync_postcodes()
 
         print("\n" + "=" * 60)
         print("✅ Sync complete!")
@@ -379,6 +428,7 @@ def main():
         print(f"   📍 Countries: {countries_count}")
         print(f"   📍 States: {states_count}")
         print(f"   📍 Cities: {cities_count:,}")
+        print(f"   📍 Postcodes: {postcodes_count:,}")
         print("\n💡 Next steps:")
         print("   1. Review changes: git diff")
         print("   2. Commit: git add . && git commit -m 'sync: update from MySQL'")


### PR DESCRIPTION
## Summary

Completes the **deferred export-pipeline work** from #1398. With the `postcodes` table landed and #1401/#1402 starting to populate it, every export command and the export workflow itself now emit postcode data alongside the existing 5 tables.

## Files changed (9)

### PHP commands (`bin/Commands/`)

| File | Change |
|------|--------|
| `ExportJson.php` | SELECT from `postcodes` (graceful skip if table missing); emit `/json/postcodes.json` |
| `ExportCsv.php` | Add `postcodes` to `FILES`; guard empty arrays so empty source files no longer crash on `$csc[0]` access |
| `ExportXml.php` | Add `postcodes` to `FILES`; replace fragile `?: throw` on empty arrays with explicit `is_array()` check |
| `ExportYaml.php` | Same as XML |
| `ExportSqlServer.php` | Add `postcodes` to `TABLES` with full `CREATE TABLE` schema (FKs to countries/states/cities, nullable state_id/city_id) |
| `ExportMongoDB.php` | Add `postcodes` to `COLLECTIONS` plus new `processPostcodes()` method with country/state DBRef refs and GeoJSON `Point` location |

### Python helpers (`bin/scripts/`)

| File | Change |
|------|--------|
| `export/export_plist.py` | Include `postcodes.csv` with missing-file guard so the script no-ops cleanly when no postcodes have landed yet |
| `sync/sync_mysql_to_json.py` | New `sync_postcodes()` per-country file writer (mirrors `sync_cities`); `export_schema()` includes `postcodes` when present |

### Workflow (`.github/workflows/export.yml`)

- `postcode_count` env var with graceful fallback to `0` if table absent
- `mysqldump postcodes` → `sql/postcodes.sql`
- `pg_dump postcodes` → `psql/postcodes.sql`
- `mysql2sqlite postcodes` → `sqlite/postcodes.sqlite3`
- `mongoimport` gated on non-empty `postcodes.json` (uses `jq`)
- `gzip postcodes.sql` in `sql/` and `psql/` when present
- `POSTCODE_COUNT` exposed to Release body and PR body
- DROP order updated: `postcodes` drops first (FKs to countries/states/cities)

## Behaviour with empty postcodes table

This PR is designed to ship cleanly **even if `postcodes` is empty**:

- Importer/JSON/XML/YAML produce empty `postcodes.json` / `.xml` / `.yml` files without erroring
- CSV writes an empty file and emits a "no records" note
- `mongoimport` skipped via jq length check
- mysqldump still emits the (empty) DDL — so consumers can rely on the table existing in every export format
- `sync_postcodes` skips writing files when no rows exist (no spurious empty `LI.json` etc.)

## Why bundle 9 files in one PR

Each file's change is small (1–60 lines), but they're functionally interdependent: `ExportJson` produces `postcodes.json`, which `ExportCsv`/`Xml`/`Yaml` consume; the workflow expects all formats to exist. Splitting would create CI-broken intermediate states.

## Test plan

- [x] All 6 PHP files lint clean (`php -l`)
- [x] Both Python scripts compile (`python3 -m py_compile`)
- [x] Workflow YAML is valid (`yaml.safe_load`)
- [x] DROP TABLE order respects FK dependencies (postcodes → cities → states → countries → subregions → regions)
- [ ] Reviewer runs `php console export:json` against a `world` DB with postcodes table populated
- [ ] Reviewer runs `php console export:json` against a `world` DB **without** postcodes table — should not crash
- [ ] Reviewer triggers the workflow once #1401 / #1402 country data has merged

## Out of scope / follow-ups

- **GeoJSON / Toon converters** (`bin/scripts/export/json_to_geojson.py`, `json_to_toon.py`) — these have hardcoded `["cities", "states", "countries"]` lists. Postcode geo-coordinates are sparse (most rows null) and Toon serialisation of postcode arrays would benefit from a separate review. Tracked for a follow-up PR.
- **PostgreSQL schema dump** (`psql/schema.sql`) — auto-generated by `pg_dump --schema-only` in the workflow, so picks up postcodes automatically once the table exists in PostgreSQL via NMIG.

Refs: #1039
Builds on: #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)