### PR TITLE
feat(postcodes/AD): add Andorra postcodes (#1039)

### DIFF
--- a/contributions/postcodes/AD.json
+++ b/contributions/postcodes/AD.json
@@ -1,0 +1,72 @@
+[
+  {
+    "code": "AD100",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 489,
+    "state_code": "02",
+    "locality_name": "Canillo",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD200",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 487,
+    "state_code": "03",
+    "locality_name": "Encamp",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD300",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 491,
+    "state_code": "05",
+    "locality_name": "Ordino",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD400",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 493,
+    "state_code": "04",
+    "locality_name": "La Massana",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD500",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 488,
+    "state_code": "07",
+    "locality_name": "Andorra la Vella",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD600",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 490,
+    "state_code": "06",
+    "locality_name": "Sant Julia de Loria",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "AD700",
+    "country_id": 6,
+    "country_code": "AD",
+    "state_id": 492,
+    "state_code": "08",
+    "locality_name": "Escaldes-Engordany",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds the 7 Andorran postcodes (AD100–AD700), one per parish.

| state_code | Parish | Postcode |
|---|---|---|
| 02 | Canillo | AD100 |
| 03 | Encamp | AD200 |
| 05 | Ordino | AD300 |
| 04 | La Massana | AD400 |
| 07 | Andorra la Vella (capital) | **AD500** |
| 06 | Sant Julià de Lòria | AD600 |
| 08 | Escaldes-Engordany | AD700 |

`source: "manual"` — universally documented and stable. All 7 codes match `countries.postal_code_regex` (`^(?:AD)*(\d{3})$`).

Refs: #1039