### PR TITLE
feat(postcodes/AS): add American Samoa postcode (#1039)

### DIFF
--- a/contributions/postcodes/AS.json
+++ b/contributions/postcodes/AS.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "96799",
+    "country_id": 5,
+    "country_code": "AS",
+    "locality_name": "American Samoa",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds American Samoa's single ZIP **96799** (US ZIP system, sole code for the territory).

Refs: #1039