### PR TITLE
feat(postcodes/CO): bulk-import 3,676 Colombia postcodes via 4-72 (#1039)

### DIFF
--- a/bin/scripts/sync/import_colombia_postcodes.py
+++ b/bin/scripts/sync/import_colombia_postcodes.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Colombia -> contributions/postcodes/CO.json importer for issue #1039.
+
+Source data
+-----------
+The community ``JohaAlarcon/Load_postal_code`` repository ships the
+official Colombian postcode catalogue published by 4-72 (Servicios
+Postales Nacionales). Each row has:
+
+  cod_departamento;cod_municipio;cod_postal;limite
+
+- ``cod_departamento`` is the DANE 2-digit department code
+- ``cod_municipio`` is the DANE 3-digit municipality code
+- ``cod_postal`` is the 6-digit national postcode
+- ``limite`` is a free-text boundary description (street-level)
+
+Source URL: https://raw.githubusercontent.com/JohaAlarcon/Load_postal_code/master/C_digos_Postales_Nacionales.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked in the harness)
+2. Maps DANE department code -> CSC ``states.json`` iso2 (3-letter)
+3. Emits one record per (cod_postal, cod_municipio) pair
+4. Writes contributions/postcodes/CO.json idempotently
+
+The ``limite`` field is a street-level boundary description and not a
+human-friendly locality name (and arrives double-encoded in the source
+file); it is intentionally not surfaced as ``locality_name``.
+
+License & attribution
+---------------------
+- Source: 4-72 (Servicios Postales Nacionales) via JohaAlarcon mirror
+- Each row: source: "4-72-via-JohaAlarcon"
+
+Usage
+-----
+    python3 bin/scripts/sync/import_colombia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/JohaAlarcon/Load_postal_code/"
+    "master/C_digos_Postales_Nacionales.csv"
+)
+
+# DANE department code (2 digits) -> CSC states.json iso2 (3 letters).
+# Mapping derived from DANE División Político-Administrativa codes.
+DANE_TO_ISO2: Dict[str, str] = {
+    "05": "ANT",  # Antioquia
+    "08": "ATL",  # Atlántico
+    "11": "DC",   # Bogotá D.C.
+    "13": "BOL",  # Bolívar
+    "15": "BOY",  # Boyacá
+    "17": "CAL",  # Caldas
+    "18": "CAQ",  # Caquetá
+    "19": "CAU",  # Cauca
+    "20": "CES",  # Cesar
+    "23": "COR",  # Córdoba
+    "25": "CUN",  # Cundinamarca
+    "27": "CHO",  # Chocó
+    "41": "HUI",  # Huila
+    "44": "LAG",  # La Guajira
+    "47": "MAG",  # Magdalena
+    "50": "MET",  # Meta
+    "52": "NAR",  # Nariño
+    "54": "NSA",  # Norte de Santander
+    "63": "QUI",  # Quindío
+    "66": "RIS",  # Risaralda
+    "68": "SAN",  # Santander
+    "70": "SUC",  # Sucre
+    "73": "TOL",  # Tolima
+    "76": "VAC",  # Valle del Cauca
+    "81": "ARA",  # Arauca
+    "85": "CAS",  # Casanare
+    "86": "PUT",  # Putumayo
+    "88": "SAP",  # San Andrés, Providencia y Santa Catalina
+    "91": "AMA",  # Amazonas
+    "94": "GUA",  # Guainía
+    "95": "GUV",  # Guaviare
+    "97": "VAU",  # Vaupés
+    "99": "VID",  # Vichada
+}
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local CSV (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8", errors="replace")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    co_country = next((c for c in countries if c.get("iso2") == "CO"), None)
+    if co_country is None:
+        print("ERROR: CO not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(co_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    co_states = [s for s in states if s.get("country_id") == co_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        (s.get("iso2") or "").upper(): s for s in co_states if s.get("iso2")
+    }
+    print(f"Country: Colombia (id={co_country['id']}); states indexed: {len(co_states)}")
+
+    reader = csv.DictReader(io.StringIO(text), delimiter=";")
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        code = (row.get("cod_postal") or "").strip()
+        if not code:
+            continue
+        # Source occasionally drops the leading zero (5-digit) or carries a
+        # spurious extra zero (7-digit). Normalise to canonical 6-digit form.
+        if code.isdigit():
+            if len(code) == 5:
+                code = "0" + code
+            elif len(code) == 7 and code.startswith("0"):
+                code = code[1:]
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        muni = (row.get("cod_municipio") or "").strip()
+        key = (code, muni)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(co_country["id"]),
+            "country_code": "CO",
+        }
+        dept = (row.get("cod_departamento") or "").strip().zfill(2)
+        iso2 = DANE_TO_ISO2.get(dept)
+        if iso2:
+            state = state_by_iso2.get(iso2)
+            if state is not None:
+                record["state_id"] = int(state["id"])
+                record["state_code"] = iso2
+                matched_state += 1
+            else:
+                skipped_no_state += 1
+        else:
+            skipped_no_state += 1
+
+        record["type"] = "full"
+        record["source"] = "4-72-via-JohaAlarcon"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/CO.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/CO.json
+++ b/contributions/postcodes/CO.json
@@ -1,0 +1,33086 @@
+[
+  {
+    "code": "050001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050012",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050013",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050014",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050015",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050016",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050022",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050023",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050024",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050025",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050026",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050032",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050033",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050034",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050035",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050036",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050042",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050043",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050044",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "050048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051052",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051053",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051054",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051838",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051858",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "051868",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052418",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052438",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052458",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052803",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052806",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052828",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052856",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "052857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053418",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053838",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "053857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054438",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054828",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054829",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054838",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "054850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055411",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055412",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055413",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055421",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055422",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055438",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055858",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "055867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056438",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056470",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056477",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056478",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056828",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056838",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056858",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "056868",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057418",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057438",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057458",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057828",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057829",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057838",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057839",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057841",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057858",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057868",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057869",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057870",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057877",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "057878",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2890,
+    "state_code": "ANT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080012",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080013",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080014",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080015",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080016",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "080020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "081067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "082067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "083087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "084087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "085068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110111",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110121",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110131",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110141",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110151",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110211",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110221",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110231",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110311",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110321",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110411",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110421",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110431",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110441",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110571",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110611",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110621",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110711",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110721",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110731",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110741",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110811",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110821",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110831",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110841",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110851",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110861",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110871",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110881",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110911",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110921",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "110931",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111071",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111111",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111121",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111131",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111141",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111151",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111156",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111161",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111166",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111171",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111176",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111211",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111221",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111311",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111321",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111411",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111611",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111621",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111631",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111711",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111811",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111821",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111831",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111841",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111911",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111921",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111931",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111941",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111951",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111961",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111971",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "111981",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "112011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "112021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "112031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "112041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4921,
+    "state_code": "DC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130012",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130013",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130014",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130015",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "130547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "131567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132512",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132519",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "132568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "133567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "134548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "135067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2893,
+    "state_code": "BOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150208",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150268",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150408",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150449",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150461",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150462",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150469",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150477",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150480",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150487",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150488",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150680",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150687",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150880",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "150887",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151280",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151287",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151609",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151628",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "151847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152210",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152211",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152218",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152219",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152230",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152237",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152250",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152257",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152268",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152280",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152287",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152288",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152429",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152469",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152680",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152687",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "152867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153210",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153248",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153268",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153280",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153287",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153408",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153480",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153487",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153630",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153637",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153648",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153649",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153668",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153808",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153809",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153880",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "153887",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154268",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154269",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154609",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154648",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154670",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154677",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154680",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154687",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154808",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154828",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154880",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "154887",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155208",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155209",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155218",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "155219",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2903,
+    "state_code": "BOY",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "170017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "171047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "172067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "173069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "174038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "175038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "176048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "177089",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "178057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2887,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "180017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "181067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "182059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "183010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "183017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "183018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "183019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "183027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "184010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "184017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "184018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "184019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "185078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "186078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2891,
+    "state_code": "CAQ",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190559",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190589",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "190597",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "191569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "192579",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193579",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193589",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "193597",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194089",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "194558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "195567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "196068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2884,
+    "state_code": "CAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "200018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "201058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "202058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "203067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "204068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "205078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2899,
+    "state_code": "CES",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "230559",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "231547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232549",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "232559",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "233539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "234539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "235048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2898,
+    "state_code": "COR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250052",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250053",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250054",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250055",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250208",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250210",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250228",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250230",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250237",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250251",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250252",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250257",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250258",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250408",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250418",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250450",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250457",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250618",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250630",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250637",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250808",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250818",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "250848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251208",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251210",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251218",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251230",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251237",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251238",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251250",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251257",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251268",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251428",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251628",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251648",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251808",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251860",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "251867",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252208",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252211",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252212",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252218",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252219",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252230",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252237",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252248",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252250",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252257",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252408",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252431",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252432",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252630",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252637",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252638",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252648",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252650",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252657",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252668",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252810",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252817",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252830",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252837",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252850",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "252857",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253052",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253201",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253207",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253210",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253217",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253220",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253227",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253230",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253237",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253240",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253247",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253250",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253257",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253258",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253260",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253267",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253401",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253407",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253408",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253410",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253417",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253418",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253420",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253427",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253430",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253437",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253440",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253447",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253448",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253449",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253460",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253467",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253468",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253480",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253487",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253601",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253607",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253608",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253610",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253617",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253618",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253620",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253627",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253630",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253637",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253640",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253647",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253648",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253650",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253657",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253658",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253660",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253667",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253801",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253807",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253808",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253820",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253827",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253840",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253847",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "253848",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "254057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2875,
+    "state_code": "CUN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "270078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "271077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "272058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "273078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "274058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "275058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "276078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "277057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "278058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2876,
+    "state_code": "CHO",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "410018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "411088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "412087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "413067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "414068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "415088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "416089",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "417088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "418077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 4871,
+    "state_code": "HUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "440017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "441059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "442001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "442007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "442008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "442009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "443049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "444057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "445047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "446001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "446007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "446008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "446009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "446017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2889,
+    "state_code": "LAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "470017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "472047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "473049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "474068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "475057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "476068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "477058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "478067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2886,
+    "state_code": "MAG",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "500017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "501057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "502059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "503068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "504068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "505048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "506068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "507058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2878,
+    "state_code": "MET",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "520578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521549",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "521569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "522548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "523548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "524588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "525579",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "526568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "527589",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528502",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528503",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528519",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "528568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2897,
+    "state_code": "NAR",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540013",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "540019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "541077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "542058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "543058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "544578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "545558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546552",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "546559",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "547079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "548058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2877,
+    "state_code": "NSA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "630008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "631028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "632087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "633001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "633007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "633008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "633020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "633027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "634001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "634007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "634008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "634020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "634027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2874,
+    "state_code": "QUI",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "660017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "661048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "662037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "663038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "664048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2879,
+    "state_code": "RIS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "680568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681012",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681519",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "681567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682519",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682549",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682559",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682571",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "682578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683071",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683571",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683581",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "683587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684051",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "684557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685521",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685551",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "685569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686561",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "686577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687032",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687033",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687061",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687511",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687519",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687541",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687542",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687549",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687571",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687579",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "687587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2901,
+    "state_code": "SAN",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "700017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "701078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "702078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "703078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "704057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "705079",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "706057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "707057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2902,
+    "state_code": "SUC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730005",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "730588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "731587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "732508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733549",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733590",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "733597",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "734567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735569",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735580",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735587",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735588",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "735589",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2883,
+    "state_code": "TOL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760003",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760004",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760006",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760011",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760012",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760013",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760014",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760015",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760016",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760022",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760023",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760024",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760025",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760026",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760031",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760032",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760033",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760034",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760035",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760036",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760042",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760043",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760044",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760045",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760046",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760502",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760529",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "760557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "761567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762022",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762530",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762540",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "762548",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763021",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763022",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763023",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763041",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763042",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763510",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763518",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763520",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763527",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763528",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763531",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763532",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763533",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763537",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763538",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763539",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763547",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763550",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763557",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763558",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763560",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763567",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763568",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763570",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763577",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763578",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "763579",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764501",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764502",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764503",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764504",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764507",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764508",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764509",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "764517",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2904,
+    "state_code": "VAC",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "810001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "810007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "810008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "810009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "812010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "812017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "812018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "812019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "813010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "813017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "813018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "814058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "815010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "815017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "815018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "816010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2880,
+    "state_code": "ATL",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "816017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "816018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "816019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2881,
+    "state_code": "ARA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "850001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "850002",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "850007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "850008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "850009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851070",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851077",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "851078",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "852058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "853059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "854039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "855058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "856058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2892,
+    "state_code": "CAS",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "860001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "860007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "860008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "861088",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862060",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862068",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862069",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862080",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "862087",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "863001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "863007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "863008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "864001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "864007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "864008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "864009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2896,
+    "state_code": "PUT",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880020",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "880028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2900,
+    "state_code": "SAP",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "910001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "910007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "910008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911030",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "911039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "912010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "912017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "912018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "912019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "913057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "914050",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "914057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "915010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "915017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "915018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "915019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "916017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "916057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "916058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "917010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "917017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "917018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2895,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "940028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "941047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "942010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "942017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "942018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "942057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "943067",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944010",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "944059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2882,
+    "state_code": "GUA",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "950001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "950007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "950008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "950009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "951001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "951007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "951008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "951009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "951017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "952001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "952007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "952008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "952009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "952017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "953018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2888,
+    "state_code": "GUV",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "970001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "970007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "970008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "970009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "971007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "971008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "972007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "972008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "972040",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "972047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "972048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "973001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "973007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "973008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "973047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "973048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2885,
+    "state_code": "VAU",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "990018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991019",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991027",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991028",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991029",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991037",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991038",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991039",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991047",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991048",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991049",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991057",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991058",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "991059",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992001",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992017",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "992018",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "995007",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "995008",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  },
+  {
+    "code": "995009",
+    "country_id": 48,
+    "country_code": "CO",
+    "state_id": 2894,
+    "state_code": "VID",
+    "type": "full",
+    "source": "4-72-via-JohaAlarcon"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 3,676 Colombia postcodes spanning all 33 DANE departments,
sourced from the official 4-72 (Servicios Postales Nacionales)
catalogue distributed via the ``JohaAlarcon/Load_postal_code`` mirror.

- **Coverage**: 100% department resolution (33/33 in states.json).
- **Format**: Canonical 6-digit national code (matches
  ``^(\d{6})$``); a handful of source rows ship with a missing or
  spurious leading zero and are normalised on import.

## Source & licence

- Source URL: https://raw.githubusercontent.com/JohaAlarcon/Load_postal_code/master/C_digos_Postales_Nacionales.csv
- Origin: 4-72 / Servicios Postales Nacionales (Colombian postal
  operator). The catalogue is published for free public reference;
  attribution recorded in the ``source`` column of every row.
- Each row: ``"source": "4-72-via-JohaAlarcon"``

## How it works

- DANE department code (2-digit) is mapped to CSC's 3-letter ``iso2``
  via a hand-curated 33-entry table (e.g. 05 -> ANT, 11 -> DC, 88 -> SAP).
- The free-text ``limite`` column carries street-level boundary
  descriptions (and arrives mojibake-encoded); intentionally not used
  as ``locality_name``.

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 3,676 codes match ``country.postal_code_regex``.
- 100% of records resolve a valid ``state_id`` whose
  ``country_id == 48`` and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``,
  ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)