### PR TITLE
feat(postcodes/SM): add San Marino postcodes (#1039)

### DIFF
--- a/contributions/postcodes/SM.json
+++ b/contributions/postcodes/SM.json
@@ -1,0 +1,92 @@
+[
+  {
+    "code": "47890",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 58,
+    "state_code": "07",
+    "locality_name": "San Marino",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47891",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 65,
+    "state_code": "09",
+    "locality_name": "Serravalle",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47892",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 59,
+    "state_code": "01",
+    "locality_name": "Acquaviva",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47893",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 61,
+    "state_code": "06",
+    "locality_name": "Borgo Maggiore",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47894",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 60,
+    "state_code": "02",
+    "locality_name": "Chiesanuova",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47895",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 64,
+    "state_code": "03",
+    "locality_name": "Domagnano",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47896",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 62,
+    "state_code": "04",
+    "locality_name": "Faetano",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47897",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 66,
+    "state_code": "05",
+    "locality_name": "Fiorentino",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "47898",
+    "country_id": 192,
+    "country_code": "SM",
+    "state_id": 63,
+    "state_code": "08",
+    "locality_name": "Montegiardino",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds the 9 San Marino postal codes (47890–47898) covering all 9 castelli (municipalities). San Marino uses the Italian CAP system; the country code range `4789x` is reserved for it and each castello has a unique code (a clean 1:1 mapping, unlike Italy proper where one code spans many cities).

## Mapping

| state_code | Castello | Postcode |
|------------|----------|----------|
| 01 | Acquaviva | 47892 |
| 02 | Chiesanuova | 47894 |
| 03 | Domagnano | 47895 |
| 04 | Faetano | 47896 |
| 05 | Fiorentino | 47897 |
| 06 | Borgo Maggiore | 47893 |
| 07 | San Marino (capital) | **47890** |
| 08 | Montegiardino | 47898 |
| 09 | Serravalle | 47891 |

## Source

`source: "manual"` — composed from common knowledge. SM postal codes are stable and universally documented; the country's `postal_code_format` (`4789#`) and regex (`^(4789\d)$`) already exist in `countries.json` and were used to validate every code.

## Validation

- ✅ 9 records pass schema rules in `.github/scripts/utils.js`
- ✅ All `country_id: 192` / `country_code: "SM"` agree
- ✅ All `state_id` values resolve to SM castelli, and `state_code` matches the corresponding `state.iso2`
- ✅ All codes match `countries.postal_code_regex` for SM (`^(4789\d)$`)
- ✅ No auto-managed fields present

Refs: #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)