### PR TITLE
feat(postcodes/MP): add Northern Mariana Islands postcodes (#1039)

### DIFF
--- a/contributions/postcodes/MP.json
+++ b/contributions/postcodes/MP.json
@@ -1,0 +1,26 @@
+[
+  {
+    "code": "96950",
+    "country_id": 164,
+    "country_code": "MP",
+    "locality_name": "Saipan",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96951",
+    "country_id": 164,
+    "country_code": "MP",
+    "locality_name": "Rota",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96952",
+    "country_id": 164,
+    "country_code": "MP",
+    "locality_name": "Tinian",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds 3 ZIP codes for the Northern Mariana Islands' main islands:

| Code | Locality |
|------|----------|
| 96950 | Saipan (capital) |
| 96951 | Rota |
| 96952 | Tinian |

US ZIP system. All match `countries.postal_code_regex` (`^9695\d{1}$`).

Refs: #1039