### PR TITLE
feat(postcodes/GI): add Gibraltar postcode (#1039)

### DIFF
--- a/contributions/postcodes/GI.json
+++ b/contributions/postcodes/GI.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "GX11 1AA",
+    "country_id": 84,
+    "country_code": "GI",
+    "locality_name": "Gibraltar",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds Gibraltar's single national postcode **GX11 1AA**. Country-only (Gibraltar has no state-level subdivisions in this dataset; same shape as Monaco #1402 / Vatican #1406).

Gibraltar uses one fixed postcode assigned in 2008 when it joined the UK postcode address file.

## Validation
- ✅ 1 record passes schema
- ✅ `country_id: 84` / `country_code: "GI"` agree
- ✅ Code matches `countries.postal_code_regex` (`GX11 1AA`)
- ✅ `state_id` correctly null

Refs: #1039