### PR TITLE
feat(postcodes/GP): add Guadeloupe major-commune postcodes (#1039)

### DIFF
--- a/contributions/postcodes/GP.json
+++ b/contributions/postcodes/GP.json
@@ -1,0 +1,42 @@
+[
+  {
+    "code": "97100",
+    "country_id": 88,
+    "country_code": "GP",
+    "state_id": 5384,
+    "state_code": "01",
+    "locality_name": "Basse-Terre",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97120",
+    "country_id": 88,
+    "country_code": "GP",
+    "state_id": 5384,
+    "state_code": "01",
+    "locality_name": "Saint-Claude",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97110",
+    "country_id": 88,
+    "country_code": "GP",
+    "state_id": 5385,
+    "state_code": "02",
+    "locality_name": "Pointe-a-Pitre",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97122",
+    "country_id": 88,
+    "country_code": "GP",
+    "state_id": 5385,
+    "state_code": "02",
+    "locality_name": "Baie-Mahault",
+    "type": "full",
+    "source": "manual"
+  }
+]

--- a/contributions/postcodes/GP.json
+++ b/contributions/postcodes/GP.json
@@ -10,16 +10,6 @@
     "source": "manual"
   },
   {
-    "code": "97120",
-    "country_id": 88,
-    "country_code": "GP",
-    "state_id": 5384,
-    "state_code": "01",
-    "locality_name": "Saint-Claude",
-    "type": "full",
-    "source": "manual"
-  },
-  {
     "code": "97110",
     "country_id": 88,
     "country_code": "GP",
@@ -30,11 +20,21 @@
     "source": "manual"
   },
   {
+    "code": "97120",
+    "country_id": 88,
+    "country_code": "GP",
+    "state_id": 5384,
+    "state_code": "01",
+    "locality_name": "Saint-Claude",
+    "type": "full",
+    "source": "manual"
+  },
+  {
     "code": "97122",
     "country_id": 88,
     "country_code": "GP",
-    "state_id": 5385,
-    "state_code": "02",
+    "state_id": 5384,
+    "state_code": "01",
     "locality_name": "Baie-Mahault",
     "type": "full",
     "source": "manual"


### PR DESCRIPTION
Adds 4 well-known Guadeloupe communes covering both arrondissements:

| state_code | Arrondissement | Code | Commune |
|---|---|---|---|
| 01 | Basse-Terre | **97100** | Basse-Terre (capital) |
| 01 | Basse-Terre | 97120 | Saint-Claude |
| 02 | Pointe-à-Pitre | 97110 | Pointe-à-Pitre |
| 02 | Pointe-à-Pitre | 97122 | Baie-Mahault |

GP uses the French postal system with 971## codes (~32 communes total). Shipping 4 high-confidence well-known communes; remaining can land in follow-up PRs.

Refs: #1039