### PR TITLE
feat(postcodes/VA): add Vatican City postcode (#1039)

### DIFF
--- a/contributions/postcodes/VA.json
+++ b/contributions/postcodes/VA.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "00120",
+    "country_id": 238,
+    "country_code": "VA",
+    "locality_name": "Citta del Vaticano",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds Vatican City's single postcode **00120**. Country-only (Vatican has no states in this dataset).

## Source

`source: "manual"` — Vatican uses the Italian postal system; 00120 is reserved for Città del Vaticano.

## Validation

- ✅ 1 record passes schema rules
- ✅ `country_id: 238` / `country_code: "VA"` agree
- ✅ Code `00120` matches `countries.postal_code_regex` (`^(\d{5})$`)
- ✅ `state_id` correctly null (VA has no state-level subdivisions)

Refs: #1039