### PR TITLE
feat(postcodes/PW): add Palau postcode (#1039)

### DIFF
--- a/contributions/postcodes/PW.json
+++ b/contributions/postcodes/PW.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "96940",
+    "country_id": 168,
+    "country_code": "PW",
+    "locality_name": "Palau",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds Palau's single national postcode **96940**. Country-only — Palau has 16 administrative states but they share the one ZIP. Uses US ZIP system (Compact of Free Association).

Refs: #1039