### PR TITLE
feat(postcodes/NC): add New Caledonia provincial-capital postcodes (#1039)

### DIFF
--- a/contributions/postcodes/NC.json
+++ b/contributions/postcodes/NC.json
@@ -1,0 +1,32 @@
+[
+  {
+    "code": "98800",
+    "country_id": 157,
+    "country_code": "NC",
+    "state_id": 5225,
+    "state_code": "01",
+    "locality_name": "Noumea",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "98860",
+    "country_id": 157,
+    "country_code": "NC",
+    "state_id": 5226,
+    "state_code": "02",
+    "locality_name": "Kone",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "98820",
+    "country_id": 157,
+    "country_code": "NC",
+    "state_id": 5227,
+    "state_code": "03",
+    "locality_name": "We",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 3 New Caledonia postcodes — one per province, each the provincial capital.

| state_code | Province | Postcode | Capital |
|---|---|---|---|
| 01 | South Province | **98800** | Nouméa (territorial capital) |
| 02 | North Province | 98860 | Koné |
| 03 | Loyalty Islands | 98820 | Wé (on Lifou) |

NC uses the French postal system with 988## codes (~40 communes total). Shipping just the provincial capitals for high-confidence coverage; commune-level codes can land in follow-up PRs once an automated La Poste pipeline is wired up.

`source: "manual"` — universally documented.

Refs: #1039