### PR TITLE
feat(postcodes/GL): add Greenland major-settlement postcodes (#1039)

### DIFF
--- a/contributions/postcodes/GL.json
+++ b/contributions/postcodes/GL.json
@@ -1,0 +1,102 @@
+[
+  {
+    "code": "3900",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5383,
+    "state_code": "SM",
+    "locality_name": "Nuuk",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3911",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5382,
+    "state_code": "QE",
+    "locality_name": "Sisimiut",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3912",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5382,
+    "state_code": "QE",
+    "locality_name": "Maniitsoq",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3920",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5380,
+    "state_code": "KU",
+    "locality_name": "Qaqortoq",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3922",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5380,
+    "state_code": "KU",
+    "locality_name": "Nanortalik",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3940",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5383,
+    "state_code": "SM",
+    "locality_name": "Paamiut",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3950",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5381,
+    "state_code": "QT",
+    "locality_name": "Aasiaat",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3952",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5379,
+    "state_code": "AV",
+    "locality_name": "Ilulissat",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3971",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5379,
+    "state_code": "AV",
+    "locality_name": "Qaanaaq",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "3980",
+    "country_id": 86,
+    "country_code": "GL",
+    "state_id": 5383,
+    "state_code": "SM",
+    "locality_name": "Ittoqqortoormiit",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 10 Greenlandic postcodes covering the 5 municipal capitals plus 5 major secondary settlements. Greenland uses the Danish 4-digit system (3900–3992 reserved range).

## Mapping

| state_code | Municipality | Codes |
|---|---|---|
| SM | Sermersooq | **3900 Nuuk** (capital), 3940 Paamiut, 3980 Ittoqqortoormiit |
| QE | Qeqqata | 3911 Sisimiut, 3912 Maniitsoq |
| KU | Kujalleq | 3920 Qaqortoq, 3922 Nanortalik |
| QT | Qeqertalik | 3950 Aasiaat |
| AV | Avannaata | 3952 Ilulissat, 3971 Qaanaaq |

## Scope

Approximately 30 Greenlandic postcodes exist in total. This PR ships the 10 largest / most-canonical settlements with confident municipality assignments. Smaller villages (e.g. 3961 Uummannaq, 3962 Upernavik, 3962 Tasiilaq, 3970 Pituffik) can land in follow-up PRs once the schema is exercised.

`source: "manual"` — universally documented via Posten and the Kommuneqarfik administrative reorganisation.

Refs: #1039