### PR TITLE
feat(postcodes/FM): add Micronesia postcodes (#1039)

### DIFF
--- a/contributions/postcodes/FM.json
+++ b/contributions/postcodes/FM.json
@@ -1,0 +1,42 @@
+[
+  {
+    "code": "96941",
+    "country_id": 143,
+    "country_code": "FM",
+    "state_id": 2581,
+    "state_code": "PNI",
+    "locality_name": "Pohnpei",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96942",
+    "country_id": 143,
+    "country_code": "FM",
+    "state_id": 2580,
+    "state_code": "TRK",
+    "locality_name": "Chuuk",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96943",
+    "country_id": 143,
+    "country_code": "FM",
+    "state_id": 2582,
+    "state_code": "YAP",
+    "locality_name": "Yap",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96944",
+    "country_id": 143,
+    "country_code": "FM",
+    "state_id": 2583,
+    "state_code": "KSA",
+    "locality_name": "Kosrae",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds 4 ZIP codes for the Federated States of Micronesia, one per state:

| state_code | State | ZIP |
|---|---|---|
| PNI | Pohnpei (capital) | **96941** |
| TRK | Chuuk | 96942 |
| YAP | Yap | 96943 |
| KSA | Kosrae | 96944 |

US ZIP system (Compact of Free Association). Clean 1:1 state-to-ZIP mapping. All codes match `countries.postal_code_regex` (`^(\d{5})$`).

Refs: #1039