### PR TITLE
feat(postcodes/IT): bulk-import 4,678 CAP codes via Istat (#1039)

### DIFF
--- a/bin/scripts/sync/import_italy_postcodes.py
+++ b/bin/scripts/sync/import_italy_postcodes.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Italy CAP -> contributions/postcodes/IT.json importer for issue #1039.
+
+Source data
+-----------
+The community-maintained ``matteocontrini/comuni-json`` archive is the
+canonical redistribution of Istat's official Italian commune list with
+postal codes (CAP). It carries Istat data under the original CC-BY 3.0
+attribution (Istat licensing).
+
+  https://github.com/matteocontrini/comuni-json
+
+The JSON has 7,904 commune records, each with:
+- nome (commune name, mixed-case)
+- sigla (2-letter province ISO 3166-2:IT code, e.g. RM, MI, NA)
+- cap (array of postal codes — large cities have many)
+- regione, provincia, codiceCatastale, popolazione
+
+About 4,678 unique CAPs across all comuni.
+
+What this script does
+---------------------
+1. Reads comuni.json (UTF-8)
+2. Expands each commune's cap[] array, one record per (cap, commune)
+3. Picks ONE canonical commune per unique CAP (first alphabetical)
+   — large cities like Rome/Milan have ~50-80 CAPs each, but each CAP
+   points to one neighbourhood/zone within a single commune
+4. Resolves state_id by mapping commune.sigla to state.iso2 directly
+   (Italy's 2-letter province codes match exactly: RM = Rome, MI = Milan)
+5. Writes contributions/postcodes/IT.json
+
+License & attribution
+---------------------
+- Upstream source: Istat (CC-BY 3.0)
+- Mirror: github.com/matteocontrini/comuni-json
+- Each row: source: "istat"
+
+Usage
+-----
+    python3 -c "import urllib.request; urllib.request.urlretrieve(
+      'https://raw.githubusercontent.com/matteocontrini/comuni-json/master/comuni.json',
+      '/tmp/it_comuni.json')"
+
+    python3 bin/scripts/sync/import_italy_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="/tmp/it_comuni.json")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    src = Path(args.input)
+    if not src.exists():
+        print(f"ERROR: input not found: {src}", file=sys.stderr)
+        return 2
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load((project_root / "contributions/countries/countries.json").open(encoding="utf-8"))
+    it = next((c for c in countries if c.get("iso2") == "IT"), None)
+    if it is None:
+        print("ERROR: IT not in countries.json", file=sys.stderr)
+        return 2
+    states = json.load((project_root / "contributions/states/states.json").open(encoding="utf-8"))
+    it_states = [s for s in states if s.get("country_id") == it["id"]]
+    state_by_iso2: Dict[str, dict] = {(s.get("iso2") or "").upper(): s for s in it_states if s.get("iso2")}
+
+    # Aosta is sigla "AO" in the source, but states.json treats it as the
+    # "Aosta Valley" autonomous region with iso2 "23" instead of a standard
+    # province. Bridge it explicitly.
+    if "23" in state_by_iso2 and "AO" not in state_by_iso2:
+        state_by_iso2["AO"] = state_by_iso2["23"]
+
+    print(f"Country: Italy (id={it['id']}); states indexed by iso2: {len(state_by_iso2)}")
+
+    comuni = json.load(src.open(encoding="utf-8"))
+
+    # Expand to one row per (cap, commune); group by cap; pick first commune alphabetically.
+    by_cap: Dict[str, List[dict]] = {}
+    for c in comuni:
+        nome = (c.get("nome") or "").strip()
+        sigla = (c.get("sigla") or "").strip().upper()
+        for cap in c.get("cap", []):
+            cap = (cap or "").strip()
+            if not cap or not cap.isdigit() or len(cap) != 5:
+                continue
+            by_cap.setdefault(cap, []).append({"nome": nome, "sigla": sigla})
+
+    print(f"Comuni:            {len(comuni):,}")
+    print(f"Unique CAPs:       {len(by_cap):,}")
+
+    records: List[dict] = []
+    matched_state = 0
+    for cap in sorted(by_cap):
+        rows = sorted(by_cap[cap], key=lambda r: r["nome"].upper())
+        chosen = rows[0]
+        record = {
+            "code": cap,
+            "country_id": int(it["id"]),
+            "country_code": "IT",
+        }
+        state = state_by_iso2.get(chosen["sigla"])
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            # Use the state's canonical iso2 from states.json, not the raw
+            # source sigla — they differ for Aosta (AO -> 23) and any future
+            # alias bridges.
+            record["state_code"] = state.get("iso2") or chosen["sigla"]
+            matched_state += 1
+        if chosen["nome"]:
+            record["locality_name"] = chosen["nome"]
+        record["type"] = "full"
+        record["source"] = "istat"
+        records.append(record)
+
+    print(f"Records:           {len(records):,}")
+    print(f"  with state_id:   {matched_state:,} ({matched_state*100//max(1,len(records))}%)")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/IT.json"
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        seen = {(r["code"], (r.get("locality_name") or "").lower()) for r in existing}
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in seen:
+                merged.append(r)
+                seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(f"\n[OK] Wrote {target.relative_to(project_root)} ({len(merged):,} rows, {size_kb:.0f} KB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/IT.json
+++ b/contributions/postcodes/IT.json
@@ -1,0 +1,46782 @@
+[
+  {
+    "code": "00010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Casape",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Guidonia Montecelio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Fonte Nuova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Monterotondo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Nerola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Palombara Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Tivoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Agosta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Affile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Anticoli Corrado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Arsoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Castel Madama",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Gerano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Licenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Subiaco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Vicovaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Bellegra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Artena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Carpineto Romano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Cave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Colleferro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Olevano Romano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Palestrina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Segni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Valmontone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Zagarolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Ardea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Albano Laziale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Anzio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Ciampino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Frascati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Genzano di Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Grottaferrata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Marino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Nettuno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Velletri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Allumiere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Cerveteri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Civitavecchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Fiumicino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Ladispoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Santa Marinella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Tolfa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Canale Monterano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Anguillara Sabazia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Bracciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Campagnano di Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Fiano Romano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Manziana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Morlupo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Rignano Flaminio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Trevignano Romano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Pomezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Ariccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Castel Gandolfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Nemi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Lanuvio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Lariano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Monte Compatri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Monte Porzio Catone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Rocca Priora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00118",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00119",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00120",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00157",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00158",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00159",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00160",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00161",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00162",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00163",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00164",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00165",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00166",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00167",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00168",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00169",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00171",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00172",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00173",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00174",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00175",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00176",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00177",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00178",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00179",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00180",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00181",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00182",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00183",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00184",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00185",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00186",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00187",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00188",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00189",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00190",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00191",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00192",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00193",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00194",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00195",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00196",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00197",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00198",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "00199",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5636,
+    "state_code": "RM",
+    "locality_name": "Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Arlena di Castro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Canino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Capranica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Montalto di Castro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Sutri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Tarquinia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Tuscania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Valentano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Vetralla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Bomarzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Acquapendente",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Bagnoregio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Bolsena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Castiglione in Teverina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Grotte di Castro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Montefiascone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Orte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Bassano in Teverina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Caprarola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Civita Castellana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Fabrica di Roma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Gallese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Nepi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Ronciglione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Soriano nel Cimino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Vignanello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "01100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1735,
+    "state_code": "VT",
+    "locality_name": "Viterbo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Borbona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Accumoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Amatrice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Antrodoco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Cantalice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Cittaducale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Leonessa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Poggio Bustone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Posta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Ascrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Borgorose",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Collalto Sabino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Fiamignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Pescorocchiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Petrella Salto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Rocca Sinibalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Casaprota",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Castelnuovo di Farfa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Fara in Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Monteleone Sabino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Montopoli di Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Orvinio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Poggio Moiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Scandriglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Toffia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Cantalupo in Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Casperia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Collevecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Contigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Forano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Greccio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Magliano Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Poggio Mirteto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Stimigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Torri in Sabina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "02100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1712,
+    "state_code": "RI",
+    "locality_name": "Rieti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Acuto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Alatri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Anagni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Ferentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Fiuggi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Guarcino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Morolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Paliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Supino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Arnara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Amaseno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Boville Ernica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Ceccano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Ceprano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Monte San Giovanni Campano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Pofi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Ripi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "San Giovanni Incarico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Veroli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Broccostella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Aquino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Arce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Arpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Casalvieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Fontana Liri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Isola del Liri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Pontecorvo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Roccasecca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Sora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Acquafondata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Alvito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Atina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Cassino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Cervaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Esperia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "San Donato Val di Comino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "San Giorgio a Liri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Sant'Apollinare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Sant'Elia Fiumerapido",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "03100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1776,
+    "state_code": "FR",
+    "locality_name": "Frosinone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Bassiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Aprilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Cisterna di Latina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Sermoneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Pontinia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Priverno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Sabaudia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "San Felice Circeo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Sezze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Terracina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Campodimele",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Castelforte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Fondi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Formia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Gaeta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Lenola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Minturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Ponza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Sperlonga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Ventotene",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "04100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1674,
+    "state_code": "LT",
+    "locality_name": "Latina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Montegabbione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Allerona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Attigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Castel Giorgio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Castel Viscardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Fabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Ficulle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Monteleone d'Orvieto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Orvieto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Alviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Acquasparta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Amelia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Baschi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Giove",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Guardea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Montecastrilli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Penna in Teverina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "San Gemini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Montefranco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Arrone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Calvi dell'Umbria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Ferentillo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Narni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Stroncone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "05100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1755,
+    "state_code": "TR",
+    "locality_name": "Terni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Citerna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Città di Castello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Montone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "San Giustino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Umbertide",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Costacciaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Fossato di Vico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Gualdo Tadino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Gubbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Nocera Umbra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Pietralunga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Scheggia e Pascelupo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Sigillo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Valfabbrica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Giano dell'Umbria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Bevagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Cannara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Foligno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Gualdo Cattaneo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Montefalco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Spello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Trevi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Poggiodomo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Cerreto di Spoleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Campello sul Clitunno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Cascia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Castel Ritaldi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Monteleone di Spoleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Norcia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Preci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Spoleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Collazzone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Deruta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Fratta Todina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Marsciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Massa Martana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Monte Castello di Vibio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Todi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Lisciano Niccone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Castiglione del Lago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Città della Pieve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Magione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Panicale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Passignano sul Trasimeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Piegaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Tuoro sul Trasimeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Corciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Assisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Bastia Umbra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Bettona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Torgiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "06135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1691,
+    "state_code": "PG",
+    "locality_name": "Perugia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Anela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Bono",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Bonorva",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Mores",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Ozieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Padria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Pattada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Ploaghe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Pozzomaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Villanova Monteleone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Aggius",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Arzachena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Berchidda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Calangianus",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "La Maddalena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Luras",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Olbia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Oschiri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Santa Teresa Gallura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Tempio Pausania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Badesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Castelsardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Nulvi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Osilo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Perfugas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Sedini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Sennori",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Sorso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Trinità d'Agultu e Vignola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Valledoria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Banari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Alghero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Bonnanaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Ittiri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Ossi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Porto Torres",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Thiesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Torralba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Usini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Budoni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "San Teodoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "07100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1722,
+    "state_code": "SS",
+    "locality_name": "Sassari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Birori",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Bolotana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Bortigali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Macomer",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Borore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Silanus",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Sindia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Galtellì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Bitti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Dorgali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Fonni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Mamoiada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Oliena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Orani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Orgosolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Orosei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Siniscola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Atzara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Aritzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Desulo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Ortueri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Sorgono",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Tonara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Arzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Bari Sardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Jerzu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Lanusei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Perdasdefogu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Tertenia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Tortolì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Villagrande Strisaili",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "08100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1790,
+    "state_code": "NU",
+    "locality_name": "Nuoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Buggerru",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Calasetta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Capoterra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Carbonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Carloforte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Domusnovas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Iglesias",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Sant'Antioco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Sarroch",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Teulada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Collinas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Barumini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Lunamatrona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Monastir",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Nuraminis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Sanluri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "San Sperate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Serrenti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Sestu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Setzu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Pabillonis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Arbus",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Assemini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Decimomannu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Villasor",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Gonnosfanadiga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Guspini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "San Gavino Monreale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Serramanna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Villacidro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Armungia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Dolianova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Monserrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Muravera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Quartucciu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Quartu Sant'Elena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Selargius",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Sinnai",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Villasimius",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Pula",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Escalaplano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Escolca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Esterzili",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Genoni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Gergei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Isili",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Nuragus",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Nurallao",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Nurri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Settimo San Pietro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Orroli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Sadali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Serri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Seui",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Seulo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1730,
+    "state_code": "SU",
+    "locality_name": "Villanova Tulo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Elmas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Uta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Maracalagonis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Aidomaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Abbasanta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Cabras",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Cuglieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Ghilarza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Santu Lussurgiu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Sedilo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Solarussa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Scano di Montiferro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Tresnuraghes",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Allai",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Ardauli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Busachi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Fordongianus",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Villanova Truschedu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Ruinas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Samugheo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Ollastra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Bosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Albagiara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Ales",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Arborea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Gonnostramatza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Marrubiu",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Mogoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Santa Giusta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09097",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "San Nicolò d'Arcidano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09098",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Terralba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09099",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Uras",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5628,
+    "state_code": "CA",
+    "locality_name": "Cagliari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "09170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1786,
+    "state_code": "OR",
+    "locality_name": "Oristano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Albiano d'Ivrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Agliè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Bollengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Borgofranco d'Ivrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Caluso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Ivrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Montalto Dora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Montanaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pavone Canavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Strambino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Andezeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Carmagnola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Chieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Moncalieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pino Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Santena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Trofarello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Villastellone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Maglione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Borgomasino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Brandizzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Chivasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Mazzè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Settimo Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torrazza Piemonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Verolengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Val di Chy",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Almese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Carignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Nichelino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Orbassano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pianezza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Piossasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Isolabella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Vinovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Borgone Susa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Avigliana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Bardonecchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Bussoleno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Cesana Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Condove",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Oulx",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Sant'Ambrogio di Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Sestriere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Mompantero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Airasca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Cavour",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Luserna San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Perosa Argentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pinerolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pramollo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torre Pellice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Vigone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Villafranca Piemonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Villar Perosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Ala di Stura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Borgaro Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Caselle Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Ciriè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Lanzo Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Mathi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Nole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "San Maurizio Canavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Venaria Reale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Mappano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Alpette",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Castellamonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Cuorgnè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Favria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Forno Canavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Pont-Canavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Rivarolo Canavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Valperga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Volpiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Valchiusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Bruino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Alpignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Beinasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Collegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Giaveno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Grugliasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10098",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Rivoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10099",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "San Mauro Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "10156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5637,
+    "state_code": "TO",
+    "locality_name": "Torino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Allein",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Arvier",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Cogne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Courmayeur",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Etroubles",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "La Salle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "La Thuile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Morgex",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Villeneuve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Antey-Saint-André",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Brusson",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Chambave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Châtillon",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Gressoney-Saint-Jean",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Pont-Saint-Martin",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Saint-Vincent",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Valtournenche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Verrès",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "11100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1716,
+    "state_code": "23",
+    "locality_name": "Aosta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Aisone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Borgo San Dalmazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Boves",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Chiusa di Pesio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Demonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Limone Piemonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Peveragno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Robilante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Roccavione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Vernante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bellino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Acceglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Busca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Caraglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Costigliole Saluzzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Dronero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Piasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Pradleves",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Prazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "San Damiano Macra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Brondello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bagnolo Piemonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Barge",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Moretta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Paesana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Racconigi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Revello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Saluzzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Savigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Verzuolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Baldissero d'Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bene Vagienna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Canale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Centallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Fossano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Montà",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Rocca de' Baldi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Sommariva del Bosco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Trinità",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Albaretto della Torre",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Neive",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Castiglione Tinella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Cossano Belbo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Diano d'Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Mango",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Santo Stefano Belbo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Barolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Carrù",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Cherasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Dogliani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "La Morra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Monforte d'Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Monticello d'Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Narzole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Santa Vittoria d'Alba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Alto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bagnasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Camerana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Ceva",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Bergolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Garessio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Lesegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Monesiglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Ormea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Saliceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Briaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Beinette",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Frabosa Soprana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Frabosa Sottana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Mondovì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Pamparato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Roccaforte Mondovì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Villanova Mondovì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "12100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Cuneo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Caresana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Borgosesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Borgo Vercelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Quarona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Valduggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Varallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Balmuccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Alagna Valsesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Boccioleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Campertogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Cellio con Breia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Cervatto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Carcoforo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Scopa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Scopello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Alto Sermenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Albano Vercellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Arborio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Asigliano Vercellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Costanzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Desana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Lenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Ronsecco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Serravalle Sesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Tricerro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Trino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Alice Castello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Bianzè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Cigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Crescentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Gattinara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Lamporo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Olcenengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Santhià",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Tronzano Vercellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Roasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1785,
+    "state_code": "VC",
+    "locality_name": "Vercelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Andorno Micca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Campiglia Cervo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Pollone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Rosazza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Miagliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Sordevolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Tollegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Callabiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Strona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Veglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Mezzana Mortigliengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Portula",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Valdilana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Cossato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Bioglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Pettinengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Piatto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Ronco Biellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13847",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Vallanzengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13848",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Zumaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Castelletto Cervo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Lessona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Quaregna Cerreto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Valdengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13856",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Vigliano Biellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Ailoche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Brusnengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Coggiola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Caprile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Curino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Casapinta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Pray",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13868",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Sostegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13871",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Benna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13872",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Borriana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13873",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Massazza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13874",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Gifflenga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13875",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Ponderano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13876",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Sandigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13877",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Villanova Biellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13878",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Candelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13881",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Cavaglià",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13882",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Cerrione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13883",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Roppolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13884",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Sala Biellese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13885",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Salussola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13886",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Viverone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13887",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Magnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13888",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Mongrando",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13891",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Camburzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13893",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Donato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13894",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Gaglianico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13895",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Graglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13896",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Netro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13897",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Occhieppo Inferiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13898",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Occhieppo Superiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13899",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Pralungo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "13900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1778,
+    "state_code": "BI",
+    "locality_name": "Biella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Antignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Baldichieri d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Ferrere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castellero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Capriglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "San Damiano d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Tigliole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Valfenera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Maretto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Villanova d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Aramengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Buttigliera d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Albugnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Cocconato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Moncucco Torinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Chiusano d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Cunico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Azzano d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Calliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Casorzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castell'Alfero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castello di Annone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Grazzano Badoglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Moncalvo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Portacomaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Tonco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Belveglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Agliano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Calamandrana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castelnuovo Belbo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castel Rocchero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Incisa Scapaccino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Bruno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Mombercelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Montaldo Scarampi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Nizza Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Cassinasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Bubbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Calosso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Canelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Castagnole delle Lanze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Costigliole d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Isola d'Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Monastero Bormida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "San Giorgio Scarampi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "14100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1780,
+    "state_code": "AT",
+    "locality_name": "Asti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alice Bel Colle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Acqui Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Bistagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Borgoratto Alessandrino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Cartosio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Cassine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Castelnuovo Bormida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Spigno Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Strevi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Camino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alfiano Natta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Bergamasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Felizzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Masio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Morano sul Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Carentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Pontestura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Quattordio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Solero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Camagna Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Balzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Borgo San Martino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Casale Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Cella Monte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Frassinello Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Giarole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Lu e Cuccaro Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Ottiglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Ozzano Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Bozzole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Altavilla Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Bassignana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Fubine Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Quargnento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Sale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "San Salvatore Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alluvioni Piovera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Valenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Vignale Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alzano Scrivia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Carezzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Casalnoceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Castelnuovo Scrivia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Fabbrica Curone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Pontecurone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Dernice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Tortona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Viguzzolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Monleale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Albera Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Arquata Scrivia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Bosco Marengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Cassano Spinola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Fresonara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Frugarolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Gavi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Novi Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Pozzolo Formigaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Serravalle Scrivia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Belforte Monferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Carpeneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Casal Cermelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Castellazzo Bormida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Molare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Mornese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Ovada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Predosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Rocca Grimalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Sezzadio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alessandria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "15122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1783,
+    "state_code": "AL",
+    "locality_name": "Alessandria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Crocefieschi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Arenzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Busalla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Campo Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Campomorone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Casella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Cogoleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Isola del Cantone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Mignanego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Ronco Scrivia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Fascia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Bargagli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Davagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Fontanigorda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Lumarzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Montebruno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Montoggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Propata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Rovegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Torriglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Casarza Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Bogliasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Camogli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Lavagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Portofino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Rapallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Avegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Santa Margherita Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Sestri Levante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Coreglia Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Borzonasca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Carasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Chiavari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Cicagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Lorsica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Mezzanego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Moconesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Rezzoaglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Santo Stefano d'Aveto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16157",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16158",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16159",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16160",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16161",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16162",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16163",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16164",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16165",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16166",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "16167",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5631,
+    "state_code": "GE",
+    "locality_name": "Genova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Giusvalla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Albisola Superiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Albissola Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Murialdo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Cairo Montenotte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Celle Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Cosseria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Varazze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Balestrino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Alassio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Borgio Verezzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Ceriale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Finale Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Loano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Noli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Giustenice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Bergeggi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Castelbianco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Albenga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Arnasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Casanova Lerrone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Castelvecchio di Rocca Barbena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Cisano sul Neva",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Onzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Villanova d'Albenga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Zuccarello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Mioglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Altare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Pontinvrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Carcare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Stella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Bormida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Sassello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Quiliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Urbe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Andora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Borghetto Santo Spirito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Laigueglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Boissano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Toirano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Cengio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Bardineto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Dego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "17100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1732,
+    "state_code": "SV",
+    "locality_name": "Savona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Badalucco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Castellaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Bordighera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Diano Arentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Ospedaletti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Pompeiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "San Bartolomeo al Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Cipressa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Taggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Vallecrosia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Aquila d'Arroscia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Borgomaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Cesio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Cosio d'Arroscia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Pornassio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1775,
+    "state_code": "CN",
+    "locality_name": "Briga Alta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Armo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Chiusanico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Montalto Carpasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Airole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Bajardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Perinaldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Camporosso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Ceriana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Apricale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "San Biagio della Cima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Pigna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Sanremo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Ventimiglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "18100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1788,
+    "state_code": "IM",
+    "locality_name": "Imperia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Maissana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Bonassola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Carro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Deiva Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Framura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Levanto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Monterosso al Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Riomaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Vernazza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Beverino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Arcola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Portovenere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Varese Ligure",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Ameglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Lerici",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Castelnuovo Magra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Luni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Santo Stefano di Magra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "Sarzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "19137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1791,
+    "state_code": "SP",
+    "locality_name": "La Spezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Arluno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Corbetta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cuggiono",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Magenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Nerviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Parabiago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Pero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Rho",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Sedriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Settimo Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Arconate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Baranzate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Castano Primo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cerro Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Garbagnate Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Legnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Novate Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Rescaldina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "San Vittore Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Turbigo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Senago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cormano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Paderno Dugnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cambiago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Grezzago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Basiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Carugate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cassano d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cernusco sul Naviglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Gorgonzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Inzago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Melzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Paullo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Peschiera Borromeo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Vaprio d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cerro al Lambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Vermezzo con Zelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Melegnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "San Colombano al Lambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Albairate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Abbiategrasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Binasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Gaggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Lacchiarella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Locate di Triulzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Motta Visconti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Robecco sul Naviglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Gudo Visconti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Rozzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Assago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Bresso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cinisello Balsamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cologno Monzese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Corsico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Cusano Milanino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Pioltello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20097",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "San Donato Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20098",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "San Giuliano Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20099",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Sesto San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20157",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20158",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20159",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20160",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20161",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20162",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5633,
+    "state_code": "MI",
+    "locality_name": "Milano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Cesano Maderno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Limbiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Bovisio-Masciago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Varedo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Cogliate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Ceriano Laghetto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Meda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Seveso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Lentate sul Seveso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Lazzate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20825",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Barlassina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Misinto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Seregno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Desio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Giussano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Nova Milanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Muggiò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Briosco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Veduggio con Colzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Renate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Carate Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Besana in Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Verano Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Triuggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Sovico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20846",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Macherio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20847",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Albiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Lissone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Villasanta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Biassono",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Vedano al Lambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Lesmo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20856",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Correzzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20857",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Camparada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Brugherio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Arcore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Concorezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Agrate Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Usmate Velate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Carnate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Caponago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20871",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Vimercate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20872",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Cornate d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20873",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Cavenago di Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20874",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Busnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20875",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Burago di Molgora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20876",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Ornago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20877",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Roncello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20881",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Bernareggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20882",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Bellusco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20883",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Mezzago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20884",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Sulbiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20885",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Ronco Briantino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20886",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Aicurzio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "20900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1769,
+    "state_code": "MB",
+    "locality_name": "Monza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Agra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Casorate Sempione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cassano Magnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Gallarate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Laveno-Mombello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Lonate Pozzolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Luino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Samarate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Sesto Calende",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Somma Lombardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Barasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Angera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Azzate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Besozzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Biandronno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Comerio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Gavirate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Ispra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Travedona-Monate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Vergiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Azzio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cadegliano-Viconago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Caravate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cittiglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cocquio-Trevisago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cunardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Gemonio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Lavena Ponte Tresa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Leggiuno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Bedero Valcuvia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Carnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Albizzate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Caronno Pertusella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Castiglione Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cavaria con Premezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Gazzada Schianno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Malnate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Saronno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Solbiate Arno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Tradate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Besano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Arcisate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Busto Arsizio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Castellanza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Fagnano Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Gorla Minore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Induno Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Olgiate Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Solbiate Olona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Viggiù",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Maccagno con Pino e Veddasca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Cadrezzate con Osmate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "21100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1765,
+    "state_code": "VA",
+    "locality_name": "Varese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Argegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Griante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Cernobbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Domaso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Dongo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Gravedona ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Tremezzina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Menaggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Porlezza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Bizzarone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Bellagio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Centro Valle Intelvi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Alta Valle Intelvi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Lezzeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Maslianico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Ronago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Blessagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Uggiate-Trevano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Barni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Albavilla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Albese con Cassano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Asso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Brunate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Canzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Erba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Ponte Lambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Tavernerio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Valbrona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Alserio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Colverde",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "San Fermo della Battaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Solbiate con Cagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Inverigo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Lambrugo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Merone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Arosio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Cantù",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Mariano Comense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Rovellasca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Albiolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Cadorago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Cermenate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Fino Mornasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Lomazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Lurate Caccivio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Mozzate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Olgiate Comasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Turate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Villa Guardia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "22100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1740,
+    "state_code": "CO",
+    "locality_name": "Como",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Albaredo per San Marco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Ardenno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Castione Andevenno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Cosio Valtellino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Andalo Valtellino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Dubino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Cercino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Morbegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Talamona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Traona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Caspoggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Campodolcino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Chiavenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Chiesa in Valmalenco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Madesimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Novate Mezzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Ponte in Valtellina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Samolaco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Villa di Chiavenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Bianzone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Aprica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Bormio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Grosio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Grosotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Sondalo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Teglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Tirano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Valdidentro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1741,
+    "state_code": "SO",
+    "locality_name": "Sondrio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23801",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Calolziocorte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23802",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Carenno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23804",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Monte Marenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23805",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Erve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23806",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Torre de' Busi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23807",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Merate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23808",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Vercurago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Ballabio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cortenova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cremeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Introbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Barzio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cassina Valsassina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Pasturo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23819",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Primaluna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Abbadia Lariana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Bellano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Colico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Dervio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23825",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Esino Lario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Mandello del Lario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23827",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Lierna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23828",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Perledo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23829",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Varenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Casargo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Crandola Valsassina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Pagnona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Premana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Sueglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Valvarrone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Parlasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Annone di Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Bosisio Parini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Dolzago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Sirone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Costa Masnaga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23846",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Garbagnate Monastero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23847",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Molteno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23848",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Ello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23849",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Rogeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Galbiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Garlate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Olginate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Pescate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23857",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Valgreghentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cesana Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Civate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Malgrate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Oliveto Lario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Suello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23868",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Valmadrera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23870",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cernusco Lombardone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23871",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Lomagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23873",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Missaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23874",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Montevecchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23875",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Osnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23876",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Monticello Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23877",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Paderno d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23879",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Verderio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23880",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Casatenovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23881",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Airuno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23883",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Brivio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23884",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Castello di Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23885",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Calco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23886",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Colle Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23887",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Olgiate Molgora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23888",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "La Valletta Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23889",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Santa Maria Hoè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23890",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Barzago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23891",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Barzanò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23892",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Bulciago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23893",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cassago Brianza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23894",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Cremella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23895",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Nibionno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23896",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Sirtori",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23897",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Viganò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23898",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Imbersago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23899",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Robbiate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "23900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1677,
+    "state_code": "LC",
+    "locality_name": "Lecco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Algua",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Almè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Val Brembilla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Oltre il Colle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Piazza Brembana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "San Giovanni Bianco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "San Pellegrino Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Cornalba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Villa d'Almè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Zogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Ardesio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Albino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Alzano Lombardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Clusone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Gandino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Gazzaniga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Cazzano Sant'Andrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Nembro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Ponte Nossa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Vertova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Almenno San Bartolomeo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Almenno San Salvatore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Calusco d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Cisano Bergamasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Curno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Ponte San Pietro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Brumano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Sant'Omobono Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Sotto il Monte Giovanni XXIII",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Arcene",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Brembate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Capriate San Gervasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Caravaggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Dalmine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Fara Gera d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Osio Sotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Treviglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Treviolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Verdello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bariano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Antegnate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Azzano San Paolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Brignano Gera d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Calcio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Cologno al Serio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Fontanella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Martinengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Fara Olivana con Sola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Urgnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Adrara San Martino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Albano Sant'Alessandro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Costa Volpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Castro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Grumello del Monte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Lovere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Pedrengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Sarnico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Seriate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Cenate Sotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "24129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1704,
+    "state_code": "BG",
+    "locality_name": "Bergamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Acquafredda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Calcinato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Calvisano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Carpenedolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Castenedolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Desenzano del Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Ghedi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Lonato del Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Montichiari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Sirmione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Alfianello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Bagnolo Mella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Borgo San Giacomo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gottolengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Leno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Manerbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Pontevico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Quinzano d'Oglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Verolanuova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Verolavecchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Adro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Capriolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Chiari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Cologne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Orzinuovi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Ospitaletto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Palazzolo sull'Oglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Pontoglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Rovato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Travagliato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Angolo Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Borno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Breno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Capo di Ponte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Castegnato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Cazzago San Martino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Darfo Boario Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Edolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Iseo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Cimbergo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Cedegolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Piancogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Malegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Marone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Pisogne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Ponte di Legno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Sale Marasino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Sulzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Vezza d'Oglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Bovegno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Concesio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gardone Val Trompia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gussago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Lumezzane",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Sarezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Villa Carcina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Anfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Agnosine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Bagolino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Bovezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Idro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Nave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Odolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Roè Volciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Pertica Bassa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Vobarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Calvagese della Riviera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Bedizzole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Botticino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gardone Riviera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gargnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Gavardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Rezzato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Salò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Toscolano-Maderno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Villanuova sul Clisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "25136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1717,
+    "state_code": "BS",
+    "locality_name": "Brescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Azzanello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Casalbuttano ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Castelleone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Crema",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Casaletto di Sopra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Soresina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Spino d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Pieranica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Trigolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Vailate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Acquanegra Cremonese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Annicco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Castelverde",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Grumello Cremonese ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Paderno Ponchielli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Pandino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Pizzighettone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Rivolta d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Sesto ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Soncino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Calvatone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Isola Dovarese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Ostiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Pescarolo ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Piadena Drizzona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Pieve San Giacomo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Rivarolo del Re ed Uniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "San Giovanni in Croce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Torre de' Picenardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Vescovato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Bonemerse",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Casalmaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Cingia de' Botti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Persico Dosimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Grontardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Motta Baluffi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "San Daniele Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Scandolara Ripa d'Oglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Sospiro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Stagno Lombardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1751,
+    "state_code": "CR",
+    "locality_name": "Cremona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Boffalora d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Borghetto Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Graffignana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Livraga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Massalengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Ossago Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "San Martino in Strada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Villanova del Sillaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Bertonico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Brembio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Castiglione d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Cavenago d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26825",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Mairago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Secugnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26827",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Terranova dei Passerini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26828",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Turano Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Casalmaiocco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Cervignano d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Comazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Abbadia Cerreto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Crespiatica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Montanaso Lombardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Mulazzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Tavazzano con Villavesco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26839",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Zelo Buon Persico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Casalpusterlengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Caselle Landi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Castelnuovo Bocca d'Adda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Castelgerundo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Codogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26846",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Corno Giovine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26847",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Maleo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26848",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "San Fiorano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26849",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Santo Stefano Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Borgo San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Casaletto Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Caselle Lurani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Cornegliano Laudense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Lodi Vecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26856",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Senna Lodigiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26857",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Salerano sul Lambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26858",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Sordio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26859",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Valera Fratta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Fombio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Guardamiglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Orio Litta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Ospedaletto Lodigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "San Rocco al Porto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Castiraga Vidardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Somaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "26900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1747,
+    "state_code": "LO",
+    "locality_name": "Lodi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Albuzzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Belgioioso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Certosa di Pavia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Chignolo Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Corteolona e Genzone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Landriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Lardirago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Pieve Porto Morone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Vidigulfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Villanterio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Alagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Bereguardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Casorate Primo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Cassolnovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Cilavegna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Gambolò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Garlasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Gropello Cairoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "San Martino Siccomario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Vigevano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Castello d'Agogna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Candia Lomellina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Ferrera Erbognone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Galliavola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Mede",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Mortara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Pieve del Cairo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Robbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Sannazzaro de' Burgondi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Albaredo Arnaboldi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Barbianello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Bressana Bottarone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Broni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Canneto Pavese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Casteggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Santa Giuletta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Golferenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Sommo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Stradella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Bagnaria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Cava Manara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Godiasco Salice Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Lungavilla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Montebello della Battaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Rivanazzano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Cornale e Bastida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Varzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Voghera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Zavattarello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Colli Verdi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "27100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1676,
+    "state_code": "PV",
+    "locality_name": "Pavia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Agrate Conturbia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Armeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Cressa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Gattico-Veruno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Maggiora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Momo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Orta San Giulio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "San Maurizio d'Opaglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Suno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Borgomanero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Gozzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Pettenasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Borgo Ticino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Arona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Bellinzago Novarese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Invorio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Meina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Oleggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Pombia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Castelletto sopra Ticino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Casalbeltrame",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Biandrate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Cameri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Carpignano Sesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Cerano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Galliate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Romentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Trecate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Garbagna Novarese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Borgolavezzaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Briona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Fara Novarese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Ghemme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Grignasco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Pogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Prato Sesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Romagnano Sesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Vespolate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1774,
+    "state_code": "NO",
+    "locality_name": "Novara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28801",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Cossogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28802",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Mergozzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28803",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Premosello-Chiovenda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28804",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "San Bernardino Verbano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28805",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Vogogna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Arizzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Aurano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Bee",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Cambiasca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Caprezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Intragna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Miazzina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Premeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28819",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Vignone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Cannero Riviera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Cannobio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Ghiffa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Oggebbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Trarego Viggiona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28827",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Valle Cannobina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28828",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Gurro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Baveno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Belgirate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Brovello-Carpugnino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Gignese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Stresa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Antrona Schieranco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Bognanco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Montescheno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Villadossola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Domodossola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28846",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Borgomezzavalle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Beura-Cardezza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Craveggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Druogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Malesco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Masera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28856",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Re",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28857",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Santa Maria Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28858",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Toceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28859",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Trontano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Baceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Crodo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Formazza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Montecrestese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Crevoladossola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Premia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28868",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Trasquera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28871",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Bannio Anzino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28873",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Calasca-Castiglione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28875",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Ceppo Morelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28876",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Macugnaga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28877",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Anzola d'Ossola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28879",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Vanzone con San Carlo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28881",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Casale Corte Cerro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28883",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Gravellona Toce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28884",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Pallanzeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28885",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Piedimulera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28886",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Pieve Vergonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28887",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Germagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28891",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Cesara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28893",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Loreglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28894",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Madonna del Sasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28895",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Massiola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28896",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Quarna Sotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28897",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Valstrona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28898",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Quarna Sopra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28899",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Arola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28921",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Verbania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28922",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Verbania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28923",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Verbania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28924",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Verbania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "28925",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1726,
+    "state_code": "VB",
+    "locality_name": "Verbania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Agazzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Borgonovo Val Tidone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Caorso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Carpaneto Piacentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Castell'Arquato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Castel San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Cortemaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Fiorenzuola d'Arda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Lugagnano Val d'Arda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "San Giorgio Piacentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Cerignale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Bettola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Bobbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Farini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Ferriere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Gropparello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Ottone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Podenzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Ponte dell'Olio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Rivergaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Alta Val Tidone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Piacenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "29122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1696,
+    "state_code": "PC",
+    "locality_name": "Piacenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Campagna Lupia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Cavallino-Treporti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Cavarzere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Chioggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Jesolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Annone Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Caorle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Ceggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Concordia Sagittaria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Musile di Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Fossalta di Portogruaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Portogruaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "San Donà di Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "San Michele al Tagliamento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "San Stino di Livenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Fossò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Dolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Fiesso d'Artico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Noale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Mira",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Mirano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Santa Maria di Sala",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Scorzè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Spinea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Stra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30157",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30158",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30159",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30160",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30161",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30162",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30163",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30164",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30165",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30166",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30167",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30168",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30169",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30171",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30172",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30173",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30174",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30175",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "30176",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5638,
+    "state_code": "VE",
+    "locality_name": "Venezia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cimadolmo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Asolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cappella Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Codognè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Colle Umberto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Conegliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cordignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Pieve del Grappa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Gaiarine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Refrontolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Mogliano Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Preganziol",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Resana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Ormelle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Santa Lucia di Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Sarmede",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Spresiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Vazzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Vittorio Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Altivole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Caerano di San Marco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Casale sul Sile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Castelfranco Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cavaso del Tomba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Crocetta del Montello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Istrana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Loria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Paese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Riese Pio X",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cessalto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Cornuda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Fontanelle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Montebelluna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Motta di Livenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Oderzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Ponte di Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "San Biagio di Callalta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Valdobbiadene",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Miane",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Follina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Maserada sul Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Pieve di Soligo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Possagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Quinto di Treviso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Roncade",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Silea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Susegana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Zero Branco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "31100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1762,
+    "state_code": "TV",
+    "locality_name": "Treviso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Chies d'Alpago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Val di Zoldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Longarone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Ponte nelle Alpi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Alpago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Canale d'Agordo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Agordo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Alleghe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Rocca Pietore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Borgo Valbelluna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Taibon Agordino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Arsiè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Alano di Piave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Feltre",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Lamon",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Pedavena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Santa Giustina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Sedico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Sospirolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Quero Vas",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Borca di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Auronzo di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Calalzo di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Cortina d'Ampezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Pieve di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Santo Stefano di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "San Vito di Cadore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "32100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1689,
+    "state_code": "BL",
+    "locality_name": "Belluno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Bordano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Artegna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Sappada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Gemona del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Treppo Ligosullo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Moggio Udinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Pontebba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Tarcento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Tarvisio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Tricesimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Amaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Ampezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Arta Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Comeglians",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Forni di Sopra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Ovaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Paluzza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Paularo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Tolmezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Lauco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Buja",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Basiliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Bertiolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Codroipo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Fagagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Martignacco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Mereto di Tomba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Pasian di Prato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "San Daniele del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Sedegliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Attimis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Aiello del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Buttrio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Cividale del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Manzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Nimis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Pulfero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Remanzacco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Chiopris-Viscone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "San Pietro al Natisone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Bagnaria Arsa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Aquileia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Cervignano del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Latisana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Lignano Sabbiadoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Muzzana del Turgnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Palazzolo dello Stella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Palmanova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "San Giorgio di Nogaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Fiumicello Villa Vicentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Rivignano Teor",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Brugnera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Casarsa della Delizia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Fontanafredda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Cordovado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Pravisdomini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Sacile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "San Vito al Tagliamento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Sesto al Reghena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Andreis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Aviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Azzano Decimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Chions",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Cordenons",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Maniago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Montereale Valcellina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Pasiano di Pordenone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Arba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Cavasso Nuovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Pinzano al Tagliamento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "San Giorgio della Richinvelda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33097",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Spilimbergo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33098",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "San Martino al Tagliamento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33099",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Vivaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1764,
+    "state_code": "UD",
+    "locality_name": "Udine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "33170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1690,
+    "state_code": "PN",
+    "locality_name": "Pordenone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Sgonico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Duino Aurisina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Muggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Monrupino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "San Dorligo della Valle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Capriva del Friuli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Cormons",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Farra d'Isonzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Grado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Monfalcone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "San Canzian d'Isonzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Medea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Ronchi dei Legionari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Sagrado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Staranzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1763,
+    "state_code": "TS",
+    "locality_name": "Trieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "34170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1777,
+    "state_code": "GO",
+    "locality_name": "Gorizia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Borgoricco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Campodarsego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Camposampiero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Cittadella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Fontaniva",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Galliera Veneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Piazzola sul Brenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Piombino Dese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "San Martino di Lupari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Tombolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Albignasego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Agna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Anguillara Veneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Bagnoli di Sopra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Bovolenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Cartura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Conselve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Noventa Padovana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Piove di Sacco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Pontelongo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Baone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Abano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Arquà Petrarca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Lozzo Atestino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Mestrino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Montegrotto Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Teolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Torreglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Barbona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Battaglia Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Este",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Monselice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Montagnana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Ospedaletto Euganeo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Borgo Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Solesino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Stanghella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "35143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1665,
+    "state_code": "PD",
+    "locality_name": "Padova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Carrè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Arsiero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Asiago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Piovene Rocchette",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Santorso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Schio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Thiene",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Agugliaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Villaga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Cassola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Longare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Nanto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Noventa Vicentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Pojana Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Rosà",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Rossano Veneto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Valbrenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Caldogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Dueville",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Gallio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Isola Vicentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Malo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Marano Vicentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Torrebelvicino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Brendola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Breganze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Camisano Vicentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Val Liona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Alonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Lusiana Conco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Montegalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Barbarano Mossano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Bolzano Vicentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Creazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Enego",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Gambellara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Montebello Vicentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Nove",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Tezze sul Brenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Arcugnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Pianezze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Bassano del Grappa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Marostica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Colceresa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Mussolente",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Sandrigo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Altissimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Arzignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Chiampo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Cornedo Vicentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Montecchio Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Recoaro Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Altavilla Vicentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Valdagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "36100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1738,
+    "state_code": "VI",
+    "locality_name": "Vicenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Affi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Bardolino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Bussolengo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Caprino Veronese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Castelnuovo del Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Sant'Ambrogio di Valpolicella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Lazise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Malcesine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Peschiera del Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Brentino Belluno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Bosco Chiesanuova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Fumane",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Grezzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Negrar di Valpolicella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Pescantina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Roverè Veronese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "San Pietro in Cariano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Badia Calavena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Illasi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Monteforte d'Alpone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "San Giovanni Ilarione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "San Martino Buon Albergo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Soave",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Tregnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Arcole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Albaredo d'Adige",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Caldiero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Castagnaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Cologna Veneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Legnago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Minerbe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "San Bonifacio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Villa Bartolomea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Angiari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Bovolone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Casaleone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Cerea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Nogara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Ronco all'Adige",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Salizzole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "San Giovanni Lupatoto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Sanguinetto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Zevio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Buttapietra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Isola della Scala",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Povegliano Veronese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Sommacampagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Valeggio sul Mincio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Vigasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Villafranca di Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "37142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1736,
+    "state_code": "VR",
+    "locality_name": "Verona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Andalo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Amblar-Don",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Predaia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Borgo d'Anaunia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Lavis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Mezzocorona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Mezzolombardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Molveno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Ville d'Anaunia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Borgo d'Anaunia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Novella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Caldes",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Cles",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Peio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Dimaro Folgarida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Ossana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Croviana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Novella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Vermiglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Capriana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Campitello di Fassa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Canazei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Cavalese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Cembra Lisignago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Moena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "San Giovanni di Fassa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Predazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Tesero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Fornace",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Albiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Baselga di Pinè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Bedollo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Civezzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Lavarone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Segonzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Sover",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Altopiano della Vigolana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Bieno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Borgo Valsugana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Caldonazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Castello Tesino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Primiero San Martino di Castrozza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Grigno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Levico Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Pergine Valsugana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Castel Ivano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Aldeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Ala",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Arco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Avio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Folgaria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Mori",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Riva del Garda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Ledro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Rovereto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Nago-Torbole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Stenico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Bleggio Superiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Cavedine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Drena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Fiavè",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Madruzzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Comano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "San Lorenzo Dorsino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Borgo Lares",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Bocenago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Castel Condino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Borgo Chiese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Pieve di Bono-Prezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Giustino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Sella Giudicarie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Spiazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Storo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Valdaone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Altavalle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Contà",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Porte di Rendena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Tre Ville",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Vallelaghi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38097",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Terre d'Adige",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Trento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Trento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "38123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5640,
+    "state_code": "TN",
+    "locality_name": "Trento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Andriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Lana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Merano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Moso in Passiria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Postal",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "San Leonardo in Passiria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Ultimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Scena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Terlano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Tirolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Castelbello-Ciardes",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Laces",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Lagundo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Lasa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Malles Venosta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Naturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Prato allo Stelvio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Curon Venosta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Silandro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Stelvio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Braies",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Brunico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Campo Tures",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Corvara in Badia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Dobbiaco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Monguelfo-Tesido",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Badia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Rio di Pusteria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "San Candido",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Villabassa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Aldino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Brennero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Bressanone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Chiusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Egna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Fortezza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Ortisei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Santa Cristina Valgardena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Selva di Val Gardena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Val di Vizze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Fiè allo Sciliar",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Bronzolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Caldaro sulla strada del vino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Cornedo all'Isarco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Renon",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Laives",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Nova Levante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Appiano sulla strada del vino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Sarentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "39100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5639,
+    "state_code": "BZ",
+    "locality_name": "Bolzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bentivoglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Anzola dell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Calderara di Reno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Crevalcore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Galliera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "San Giorgio di Piano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "San Giovanni in Persiceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "San Pietro in Casale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Sant'Agata Bolognese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Casalfiumanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Borgo Tossignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel del Rio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel Guelfo di Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel San Pietro Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Fontanelice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Imola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Mordano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel di Casio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Camugnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Casalecchio di Reno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castel d'Aiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castiglione dei Pepoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Monzuno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Sasso Marconi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Vergato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Gaggio Montano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Lizzano in Belvedere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Marzabotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Alto Reno Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "San Benedetto Val di Sambro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Argelato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Malalbergo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Baricella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Valsamoggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Budrio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Castenaso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Granarolo dell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Medicina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Dozza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Minerbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Molinella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Monghidoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Ozzano dell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Pianoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Pieve di Cento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "San Lazzaro di Savena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Zola Predosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "40141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5627,
+    "state_code": "BO",
+    "locality_name": "Bologna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Campogalliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Carpi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Castelfranco Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Castelvetro di Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Nonantola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Novi di Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Ravarino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "San Cesario sul Panaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Soliera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Riolunato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Fanano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Fiumalbo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Lama Mocogno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Montecreto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Pavullo nel Frignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Pievepelago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Serramazzoni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Sestola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Bastiglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Camposanto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Cavezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Concordia sulla Secchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Finale Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Medolla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Mirandola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "San Felice sul Panaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "San Possidonio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Polinago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Fiorano Modenese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Formigine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Frassinoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Montefiorino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Palagano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Prignano sulla Secchia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Sassuolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Castelnuovo Rangone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Guiglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Maranello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Marano sul Panaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Montese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Savignano sul Panaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Spilamberto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Vignola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Zocca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "41126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1757,
+    "state_code": "MO",
+    "locality_name": "Modena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Rio Saliceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Bagnolo in Piano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Campagnola Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Casalgrande",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Castellarano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Correggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Guastalla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Novellara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "San Martino in Rio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Scandiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Albinea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Bibbiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Boretto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Cadelbosco di Sopra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Castelnovo di Sotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Cavriago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Canossa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Montecchio Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Poviglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Vezzano sul Crostolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Baiso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Ventasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Carpineti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Casina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Castelnovo ne' Monti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Campegine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Brescello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Fabbrico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Gattatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Gualtieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Luzzara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Reggiolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Rolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Rubiera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Sant'Ilario d'Enza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Reggio nell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Reggio nell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Reggio nell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "42124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1708,
+    "state_code": "RE",
+    "locality_name": "Reggio nell'Emilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Fontevivo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Busseto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Fontanellato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Langhirano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Medesano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Noceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Polesine Zibello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "San Secondo Parmense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Sissa Trecasali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Soragna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Corniglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Montechiarugolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Neviano degli Arduini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Palanzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Tizzano Val Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Traversetolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Bore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Bardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Felino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Fidenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Lesignano de' Bagni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Sala Baganza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Salsomaggiore Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Terenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Bedonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Berceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Borgo Val di Taro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Collecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Fornovo di Taro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Solignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Pellegrino Parmense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Varsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Valmozzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Albareto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Colorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Compiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Torrile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Sorbolo Mezzani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Tornolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "43126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1666,
+    "state_code": "PR",
+    "locality_name": "Parma",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Argenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Bondeno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Portomaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Voghiera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Goro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Codigoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Comacchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Lagosanto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Mesola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Fiscaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Poggio Renatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Riva del Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Copparo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Jolanda di Savoia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Tresignana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Cento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Terre del Reno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Vigarano Mainarda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Ferrara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Ferrara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Ferrara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "44124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1746,
+    "state_code": "FE",
+    "locality_name": "Ferrara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Ceregnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Adria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Ariano nel Polesine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Porto Viro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Corbola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Loreo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Porto Tolle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Taglio di Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Canda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Badia Polesine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Bagnolo di Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Costa di Rovigo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Fiesso Umbertiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Fratta Polesine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Lendinara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Trecenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Calto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Arquà Polesine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Bergantino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Bosaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Canaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Castelmassa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Ficarolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Melara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Polesella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Stienta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "45100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1719,
+    "state_code": "RO",
+    "locality_name": "Rovigo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Commessaggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Acquanegra sul Chiese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Bozzolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Canneto sull'Oglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Castellucchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Rivarolo Mantovano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Sabbioneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Viadana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Magnacavallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Borgocarbonara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Gonzaga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Moglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Poggio Rusco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Quistello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "San Benedetto Po",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Sermide e Felonica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Suzzara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Dosolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Bagnolo San Vito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Castelbelforte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Castel d'Ario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Borgo Virgilio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Ostiglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Borgo Mantovano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Roncoferraro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Villimpenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Casalmoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Asola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Castel Goffredo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Castiglione delle Stiviere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Goito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Marmirolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Medole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Porto Mantovano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Roverbella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Volta Mantovana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "San Giorgio Bigarello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "46100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1758,
+    "state_code": "MN",
+    "locality_name": "Mantova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Galeata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Castrocaro Terme e Terra del Sole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Civitella di Romagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Dovadola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Meldola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Modigliana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Predappio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Rocca San Casciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Santa Sofia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Tredozio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Longiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Bagno di Romagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Mercato Saraceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Sarsina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Verghereto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Borghi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Bertinoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Forlimpopoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Gambettola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Savignano sul Rubicone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Cesenatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Gatteo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Forlì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Forlì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47521",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Cesena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47522",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1779,
+    "state_code": "FC",
+    "locality_name": "Cesena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Bellaria-Igea Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Santarcangelo di Romagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Poggio Torriana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Verucchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "San Clemente",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Morciano di Romagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Montefiore Conca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Saludecio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Mondaino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Montegridolfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Riccione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Cattolica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "San Giovanni in Marignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Misano Adriatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Coriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Montescudo-Monte Colombo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Gemmano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Casteldelci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Maiolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Novafeltria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Pennabilli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47865",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "San Leo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Sant'Agata Feltria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Talamello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47921",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Rimini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47922",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Rimini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47923",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Rimini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "47924",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1713,
+    "state_code": "RN",
+    "locality_name": "Rimini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Alfonsine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Bagnacavallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Brisighella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Castel Bolognese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Cervia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Conselice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Faenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Sant'Agata sul Santerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Lugo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Massa Lombarda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Riolo Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Russi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Solarolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Bagnara di Romagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Casola Valsenio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Cotignola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Fusignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Ravenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Ravenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Ravenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Ravenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "48125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1707,
+    "state_code": "RA",
+    "locality_name": "Ravenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Bagno a Ripoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Campi Bisenzio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Fiesole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Scandicci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Sesto Fiorentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Greve in Chianti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Impruneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Montespertoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "San Casciano in Val di Pesa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Barberino Tavarnelle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Barberino di Mugello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Borgo San Lorenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenzuola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Marradi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Palazzuolo sul Senio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Vaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Scarperia e San Piero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Vicchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Calenzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Capraia e Limite",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Castelfiorentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Certaldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Empoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Fucecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Lastra a Signa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Montelupo Fiorentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Signa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Vinci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Londa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Dicomano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Figline e Incisa Valdarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Pontassieve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Reggello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Rignano sull'Arno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Rufina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "50145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5630,
+    "state_code": "FI",
+    "locality_name": "Firenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Marliana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Buggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Chiesina Uzzanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Monsummano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Montecatini-Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Pescia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Pieve a Nievole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Ponte Buggianese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Sambuca Pistoiese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Abetone Cutigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "San Marcello Piteglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Agliana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Serravalle Pistoiese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Lamporecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Larciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Montale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Quarrata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "51100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1687,
+    "state_code": "PT",
+    "locality_name": "Pistoia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Capolona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Bibbiena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Poppi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Pratovecchio Stia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Castel Focognano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Castel San Niccolò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Laterina Pergine Valdarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Bucine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Cavriglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Loro Ciuffenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Montevarchi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Castelfranco Piandiscò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "San Giovanni Valdarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Terranuova Bracciolini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Castiglion Fibocchi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Anghiari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Badia Tedalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Caprese Michelangelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Monterchi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Pieve Santo Stefano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Sansepolcro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Sestino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Civitella in Val di Chiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Castiglion Fiorentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Cortona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Foiano della Chiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Lucignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Marciano della Chiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Monte San Savino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "52100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1761,
+    "state_code": "AR",
+    "locality_name": "Arezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Castellina in Chianti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Chiusdino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Gaiole in Chianti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Monteroni d'Arbia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Monticiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Murlo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Radda in Chianti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Sovicille",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Castelnuovo Berardenga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Trequanda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Abbadia San Salvatore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Buonconvento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Castiglione d'Orcia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Montalcino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Piancastagnaio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Pienza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "San Quirico d'Orcia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Radicondoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Casole d'Elsa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Colle di Val d'Elsa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Monteriggioni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Poggibonsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "San Gimignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Cetona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Asciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Chianciano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Chiusi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Montepulciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Sarteano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Sinalunga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Torrita di Siena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "53100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1734,
+    "state_code": "SI",
+    "locality_name": "Siena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Podenzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Aulla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Tresana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Fivizzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Casola in Lunigiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Comano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Licciana Nardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Bagnone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Filattiera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Mulazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Pontremoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Villafranca in Lunigiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Zeri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Carrara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Fosdinovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Montignoso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "54100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1759,
+    "state_code": "MS",
+    "locality_name": "Massa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Altopascio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Capannori",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Montecarlo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Porcari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Villa Basilica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Fosciandora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Fabbriche di Vergemoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Bagni di Lucca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Borgo a Mozzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Coreglia Antelminelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Gallicano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Careggine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Camporgiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Castelnuovo di Garfagnana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Castiglione di Garfagnana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Minucciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Piazza al Serchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Pieve Fosciana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "San Romano in Garfagnana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Sillano Giuncugnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Stazzema",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Camaiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Forte dei Marmi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Pietrasanta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Seravezza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Viareggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Barga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Massarosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Pescaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "55100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1749,
+    "state_code": "LU",
+    "locality_name": "Lucca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Vicopisano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Calci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Calcinaia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "San Giuliano Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Vecchiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Montopoli in Val d'Arno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Cascina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Castelfranco di Sotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pontedera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "San Miniato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Santa Croce sull'Arno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Lajatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Bientina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Buti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Capannoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Chianni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Casciana Terme Lari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Palaia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Peccioli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Ponsacco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Casale Marittimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Castelnuovo di Val di Cecina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Crespina Lorenzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Fauglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pomarance",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Riparbella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Volterra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "56128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1685,
+    "state_code": "PI",
+    "locality_name": "Pisa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Collesalvetti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Rosignano Marittimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Bibbona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Campiglia Marittima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Castagneto Carducci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Cecina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Piombino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "San Vincenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Suvereto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Marciana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Capoliveri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Capraia Isola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Marciana Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Campo nell'Elba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Porto Azzurro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Portoferraio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Rio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "57128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1745,
+    "state_code": "LI",
+    "locality_name": "Livorno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Sorano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Capalbio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Isola del Giglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Manciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Orbetello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Pitigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Monte Argentario",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Scarlino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Follonica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Gavorrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Massa Marittima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Monterotondo Marittimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Montieri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Arcidosso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Castel del Piano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Castell'Azzara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Roccastrada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Santa Fiora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Seggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Campagnatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Castiglione della Pescaia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Cinigiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Civitella Paganico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Magliano in Toscana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Roccalbegna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Scansano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Semproniano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "58100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1787,
+    "state_code": "GR",
+    "locality_name": "Grosseto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Montemurlo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Carmignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Poggio a Caiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Vaiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Vernio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Cantagallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "59100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1700,
+    "state_code": "PO",
+    "locality_name": "Prato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Barbara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Arcevia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Trecastelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Corinaldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Falconara Marittima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Montemarciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Senigallia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Agugliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Camerano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Castelfidardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Filottrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Loreto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Numana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Osimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Belvedere Ostrense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Castelplanio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Chiaravalle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Cupramontana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Jesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Montecarotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Monte San Vito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "San Paolo di Jesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Staffolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Genga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Sassoferrato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Cerreto d'Esi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Fabriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Serra San Quirico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "60131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1672,
+    "state_code": "AN",
+    "locality_name": "Ancona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Monte Cerignone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Gabicce Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Gradara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Mercatino Conca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Montecopiolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Montecalvo in Foglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Carpegna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Vallefoglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Macerata Feltria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Mombaroccio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Montelabbate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Belforte all'Isauro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Sassocorvaro Auditore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Urbino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Cartoceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Fano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Fermignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Fossombrone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Colli al Metauro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Mondolfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Terre Roveresche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "San Costanzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Borgo Pace",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Acqualagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Apecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Cagli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Cantiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Pergola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Piobbico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "San Lorenzo in Campo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Sant'Angelo in Vado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Peglio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Pesaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "61122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1693,
+    "state_code": "PU",
+    "locality_name": "Pesaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Appignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Cingoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Civitanova Marche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Corridonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Monte San Giusto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Porto Recanati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Potenza Picena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Recanati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Belforte del Chienti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Apiro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Castelraimondo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Esanatoglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Fiuminata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "San Ginesio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "San Severino Marche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Sarnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Tolentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Valfornace",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Camerino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Muccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Bolognola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Monte Cavallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Serravalle di Chienti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Castelsantangelo sul Nera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "62100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1750,
+    "state_code": "MC",
+    "locality_name": "Macerata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Massignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Montefiore dell'Aso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Carassai",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Cupra Marittima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Ripatransone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Grottammare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Cossignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Montalto delle Marche",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Montedinove",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Rotella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Castignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Offida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "San Benedetto del Tronto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Acquaviva Picena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Monteprandone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Monsampolo del Tronto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Spinetoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Colli del Tronto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Castorano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Castel di Lama",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Appignano del Tronto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Folignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Maltignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Force",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Comunanza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Montemonaco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Venarotta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Palmiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Roccafluvione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Montegallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Acquasanta Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Arquata del Tronto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1681,
+    "state_code": "AP",
+    "locality_name": "Ascoli Piceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Sant'Elpidio a Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montegranaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte Urano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Torre San Patrizio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte San Pietrangeli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Francavilla d'Ete",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Porto Sant'Elpidio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Porto San Giorgio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Lapedona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Altidona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63825",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monterubbiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63826",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Moresco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63827",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Pedaso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63828",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Campofilone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Rapagnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Magliano di Tenna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montegiorgio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Massa Fermana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montappone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte Vidon Corrado",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Falerone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Belmonte Piceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63839",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Servigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monteleone di Fermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monsampietro Morico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montottone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Grottazzolina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63845",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Ponzano di Fermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63846",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte Giberto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63847",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte Vidon Combatte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63848",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Petritoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Ortezzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Monte Rinaldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montelparo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63854",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Santa Vittoria in Matenano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63855",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montefalcone Appennino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63856",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Smerillo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63857",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Amandola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63858",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Montefortino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "63900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1744,
+    "state_code": "FM",
+    "locality_name": "Fermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Ancarano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Alba Adriatica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Campli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Corropoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Martinsicuro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Nereto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Sant'Egidio alla Vibrata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Tortoreto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Bellante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Giulianova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Mosciano Sant'Angelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Notaresco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Pineto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Roseto degli Abruzzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Sant'Omero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Silvi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Basciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Arsita",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Atri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Bisenti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Castiglione Messer Raimondo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Castilenti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Cellino Attanasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Cermignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Penna Sant'Andrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Cortino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Castelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Colledara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Crognaleto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Fano Adriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Isola del Gran Sasso d'Italia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Montorio al Vomano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Pietracamela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Tossicia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "64100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1752,
+    "state_code": "TE",
+    "locality_name": "Teramo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Brittoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Catignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Cepagatti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Città Sant'Angelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Loreto Aprutino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Montesilvano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Penne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pianella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Abbateggio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Bussi sul Tirino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Caramanico Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Manoppello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Serramonacesca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Popoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Scafa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Tocco da Casauria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Torre de' Passeri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "65129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1694,
+    "state_code": "PE",
+    "locality_name": "Pescara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Ari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Bucchianico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Casalincontrada",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Crecchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Fara San Martino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Guardiagrele",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Palena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Taranta Peligna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Torricella Peligna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Paglieta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Casalbordino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Fossacesia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Francavilla al Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Ortona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Arielli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Casalanguida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Castel Frentano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Castiglione Messer Marino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Lanciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Orsogna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Sant'Eusanio del Sangro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "San Vito Chietino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Altino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Atessa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Bomba",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Casoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Archi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Schiavi di Abruzzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Tornareccio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Villa Santa Maria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Carunchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Cupello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Gissi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Vasto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "66100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1739,
+    "state_code": "CH",
+    "locality_name": "Chieti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Barete",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Cagnano Amiterno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Campotosto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Capitignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Montereale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pizzoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Scoppito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Acciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Barisciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Capestrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Castel del Monte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Castelvecchio Subequo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Ofena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Poggio Picenze",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Raiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "San Demetrio ne' Vestini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Secinaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Alfedena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Castel di Sangro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pescasseroli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pescocostanzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pettorano sul Gizio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pratola Peligna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Rivisondoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Roccaraso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Scanno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Sulmona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Collarmele",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Aielli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Celano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Cerchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Lucoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Ovindoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Rocca di Cambio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Rocca di Mezzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Tornimparte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Bisegna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Avezzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Balsorano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Capistrello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Civitella Roveto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Gioia dei Marsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Luco dei Marsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pescina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "San Benedetto dei Marsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Trasacco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Cappadocia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Carsoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Magliano de' Marsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Oricola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Pereto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Rocca di Botte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Sante Marie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Scurcola Marsicana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "Tagliacozzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "67100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1781,
+    "state_code": "AQ",
+    "locality_name": "L'Aquila",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Adelfia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Alberobello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Castellana Grotte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Conversano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Noci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Noicattaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Putignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Rutigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Triggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Binetto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Acquaviva delle Fonti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Altamura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Gioia del Colle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Gravina in Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Grumo Appula",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Modugno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Palo del Colle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Sannicandro di Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Santeramo in Colle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bitonto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Corato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Ruvo di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Terlizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Mola di Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Monopoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Polignano a Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Giovinazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Molfetta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "70132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5626,
+    "state_code": "BA",
+    "locality_name": "Bari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Cagnano Varano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Apricena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Rodi Garganico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "San Giovanni Rotondo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "San Marco in Lamis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "San Nicandro Garganico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "San Severo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Torremaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Vico del Gargano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Vieste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Anzano di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Accadia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Ascoli Satriano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Bovino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Candela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Castelluccio dei Sauri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Deliceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Orsara di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Sant'Agata di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Troia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Carlantino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Alberona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Biccari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Casalnuovo Monterotaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Castelnuovo della Daunia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Celenza Valfortore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Lucera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Monte Sant'Angelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Pietramontecorvino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Roseto Valfortore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Ordona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Carapelle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Cerignola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Manfredonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Orta Nova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Stornara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Stornarella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Isole Tremiti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Foggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "71122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1771,
+    "state_code": "FG",
+    "locality_name": "Foggia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Carovigno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Ceglie Messapica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Cisternino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Fasano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Ostuni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "San Michele Salentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "San Vito dei Normanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Cellino San Marco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Francavilla Fontana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Latiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Mesagne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Oria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "San Donaci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "San Pancrazio Salentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "San Pietro Vernotico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Torre Santa Susanna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Villa Castelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "72100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1714,
+    "state_code": "BR",
+    "locality_name": "Brindisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Arnesano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Alezio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Campi Salentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Galatina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Gallipoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Salice Salentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "San Cesario di Lecce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Sannicola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Squinzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Trepuzzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Bagnolo del Salento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Calimera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Corigliano d'Otranto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Lizzanello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Maglie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Martano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Melendugno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Minervino di Lecce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Otranto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Vernole",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Castro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Alessano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Andrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Corsano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Gagliano del Capo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Miggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Muro Leccese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Poggiardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Spongano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Tricase",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Alliste",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Carmiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Casarano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Copertino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Galatone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Leverano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Matino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Monteroni di Lecce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Nardò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Ruffano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Salve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Novoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Parabita",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Patù",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Presicce-Acquarica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Racale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Taurisano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Taviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Tuglie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Ugento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "73100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1675,
+    "state_code": "LE",
+    "locality_name": "Lecce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Statte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Castellaneta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Crispiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Ginosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Laterza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Martina Franca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Massafra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Mottola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Palagianello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Palagiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Avetrana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Carosino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Fragagnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Grottaglie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Manduria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Pulsano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "San Giorgio Ionico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Sava",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Taranto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Taranto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "74123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1743,
+    "state_code": "TA",
+    "locality_name": "Taranto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Aliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Accettura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Bernalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Ferrandina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Grassano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Pisticci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Pomarico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Salandra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Stigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Tricarico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Nova Siri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Colobraro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Irsina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Montalbano Jonico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Montescaglioso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Policoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Rotondella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "San Giorgio Lucano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Tursi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Valsinni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "75100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1760,
+    "state_code": "MT",
+    "locality_name": "Matera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Bisceglie",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Canosa di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Minervino Murge",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Spinazzola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Trinitapoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Margherita di Savoia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "San Ferdinando di Puglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Barletta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Andria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "76125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1686,
+    "state_code": "BT",
+    "locality_name": "Trani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Quarto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Acerra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Calvizzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casalnuovo di Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Giugliano in Campania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Marano di Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Melito di Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Mugnano di Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Qualiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casavatore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Afragola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Arzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Caivano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Cardito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casandrino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casoria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Frattamaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Grumo Nevano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Sant'Antimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Camposano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Brusciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casamarciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Cicciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Marigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Nola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Palma Campania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Pomigliano d'Arco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Saviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Cercola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Boscoreale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Boscotrecase",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Ottaviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Pompei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "San Giorgio a Cremano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "San Giuseppe Vesuviano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Sant'Anastasia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Somma Vesuviana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casola di Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Agerola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Castellammare di Stabia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Gragnano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Portici",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Ercolano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Sant'Antonio Abate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Torre Annunziata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Torre del Greco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Massa Lubrense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Meta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Piano di Sorrento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Sant'Agnello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Sorrento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Vico Equense",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Bacoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Anacapri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Barano d'Ischia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Capri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Casamicciola Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Forio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Lacco Ameno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Ischia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Pozzuoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Procida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Serrara Fontana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "80147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5634,
+    "state_code": "NA",
+    "locality_name": "Napoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Ailano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Alife",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Alvignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Caiazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Capriati a Volturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Castello del Matese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Raviscanina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Capodrise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Arienzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Casagiove",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Cervino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Maddaloni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Marcianise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "San Felice a Cancello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Santa Maria a Vico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Cancello ed Arnone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Aversa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Carinaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Casal di Principe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Mondragone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Marzano Appio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "San Cipriano d'Aversa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Sessa Aurunca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Trentola Ducenta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Villa Literno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Castel di Sasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Bellona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Calvi Risorta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Capua",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Conca della Campania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Grazzanise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Macerata Campania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Mignano Monte Lungo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Camigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Pietramelara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Pignataro Maggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Riardo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "San Prisco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Santa Maria Capua Vetere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Sparanise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Teano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Vairano Patenora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Caianello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "81100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1731,
+    "state_code": "CE",
+    "locality_name": "Caserta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Arpaise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Airola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Bonea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Ceppaloni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Durazzano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Montesarchio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Pannarano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Calvi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Sant'Agata de' Goti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Baselice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Apice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Castelfranco in Miscano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Castelvetere in Val Fortore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Castelpagano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Montefalcone di Val Fortore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Morcone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Casalduni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "San Bartolomeo in Galdo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "San Marco dei Cavoti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Apollosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Amorosi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Cerreto Sannita",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Cusano Mutri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Guardia Sanframondi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Solopaca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Castelvenere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Vitulano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "82100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1701,
+    "state_code": "BN",
+    "locality_name": "Benevento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Capriglia Irpina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Altavilla Irpina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Cervinara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Mercogliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Ospedaletto d'Alpinolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Pietrastornina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Roccabascerana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Rotondi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "San Martino Valle Caudina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Aiello del Sabato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Avella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Baiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Lauro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Monteforte Irpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Montoro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Mugnano del Cardinale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Serino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Solofra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Greci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Ariano Irpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Bonito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Casalbore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Grottaminarda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Mirabella Eclano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Montecalvo Irpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Montemiletto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Pratola Serra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Andretta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Aquilonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Atripalda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Bagnoli Irpino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Bisaccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Calitri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Lacedonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Lioni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Montella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Monteverde",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Parolise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Nusco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Paternopoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Sant'Andrea di Conza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Sant'Angelo dei Lombardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Sturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Teora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Torella dei Lombardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Trevico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Vallata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "83100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1692,
+    "state_code": "AV",
+    "locality_name": "Avellino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Atrani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Amalfi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Angri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Cava de' Tirreni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Nocera Inferiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Nocera Superiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Pagani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Positano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Scafati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Vietri sul Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Aquara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Buccino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Campagna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Contursi Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Eboli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Postiglione",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sant'Angelo a Fasanella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Serre",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sicignano degli Alburni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Atena Lucana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Auletta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Buonabitacolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Montesano sulla Marcellana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Padula",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Polla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sala Consilina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sant'Arsenio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sassano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Teggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Alfano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Acerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Agropoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Albanella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Altavilla Silentina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Ascea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Capaccio Paestum",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Castellabate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Castel San Lorenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Cuccaro Vetere",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Centola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Ceraso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Cicerale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Felitto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Gioi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Laurino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Camerota",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Moio della Civitella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Ogliastro Cilento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Olevano sul Tusciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Piaggine",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Pisciotta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Santa Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Pollica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Roccadaspide",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Rofrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sapri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sessa Cilento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Stio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Torchiara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Torre Orsaia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Vallo della Lucania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Vibonati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Calvanico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Baronissi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Bracigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Castel San Giorgio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Fisciano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Mercato San Severino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Roccapiemonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Sarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Siano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Castiglione del Genovesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Battipaglia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Bellizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Giffoni Valle Piana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Montecorvino Rovella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84098",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Pontecagnano Faiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84099",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "San Cipriano Picentino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "84135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1720,
+    "state_code": "SA",
+    "locality_name": "Salerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Abriola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Acerenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Corleto Perticara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Genzano di Lucania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Laurenzana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Oppido Lucano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Pietragalla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Tolve",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Trivigno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Atella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Avigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Barile",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Forenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Lavello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Melfi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Palazzo San Gervasio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Rapolla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Rionero in Vulture",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Venosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Calvera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Castelsaraceno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Chiaromonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Episcopia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Fardella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Noepoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Roccanova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Sant'Arcangelo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Senise",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Spinoso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Castelluccio Inferiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Lagonegro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Latronico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Lauria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Maratea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Moliterno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Rotonda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Trecchina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Balvano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Bella",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Marsico Nuovo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Montemurro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Muro Lucano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Picerno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Ruoti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Tramutola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Vietri di Potenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Viggiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "85100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1697,
+    "state_code": "PZ",
+    "locality_name": "Potenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Busso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Baranello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Cercemaggiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Gambatesa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Guardiaregia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Jelsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Riccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Sepino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Vinchiaturo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Campochiaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Bojano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Limosano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Montagano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Petrella Tifernina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Ripalimosani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Salcito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "San Massimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Torella del Sannio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Trivento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Acquaviva Collecroce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Castelmauro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Montecilfone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Montefalcone nel Sannio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Guglionesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Larino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Montenero di Bisaccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Palata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Petacciato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Termoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Campolieto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Bonefro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Campomarino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Casacalenda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Colletorto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Portocannone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "San Martino in Pensilis",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Santa Croce di Magliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Sant'Elia a Pianisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Ururi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Conca Casale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Castel San Vincenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Cerro al Volturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Colli a Volturno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Filignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Monteroduni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Pozzilli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Sesto Campano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Venafro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86080",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Acquaviva d'Isernia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86081",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Agnone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86082",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Capracotta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86083",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Carovilli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86084",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Forlì del Sannio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86085",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Pietrabbondante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86086",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Poggio Sannita",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86087",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Rionero Sannitico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86088",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "San Pietro Avellana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86089",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Vastogirardi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86090",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Castelpetroso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86091",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Bagnoli del Trigno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86092",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Cantalupo nel Sannio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86093",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Carpinone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86094",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Civitanova del Sannio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86095",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Frosolone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86096",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Macchiagodena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86097",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Chiauci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1721,
+    "state_code": "CB",
+    "locality_name": "Campobasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "86170",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1789,
+    "state_code": "IS",
+    "locality_name": "Isernia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Acquaformosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Cassano all'Ionio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Castrovillari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Fagnano Castello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Laino Borgo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Laino Castello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Morano Calabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Roggiano Gravina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Marco Argentano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Spezzano Albanese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Acquappesa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Belvedere Marittimo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Cetraro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Diamante",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Fuscaldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Mormanno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Paola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Praia a Mare",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Scalea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Belsito",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Aiello Calabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Amantea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Belmonte Calabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Grimaldi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Lago",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Rende",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Fili",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Lucido",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Altilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Acri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Altomonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Bisignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Cerisano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Dipignano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Montalto Uffugo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Pietro in Guarano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Santa Sofia d'Epiro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Bianchi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Aprigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Celico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Rogliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Giovanni in Fiore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Santo Stefano di Rogliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Scigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Spezzano della Sila",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Casali del Manco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Bocchigliero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Campana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Cariati",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Corigliano-Rossano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Longobucco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "San Demetrio Corone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Albidona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Amendolara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Francavilla Marittima",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Oriolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Rocca Imperiale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Trebisacce",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Villapiana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "87100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1742,
+    "state_code": "CS",
+    "locality_name": "Cosenza",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Cortale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Borgia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Curinga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Girifalco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Maida",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Amato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Decollatura",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Falerna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Marcellinara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Gimigliano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Lamezia Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Nocera Terinese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Soveria Mannelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Amaroni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Cropani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Sersale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Albi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Tiriolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Argusto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Cardinale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Chiaravalle Centrale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Guardavalle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Cenadi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Soverato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Squillace",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Botricello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1728,
+    "state_code": "CZ",
+    "locality_name": "Catanzaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88811",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Cirò Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Crucoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Cirò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Melissa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Strongoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Carfizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Pallagorio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88819",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Verzino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Rocca di Neto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Casabona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Umbriatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Belvedere di Spinello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88825",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Savelli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "San Mauro Marchesato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Santa Severina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Caccuri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Castelsilano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88835",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Roccabernarda",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88836",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Cotronei",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88837",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Petilia Policastro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88838",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Mesoraca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Isola di Capo Rizzuto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Cutro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "88900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1754,
+    "state_code": "KR",
+    "locality_name": "Crotone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Molochio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bagnara Calabra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Delianuova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Gioia Tauro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Oppido Mamertina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Palmi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Rizziconi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "San Giorgio Morgeto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Villa San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Anoia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Cinquefrondi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Cittanova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Laureana di Borrello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Polistena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Rosarno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "San Ferdinando",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Sant'Eufemia d'Aspromonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Seminara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Taurianova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Africo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Ardore",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bianco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bova",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bovalino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bova Marina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Brancaleone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Palizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Platì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Agnana Calabra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Caulonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Gioiosa Ionica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Grotteria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Locri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Mammola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Marina di Gioiosa Ionica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Roccella Ionica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Siderno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Stilo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Calanna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89052",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Campo Calabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Galatro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Santa Cristina d'Aspromonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Santo Stefano in Aspromonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Scilla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Bagaladi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Melito di Porto Salvo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Montebello Jonico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Motta San Giovanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "San Lorenzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5635,
+    "state_code": "RC",
+    "locality_name": "Reggio di Calabria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89812",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Pizzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89813",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Polia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89814",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Filadelfia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89815",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Francavilla Angitola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89816",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Cessaniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89817",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Briatico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89818",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Capistrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89819",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Monterosso Calabro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89821",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "San Nicola da Crissa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89822",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Brognaturo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89823",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Fabrizia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89824",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Nardodipace",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89831",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Gerocarne",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89832",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Acquaro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89833",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Dinami",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89834",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Pizzoni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89841",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Filandari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89842",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "San Calogero",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89843",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Filogaso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89844",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Limbadi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89851",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Francica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89852",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Mileto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89853",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "San Gregorio d'Ippona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89861",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Parghelia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89862",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Drapia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89863",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Joppolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89864",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Spilinga",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89866",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Ricadi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89867",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Zaccanopoli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89868",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Zambrone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "89900",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1737,
+    "state_code": "VV",
+    "locality_name": "Vibo Valentia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Altavilla Milicia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Bagheria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Caccamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Castelbuono",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Casteldaccia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Cefalù",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Collesano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Santa Flavia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Termini Imerese",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Trabia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Alimena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Alia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Caltavuturo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Ciminna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Gangi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Lercara Friddi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Petralia Soprana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Petralia Sottana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Polizzi Generosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Valledolmo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Altofonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Belmonte Mezzagno",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Bisacquino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Chiusa Sclafani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Corleone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Marineo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Misilmeri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Piana degli Albanesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Prizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Villabate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Capaci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Balestrate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Borgetto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Camporeale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Carini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Cinisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Monreale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Partinico",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "San Giuseppe Jato",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Terrasini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Ustica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "90151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1668,
+    "state_code": "PA",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "San Vito Lo Capo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Alcamo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Buseto Palizzolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Calatafimi-Segesta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Castellammare del Golfo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Custonaci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Erice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Pantelleria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Salemi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Valderice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Petrosino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Campobello di Mazara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Castelvetrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Favignana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Gibellina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Marsala",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Mazara del Vallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Paceco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Partanna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Santa Ninfa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "91100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1733,
+    "state_code": "TP",
+    "locality_name": "Trapani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Alessandria della Rocca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Cattolica Eraclea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Cianciana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Menfi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Porto Empedocle",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Raffadali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Ribera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Sambuca di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Santa Margherita di Belice",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Sciacca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Camastra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Aragona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Cammarata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Campobello di Licata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Canicattì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Casteltermini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Favara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Licata",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Naro",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Ravanusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Lampedusa e Linosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "92100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1727,
+    "state_code": "AG",
+    "locality_name": "Agrigento",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Acquaviva Platani",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Butera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Gela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Mazzarino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Mussomeli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Niscemi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Riesi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "San Cataldo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Santa Caterina Villarmosa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Sommatino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "93100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1718,
+    "state_code": "CL",
+    "locality_name": "Caltanissetta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Aidone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Agira",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Barrafranca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Leonforte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Nicosia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Piazza Armerina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Pietraperzia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Regalbuto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Troina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Valguarnera Caropepe",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "94100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1723,
+    "state_code": "EN",
+    "locality_name": "Enna",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Milo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Calatabiano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Castiglione di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Fiumefreddo di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Giarre",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Linguaglossa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Mascali",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Piedimonte Etneo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Riposto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Zafferana Etnea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Aci Bonaccorsi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Aci Castello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Aci Catena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95024",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Acireale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Aci Sant'Antonio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "San Gregorio di Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Valverde",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Viagrande",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Gravina di Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Adrano",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Belpasso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Biancavilla",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Bronte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Maletto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Randazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "San Giovanni la Punta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Santa Maria di Licodia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Trecastagni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Camporotondo Etneo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Caltagirone",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Grammichele",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Militello in Val di Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Mineo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Misterbianco",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Palagonia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Paternò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Scordia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Vizzini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "95131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5629,
+    "state_code": "CT",
+    "locality_name": "Catania",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Buccheri",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Augusta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Avola",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Carlentini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Floridia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Francofonte",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Lentini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Noto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Pachino",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Rosolini",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "96100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1667,
+    "state_code": "SR",
+    "locality_name": "Siracusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97010",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Giarratana",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97011",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Acate",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97012",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Chiaramonte Gulfi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97013",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Comiso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97014",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Ispica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97015",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Modica",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97016",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Pozzallo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97017",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Santa Croce Camerina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97018",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Scicli",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97019",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Vittoria",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "97100",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 1729,
+    "state_code": "RG",
+    "locality_name": "Ragusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98020",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Alì",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98021",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Alì Terme",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98022",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Fiumedinisi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98023",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Furci Siculo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98025",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Itala",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98026",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Nizza di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98027",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Roccalumera",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98028",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Santa Teresa di Riva",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98029",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Scaletta Zanclea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98030",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Antillo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98031",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Capizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98032",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Casalvecchio Siculo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98033",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Cesarò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98034",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Francavilla di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98035",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Giardini-Naxos",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98036",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Graniti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98037",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Letojanni",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98038",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Savoca",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98039",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Taormina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98040",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Condrò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98041",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Monforte San Giorgio",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98042",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Pace del Mela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98043",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Rometta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98044",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "San Filippo del Mela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98045",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "San Pier Niceto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98046",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Santa Lucia del Mela",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98047",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Saponara",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98048",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Spadafora",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98049",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Villafranca Tirrena",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98050",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Fondachelli-Fantina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98051",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Barcellona Pozzo di Gotto",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98053",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Castroreale",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98054",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Furnari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98055",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Lipari",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98056",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Mazzarrà Sant'Andrea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98057",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Milazzo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98058",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Novara di Sicilia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98059",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Rodì Milici",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98060",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Basicò",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98061",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Brolo",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98062",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Ficarra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98063",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Gioiosa Marea",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98064",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Librizzi",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98065",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Montalbano Elicona",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98066",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Patti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98067",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Raccuja",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98068",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "San Piero Patti",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98069",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Sinagra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98070",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Acquedolci",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98071",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Capo d'Orlando",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98072",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Caronia",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98073",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Mistretta",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98074",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Naso",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98075",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "San Fratello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98076",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Sant'Agata di Militello",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98077",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Santo Stefano di Camastra",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98078",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Tortorici",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98079",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Tusa",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98121",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98122",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98123",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98124",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98125",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98126",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98127",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98128",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98129",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98130",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98131",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98132",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98133",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98134",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98135",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98136",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98137",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98138",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98139",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98140",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98141",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98142",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98143",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98144",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98145",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98146",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98147",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98148",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98149",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98150",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98151",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98152",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98153",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98154",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98155",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98156",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98157",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98158",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98159",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98160",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98161",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98162",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98163",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98164",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98165",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98166",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98167",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  },
+  {
+    "code": "98168",
+    "country_id": 107,
+    "country_code": "IT",
+    "state_id": 5632,
+    "state_code": "ME",
+    "locality_name": "Messina",
+    "type": "full",
+    "source": "istat"
+  }
+]


### PR DESCRIPTION
## Summary

Adds Italian postcodes via the matteocontrini/comuni-json mirror of Istat's official commune list with CAP.

1. **`bin/scripts/sync/import_italy_postcodes.py`** — pipeline expanding each commune's `cap[]` array to one record per (cap, commune), picking first-alphabetical commune per unique CAP. State resolution by sigla → state.iso2 with one alias bridge (Aosta `AO` → `23`).
2. **`contributions/postcodes/IT.json`** — **4,678 unique CAPs** across all 7,904 comuni, **100% state_id resolution**.

## Multi-CAP cities

| City | CAPs |
|---|---|
| Rome | 82 |
| Venice | 56 |
| Messina | 48 |
| Genoa | 47 |
| Milan | 42 |

Each CAP gets one record pointing to the canonical commune (matches the Tier-4 "one row per code" contract from #1398).

## Validation (zero errors across 4,678 records)

| Check | Result |
|---|---|
| Records | 4,678 |
| `state_id` resolved | **100%** |
| Codes matching `^(\d{5})$` | ✅ |
| FK resolution | ✅ |
| `state_code` ↔ `state.iso2` agreement | ✅ |
| No auto-managed fields | ✅ |

## License

- Upstream: **Istat** (CC-BY 3.0)
- Mirror: `github.com/matteocontrini/comuni-json`
- Each row: `source: "istat"`

## Cumulative postcode coverage after this lands

~223,000 postcode rows across 23 countries.

Refs: #1039