### PR TITLE
feat(postcodes/WF): add Wallis and Futuna postcode for Uvea (#1039)

### DIFF
--- a/contributions/postcodes/WF.json
+++ b/contributions/postcodes/WF.json
@@ -1,0 +1,12 @@
+[
+  {
+    "code": "98600",
+    "country_id": 243,
+    "country_code": "WF",
+    "state_id": 5707,
+    "state_code": "UV",
+    "locality_name": "Mata-Utu",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds **98600 → Uvea** (Wallis island, capital Mata-Utu).

Wallis and Futuna uses the French postal system with 986## codes. The exact district mapping for Sigave/Alo on Futuna island isn't unambiguously documented in common sources, so shipping just the confident Uvea code now; Futuna codes can land in a follow-up PR.

Refs: #1039