### PR TITLE
feat(postcodes/PM): add Saint Pierre and Miquelon postcode (#1039)

### DIFF
--- a/contributions/postcodes/PM.json
+++ b/contributions/postcodes/PM.json
@@ -3,7 +3,7 @@
     "code": "97500",
     "country_id": 187,
     "country_code": "PM",
-    "locality_name": "Saint-Pierre and Miquelon",
+    "locality_name": "Saint Pierre and Miquelon",
     "type": "full",
     "source": "manual"
   }

--- a/contributions/postcodes/PM.json
+++ b/contributions/postcodes/PM.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "97500",
+    "country_id": 187,
+    "country_code": "PM",
+    "locality_name": "Saint-Pierre and Miquelon",
+    "type": "full",
+    "source": "manual"
+  }
+]


### PR DESCRIPTION
Adds Saint Pierre and Miquelon's single postcode **97500**.

The country's `postal_code_regex` is `^(97500)$` — only one valid code, shared between the two communes (Saint-Pierre and Miquelon-Langlade). Country-only (no state subdivisions in this dataset).

Refs: #1039