### PR TITLE
fix(countries/MH): make postal_code_regex +4 extension optional (#1039)

### DIFF
--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -9145,7 +9145,7 @@
     "nationality": "Marshallese",
     "area_sq_km": 181.3,
     "postal_code_format": "#####-####",
-    "postal_code_regex": "^969\\d{2}(-\\d{4})$",
+    "postal_code_regex": "^969\\d{2}(?:-\\d{4})?$",
     "timezones": [
       {
         "zoneName": "Pacific/Kwajalein",


### PR DESCRIPTION
## Summary

Fixes a latent bug in Marshall Islands' `postal_code_regex` that was discovered while preparing postcode-data PRs for #1039.

```diff
- "postal_code_regex": "^969\\d{2}(-\\d{4})$"
+ "postal_code_regex": "^969\\d{2}(?:-\\d{4})?$"
```

## Why

The MH regex required the `-####` extension to be present. That blocked legitimate 5-digit ZIPs `96960` (Majuro) and `96970` (Ebeye) from passing the cross-reference validator's `code` ↔ `postal_code_regex` check introduced in #1398. Two issues in one regex:

1. Missing `?` after the extension group → made the +4 mandatory
2. Capturing group `(...)` instead of non-capturing `(?:...)` → inconsistent with how VI and PR encode the same `#####-####` shape

## Comparison with similar countries

| Country | Format | Regex (before / after) |
|---|---|---|
| US Virgin Islands (VI) | `#####-####` | `^008\d{2}(?:-\d{4})?$` ← already correct |
| Puerto Rico (PR) | `#####-####` | `^00[679]\d{2}(?:-\d{4})?$` ← already correct |
| Marshall Islands (MH) | `#####-####` | **was:** `^969\d{2}(-\d{4})$` → **now:** `^969\d{2}(?:-\d{4})?$` |

## Validation

| Code | Before | After | Expected |
|---|---|---|---|
| `96960` (Majuro) | ❌ | ✅ | ✅ |
| `96970` (Ebeye) | ❌ | ✅ | ✅ |
| `96960-1234` | ✅ | ✅ | ✅ |
| `96960-12` | ❌ | ❌ | ❌ |
| `123456` | ❌ | ❌ | ❌ |
| `969XX` | ❌ | ❌ | ❌ |

## Impact

- Unblocks a future MH postcode-data PR (would have hit `code does not match postal_code_regex` errors)
- No effect on existing data — `countries.json` MH record has `postal_code_format: "#####-####"`, no actual postcodes use this regex yet
- Diff is exactly 1 line

Refs: #1039