### PR TITLE
feat(postcodes/RE): add Reunion arrondissement-capital postcodes (#1039)

### DIFF
--- a/contributions/postcodes/RE.json
+++ b/contributions/postcodes/RE.json
@@ -10,12 +10,12 @@
     "source": "manual"
   },
   {
-    "code": "97470",
+    "code": "97410",
     "country_id": 180,
     "country_code": "RE",
-    "state_id": 5436,
-    "state_code": "01",
-    "locality_name": "Saint-Benoit",
+    "state_id": 5439,
+    "state_code": "04",
+    "locality_name": "Saint-Pierre",
     "type": "full",
     "source": "manual"
   },
@@ -30,12 +30,12 @@
     "source": "manual"
   },
   {
-    "code": "97410",
+    "code": "97470",
     "country_id": 180,
     "country_code": "RE",
-    "state_id": 5439,
-    "state_code": "04",
-    "locality_name": "Saint-Pierre",
+    "state_id": 5436,
+    "state_code": "01",
+    "locality_name": "Saint-Benoit",
     "type": "full",
     "source": "manual"
   }

--- a/contributions/postcodes/RE.json
+++ b/contributions/postcodes/RE.json
@@ -1,0 +1,42 @@
+[
+  {
+    "code": "97400",
+    "country_id": 180,
+    "country_code": "RE",
+    "state_id": 5437,
+    "state_code": "02",
+    "locality_name": "Saint-Denis",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97470",
+    "country_id": 180,
+    "country_code": "RE",
+    "state_id": 5436,
+    "state_code": "01",
+    "locality_name": "Saint-Benoit",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97460",
+    "country_id": 180,
+    "country_code": "RE",
+    "state_id": 5438,
+    "state_code": "03",
+    "locality_name": "Saint-Paul",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97410",
+    "country_id": 180,
+    "country_code": "RE",
+    "state_id": 5439,
+    "state_code": "04",
+    "locality_name": "Saint-Pierre",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 4 Réunion postcodes — one per arrondissement, each the sub-prefecture capital.

| state_code | Arrondissement | Postcode | Capital |
|---|---|---|---|
| 02 | Saint-Denis (north) | **97400** | Saint-Denis (territorial capital) |
| 01 | Saint-Benoît (east) | 97470 | Saint-Benoît |
| 03 | Saint-Paul (west) | 97460 | Saint-Paul |
| 04 | Saint-Pierre (south) | 97410 | Saint-Pierre |

RE uses the French postal system with 974## codes (~24 communes total). Shipping the 4 arrondissement capitals for high-confidence coverage; remaining communes can land in follow-up PRs once an automated La Poste pipeline is wired up.

`source: "manual"` — universally documented.

Refs: #1039