### PR TITLE
feat(postcodes/GF): add French Guiana major-commune postcodes (#1039)

### DIFF
--- a/contributions/postcodes/GF.json
+++ b/contributions/postcodes/GF.json
@@ -1,0 +1,26 @@
+[
+  {
+    "code": "97300",
+    "country_id": 76,
+    "country_code": "GF",
+    "locality_name": "Cayenne",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97310",
+    "country_id": 76,
+    "country_code": "GF",
+    "locality_name": "Kourou",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97320",
+    "country_id": 76,
+    "country_code": "GF",
+    "locality_name": "Saint-Laurent-du-Maroni",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds 3 well-known French Guiana communes:

| Code | Locality | Note |
|---|---|---|
| **97300** | Cayenne | Capital |
| 97310 | Kourou | Centre Spatial Guyanais (rocket launches) |
| 97320 | Saint-Laurent-du-Maroni | Major western commune |

GF has no state-level subdivisions in this dataset, so postcodes are country-only. ~22 communes total in the 973## range; shipping the 3 largest as a high-confidence starter set.

Refs: #1039