### PR TITLE
feat(postcodes/MQ): add Martinique arrondissement-capital postcodes (#1039)

### DIFF
--- a/contributions/postcodes/MQ.json
+++ b/contributions/postcodes/MQ.json
@@ -1,0 +1,42 @@
+[
+  {
+    "code": "97200",
+    "country_id": 138,
+    "country_code": "MQ",
+    "state_id": 5398,
+    "state_code": "01",
+    "locality_name": "Fort-de-France",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97220",
+    "country_id": 138,
+    "country_code": "MQ",
+    "state_id": 5399,
+    "state_code": "02",
+    "locality_name": "La Trinite",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97290",
+    "country_id": 138,
+    "country_code": "MQ",
+    "state_id": 5400,
+    "state_code": "03",
+    "locality_name": "Le Marin",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97250",
+    "country_id": 138,
+    "country_code": "MQ",
+    "state_id": 5401,
+    "state_code": "04",
+    "locality_name": "Saint-Pierre",
+    "type": "full",
+    "source": "manual"
+  }
+]

--- a/contributions/postcodes/MQ.json
+++ b/contributions/postcodes/MQ.json
@@ -20,22 +20,22 @@
     "source": "manual"
   },
   {
-    "code": "97290",
-    "country_id": 138,
-    "country_code": "MQ",
-    "state_id": 5400,
-    "state_code": "03",
-    "locality_name": "Le Marin",
-    "type": "full",
-    "source": "manual"
-  },
-  {
     "code": "97250",
     "country_id": 138,
     "country_code": "MQ",
     "state_id": 5401,
     "state_code": "04",
     "locality_name": "Saint-Pierre",
+    "type": "full",
+    "source": "manual"
+  },
+  {
+    "code": "97290",
+    "country_id": 138,
+    "country_code": "MQ",
+    "state_id": 5400,
+    "state_code": "03",
+    "locality_name": "Le Marin",
     "type": "full",
     "source": "manual"
   }


### PR DESCRIPTION
Adds 4 Martinique postcodes — one per arrondissement, each the sub-prefecture capital:

| state_code | Arrondissement | Postcode | Capital |
|---|---|---|---|
| 01 | Fort-de-France | **97200** | Fort-de-France (territorial capital) |
| 02 | La Trinité | 97220 | La Trinité |
| 03 | Le Marin | 97290 | Le Marin |
| 04 | Saint-Pierre | 97250 | Saint-Pierre |

MQ uses the French postal system with 972## codes (~34 communes total). Shipping the 4 arrondissement capitals for high-confidence coverage.

Refs: #1039