### PR TITLE
feat(postcodes/YT): add Mayotte capital postcode (#1039)

### DIFF
--- a/contributions/postcodes/YT.json
+++ b/contributions/postcodes/YT.json
@@ -1,0 +1,12 @@
+[
+  {
+    "code": "97600",
+    "country_id": 141,
+    "country_code": "YT",
+    "state_id": 5404,
+    "state_code": "03",
+    "locality_name": "Mamoudzou",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds **97600 → Mamoudzou** (capital of Mayotte).

Mayotte has 17 communes with codes in the 976## range, but exact code-to-commune mapping varies across sources. Shipping just the confidently-documented capital; remaining communes can land in follow-ups once a clean La Poste source is wired up.

Refs: #1039