### PR TITLE
feat(postcodes/MH): add Marshall Islands postcodes (#1039)

### DIFF
--- a/contributions/postcodes/MH.json
+++ b/contributions/postcodes/MH.json
@@ -1,0 +1,22 @@
+[
+  {
+    "code": "96960",
+    "country_id": 137,
+    "country_code": "MH",
+    "state_id": 5656,
+    "state_code": "MAJ",
+    "locality_name": "Majuro",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "96970",
+    "country_id": 137,
+    "country_code": "MH",
+    "state_id": 5652,
+    "state_code": "KWA",
+    "locality_name": "Ebeye",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds the 2 main Marshall Islands ZIPs:

| state_code | Atoll | ZIP | Locality |
|---|---|---|---|
| MAJ | Majuro | **96960** | Majuro (capital) |
| KWA | Kwajalein | 96970 | Ebeye |

Uses US ZIP system (Compact of Free Association). Now passes the cross-reference validator after the MH regex fix in #1414 made the +4 extension optional.

Builds on: #1414
Refs: #1039