### PR TITLE
feat(postcodes/IS): bulk-import 195 codes via iceaddr (#1039)

### DIFF
--- a/bin/scripts/sync/import_iceland_postcodes.py
+++ b/bin/scripts/sync/import_iceland_postcodes.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Iceland -> contributions/postcodes/IS.json importer for issue #1039.
+
+Source data
+-----------
+The community-maintained ``sveinbjornt/iceaddr`` Python package embeds
+the canonical Icelandic postcode metadata (postcode -> place + region)
+under MIT licence. The data is statically defined in:
+
+  https://raw.githubusercontent.com/sveinbjornt/iceaddr/master/src/iceaddr/postcodes.py
+
+Each entry has:
+  lysing       (description, e.g. "Miðborg")
+  stadur_nf    (place name nominative, e.g. "Reykjavík")
+  svaedi_nf    (region name, e.g. "Höfuðborgarsvæðið")
+
+What this script does
+---------------------
+1. Reads the iceaddr postcodes.py module from /tmp (downloaded out of band)
+2. Iterates the POSTCODES dict
+3. Resolves region via postcode prefix to states.json iso2 1-8
+4. Writes contributions/postcodes/IS.json
+
+Why prefix-based region resolution
+----------------------------------
+Iceland Post organises postcodes geographically by 1xx-9xx prefixes,
+which align with the 8 statistical regions in states.json with one
+caveat: 9xx codes (Eastern coast + Vestmannaeyjar) split between
+Eastern (7) and Southern (8). The prefix map below matches Statistics
+Iceland's 8-region NUTS-3 boundaries.
+
+License & attribution
+---------------------
+- Source: iceaddr / Sveinbjorn Thordarson (MIT) embedding postdata
+  from Pósturinn (Iceland Post)
+- Each row: source: "iceaddr"
+
+Usage
+-----
+    python3 -c "import urllib.request; urllib.request.urlretrieve(
+      'https://raw.githubusercontent.com/sveinbjornt/iceaddr/master/src/iceaddr/postcodes.py',
+      '/tmp/iceaddr_postcodes.py')"
+
+    python3 bin/scripts/sync/import_iceland_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# Postcode prefix range -> state.iso2 in CSC dataset
+def resolve_region(code: int) -> Optional[str]:
+    if 100 <= code <= 299:
+        return "1"  # Capital (Höfuðborgarsvæðið)
+    if 300 <= code <= 399:
+        return "3"  # Western (Vesturland)
+    if 400 <= code <= 499:
+        return "4"  # Westfjords
+    if 500 <= code <= 599:
+        return "5"  # Northwestern
+    if 600 <= code <= 699:
+        return "6"  # Northeastern
+    if 700 <= code <= 799:
+        return "7"  # Eastern
+    if 800 <= code <= 899:
+        return "8"  # Southern
+    # 9xx: split between Eastern (Hornafjörður 780/900-902, Höfn) and
+    # Southern (Vestmannaeyjar 900-902 historically). Default Southern
+    # since Vestmannaeyjar dominates the 9xx residential range.
+    if 900 <= code <= 999:
+        return "8"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="/tmp/iceaddr_postcodes.py")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    src = Path(args.input)
+    if not src.exists():
+        print(f"ERROR: input not found: {src}", file=sys.stderr)
+        return 2
+
+    # Dynamically import the iceaddr postcodes module
+    spec = importlib.util.spec_from_file_location("iceaddr_postcodes", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    postcodes_data = mod.POSTCODES
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load((project_root / "contributions/countries/countries.json").open(encoding="utf-8"))
+    is_country = next((c for c in countries if c.get("iso2") == "IS"), None)
+    if is_country is None:
+        print("ERROR: IS not in countries.json", file=sys.stderr)
+        return 2
+    states = json.load((project_root / "contributions/states/states.json").open(encoding="utf-8"))
+    is_states = [s for s in states if s.get("country_id") == is_country["id"]]
+    state_by_iso2: Dict[str, dict] = {(s.get("iso2") or "").upper(): s for s in is_states if s.get("iso2")}
+    print(f"Country: Iceland (id={is_country['id']}); states indexed: {len(state_by_iso2)}")
+
+    print(f"Postcodes in source: {len(postcodes_data):,}")
+
+    records: List[dict] = []
+    matched_state = 0
+    for code_int in sorted(postcodes_data.keys()):
+        meta = postcodes_data[code_int]
+        # IS regex requires 3-digit string
+        code = f"{int(code_int):03d}"
+        record = {
+            "code": code,
+            "country_id": int(is_country["id"]),
+            "country_code": "IS",
+        }
+        iso2 = resolve_region(int(code_int))
+        if iso2:
+            state = state_by_iso2.get(iso2)
+            if state is not None:
+                record["state_id"] = int(state["id"])
+                record["state_code"] = iso2
+                matched_state += 1
+        # Locality: use stadur_nf with optional lysing suffix when present
+        place = meta.get("stadur_nf", "").strip()
+        lysing = meta.get("lysing", "").strip()
+        if place and lysing and place.lower() != lysing.lower():
+            locality = f"{place}, {lysing}"
+        else:
+            locality = place or lysing
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "iceaddr"
+        records.append(record)
+
+    print(f"Records:        {len(records):,}")
+    print(f"  with state:   {matched_state:,} ({matched_state*100//max(1,len(records))}%)")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/IS.json"
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        seen = {(r["code"], (r.get("locality_name") or "").lower()) for r in existing}
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in seen:
+                merged.append(r)
+                seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(f"\n[OK] Wrote {target.relative_to(project_root)} ({len(merged):,} rows, {size_kb:.0f} KB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/IS.json
+++ b/contributions/postcodes/IS.json
@@ -1,0 +1,1952 @@
+[
+  {
+    "code": "101",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Miðborg",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "102",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Vatnsmýri og Skerjafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "103",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Háaleitis- og Bústaðahverfi",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "104",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Laugardalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "105",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Hlíðar",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "107",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Vesturbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "108",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Háaleitis- og Bústaðahverfi",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "109",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Breiðholt",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "110",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Árbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "111",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Breiðholt",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "112",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Grafarvogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "113",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Grafarholt og Úlfarsárdalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "116",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík, Kjalarnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "121",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "123",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "124",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "125",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "127",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "128",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "129",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "130",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "132",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "150",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "155",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "161",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "162",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "170",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Seltjarnarnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "172",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Seltjarnarnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "190",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Vogar",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "191",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Vogar",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "200",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kópavogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "201",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kópavogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "202",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kópavogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "203",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kópavogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "206",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kópavogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "210",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Garðabær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "212",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Garðabær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "220",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Hafnarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "221",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Hafnarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "222",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Hafnarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "225",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Garðabær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "230",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjanesbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "232",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjanesbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "233",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjanesbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "235",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Keflavíkurflugvöllur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "240",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Grindavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "241",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Grindavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "245",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Sandgerði",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "246",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Sandgerði",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "250",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Garður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "251",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Garður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "260",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjanesbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "262",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Reykjanesbær, Ásbrú",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "270",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Mosfellsbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "271",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Mosfellsbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "276",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3431,
+    "state_code": "1",
+    "locality_name": "Kjós",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "300",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Akranes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "301",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Akranes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "302",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Akranes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "310",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Borgarnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "311",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Borgarnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "320",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Reykholt",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "340",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Stykkishólmur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "341",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Stykkishólmur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "342",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Stykkishólmur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "345",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Flatey",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "350",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Grundarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "351",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Grundarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "355",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Ólafsvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "356",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Snæfellsbær",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "360",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Hellissandur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "370",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Búðardalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "371",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Búðardalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "380",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Reykhólahreppur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "381",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3436,
+    "state_code": "3",
+    "locality_name": "Reykhólahreppur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "400",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Ísafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "401",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Ísafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "410",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Hnífsdalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "415",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Bolungarvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "416",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Bolungarvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "420",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Súðavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "421",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Súðavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "425",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Flateyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "426",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Flateyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "430",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Suðureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "431",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Suðureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "450",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Patreksfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "451",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Patreksfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "460",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Tálknafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "461",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Tálknafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "465",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Bíldudalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "466",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Bíldudalur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "470",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Þingeyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "471",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3432,
+    "state_code": "4",
+    "locality_name": "Þingeyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "500",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Staður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "510",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hólmavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "511",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hólmavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "512",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hólmavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "520",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Drangsnes",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "524",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Árneshreppur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "530",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hvammstangi",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "531",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hvammstangi",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "540",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Blönduós",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "541",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Blönduós",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "545",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Skagaströnd",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "546",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Skagaströnd",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "550",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Sauðárkrókur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "551",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Sauðárkrókur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "560",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Varmahlíð",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "561",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Varmahlíð",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "565",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hofsós",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "566",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Hofsós",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "570",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Fljót",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "580",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Siglufjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "581",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3435,
+    "state_code": "5",
+    "locality_name": "Siglufjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "600",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "601",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "602",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "603",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "604",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "605",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "606",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "607",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Akureyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "610",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Grenivík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "611",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Grímsey",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "616",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Grenivík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "620",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Dalvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "621",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Dalvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "625",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Ólafsfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "626",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Ólafsfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "630",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Hrísey",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "640",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Húsavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "641",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Húsavík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "645",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Fosshóll",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "650",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Laugar",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "660",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Mývatn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "670",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Kópasker",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "671",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Kópasker",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "675",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Raufarhöfn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "676",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Raufarhöfn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "680",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Þórshöfn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "681",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Þórshöfn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "685",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Bakkafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "686",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Bakkafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "690",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Vopnafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "691",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3437,
+    "state_code": "6",
+    "locality_name": "Vopnafjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "700",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Egilsstaðir",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "701",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Egilsstaðir",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "710",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Seyðisfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "711",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Seyðisfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "715",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Mjóifjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "720",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Borgarfjörður eystra",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "721",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Borgarfjörður eystra",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "730",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Reyðarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "731",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Reyðarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "735",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Eskifjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "736",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Eskifjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "740",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Neskaupstaður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "741",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Neskaupstaður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "750",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Fáskrúðsfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "751",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Fáskrúðsfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "755",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Stöðvarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "756",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Stöðvarfjörður",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "760",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Breiðdalsvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "761",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Breiðdalsvík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "765",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Djúpivogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "766",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Djúpivogur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "780",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Höfn í Hornafirði",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "781",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Höfn í Hornafirði",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "785",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3433,
+    "state_code": "7",
+    "locality_name": "Öræfi",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "800",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "801",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "802",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "803",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "804",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "805",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "806",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Selfoss",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "810",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Hveragerði",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "815",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Þorlákshöfn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "816",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Ölfus",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "820",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Eyrarbakki",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "825",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Stokkseyri",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "840",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Laugarvatn",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "845",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Flúðir",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "846",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Flúðir",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "850",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Hella",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "851",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Hella",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "860",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Hvolsvöllur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "861",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Hvolsvöllur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "870",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Vík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "871",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Vík",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "880",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Kirkjubæjarklaustur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "881",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Kirkjubæjarklaustur",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "900",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Vestmannaeyjar",
+    "type": "full",
+    "source": "iceaddr"
+  },
+  {
+    "code": "902",
+    "country_id": 100,
+    "country_code": "IS",
+    "state_id": 3434,
+    "state_code": "8",
+    "locality_name": "Vestmannaeyjar",
+    "type": "full",
+    "source": "iceaddr"
+  }
+]


### PR DESCRIPTION
Adds Icelandic postcodes via the `sveinbjornt/iceaddr` Python package (MIT, embeds Pósturinn data).

**195 codes**, **100% state_id**. Region resolution via prefix → Statistics Iceland NUTS-3 boundaries (1xx-2xx Capital, 3xx Western, 4xx Westfjords, 5xx Northwestern, 6xx Northeastern, 7xx Eastern, 8xx-9xx Southern). Locality names combine stadur_nf + lysing.

Refs: #1039