### PR TITLE
feat(postcodes/PH): bulk-import 1,391 Philippines postcodes via PHLPost (#1039)

### DIFF
--- a/bin/scripts/sync/import_philippines_postcodes.py
+++ b/bin/scripts/sync/import_philippines_postcodes.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Philippines -> contributions/postcodes/PH.json importer for #1039.
+
+Source data
+-----------
+The community ``jayson-panganiban/phzipcodes`` package ships the
+PHLPost catalogue as a nested JSON keyed by Region -> Province ->
+City -> [zip codes]:
+
+    {
+      "Region 1 (Ilocos Region)": {
+        "Pangasinan": {
+          "Alcala": ["2425"],
+          ...
+        },
+        ...
+      },
+      ...
+    }
+
+Source URL: https://raw.githubusercontent.com/jayson-panganiban/phzipcodes/main/phzipcodes/data/ph_zip_codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Walks Region -> Province -> City -> codes; emits one row per
+   ``(zip code, city)`` pair.
+3. Resolves ``state_id`` via case-insensitive province-name match
+   against ``states.json``; STATE_ALIASES handles a handful of source
+   names that carry parenthetical suffixes or use a region label.
+4. Writes contributions/postcodes/PH.json idempotently.
+
+License & attribution
+---------------------
+- Source: jayson-panganiban/phzipcodes; data scraped from PHLPost's
+  publicly published postcode index.
+- Each row: ``source: "phlpost-via-jayson-panganiban"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_philippines_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/jayson-panganiban/phzipcodes/"
+    "main/phzipcodes/data/ph_zip_codes.json"
+)
+
+# Source name (lowercased) -> CSC states.json "name" (case-insensitive)
+STATE_ALIASES: Dict[str, str] = {
+    "metro manila": "National Capital Region (Metro Manila)",
+    "camarines sur (camsur)": "Camarines Sur",
+    "cotabato (north)": "Cotabato",
+    "davao de oro (formerly compostela valley)": "Davao de Oro",
+    # The source feed has a "Samar" entry (Region 8) that maps to
+    # Western Samar (a/k/a Samar Province) — the post-1969 rename of
+    # "Samar" to "Western Samar" is reflected in CSC's iso2 = WSA.
+    "samar": "Western Samar",
+}
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    ph_country = next((c for c in countries if c.get("iso2") == "PH"), None)
+    if ph_country is None:
+        print("ERROR: PH not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(ph_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    ph_states = [s for s in states if s.get("country_id") == ph_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in ph_states}
+    print(f"Country: Philippines (id={ph_country['id']}); states indexed: {len(ph_states)}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for _region, provinces in data.items():
+        if not isinstance(provinces, dict):
+            continue
+        for prov_name, cities in provinces.items():
+            prov_key = prov_name.strip().lower()
+            if not prov_key:
+                continue
+            target_name = STATE_ALIASES.get(prov_key, prov_name).lower()
+            state = state_by_name.get(target_name)
+            if not isinstance(cities, dict):
+                continue
+            for city, codes in cities.items():
+                if not isinstance(codes, list):
+                    continue
+                for raw_code in codes:
+                    code = str(raw_code).strip()
+                    if not code:
+                        continue
+                    if code.isdigit() and len(code) == 3:
+                        code = "0" + code
+                    if not regex.match(code):
+                        skipped_bad_regex += 1
+                        continue
+                    key = (code, (city or "").strip().lower())
+                    if key in seen:
+                        continue
+                    seen.add(key)
+
+                    record: Dict[str, object] = {
+                        "code": code,
+                        "country_id": int(ph_country["id"]),
+                        "country_code": "PH",
+                    }
+                    if state is not None:
+                        record["state_id"] = int(state["id"])
+                        record["state_code"] = state.get("iso2")
+                        matched_state += 1
+                    else:
+                        skipped_no_state += 1
+
+                    if city:
+                        record["locality_name"] = city.strip()
+                    record["type"] = "full"
+                    record["source"] = "phlpost-via-jayson-panganiban"
+                    records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/PH.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/PH.json
+++ b/contributions/postcodes/PH.json
@@ -1,0 +1,13912 @@
+[
+  {
+    "code": "1000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ermita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Quiapo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Intramuros",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Cruz (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Malate",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Paco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sampaloc (East)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Ana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Nicolas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pandacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tondo (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tondo (North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Cruz (North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sampaloc (West)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Mesa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Andres Bukid",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Port Area (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Piñahan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Project 6",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Quezon City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Quezon City CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Botocan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Diliman",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Krus Na Ligas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Malaya",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Old Capitol Site",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sikatuna Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Teachers Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "UP Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Univ. of the Phils. PO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Amihan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Claro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Duyan-duyan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "E. Rodriguez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kamias",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Quirino Dist. (Proj. 2 & 3)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Silangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kamuning",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Langing Handa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Obrero",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Paligsahan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Roxas District",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sacred Heart",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "South Triangle",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Damayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Mariblo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Nayon Kaunlaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Paraiso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Phil-am",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Talayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Alicia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Pag-asa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bungad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Del Monte",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Katipunan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Paltok",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Project 7",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ramon Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sto. Cristo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Veterans Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Apolonio Samson",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Baesa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bahay Toro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Balumbato",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Project 8",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Salumbato",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Unang Sigaw",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "New Era",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pasong Tamo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1108",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Loyola Heights",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1108",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pansol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Buhay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bayanihan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Blue Ridge",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Cubao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Dioquino Zobel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Escopa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Mangga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Marilag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Masagana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Milagrosa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Project 4",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Roque",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Socorro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tagumpay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Villa Maria Clara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Bayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Camp. Aguinaldo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Libis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "St. Ignatius",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Talampas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ugong Norte",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Lipunan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Crame",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Immaculate Concepcion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kaunlaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pinagkaisahan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "St. Martin De Porres",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Damayan Lagi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Horseshoe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kalusugan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kristong Hari",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Mariana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Valencia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Don Manuel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Doña Aurora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Doña Imelda",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Doña Josefa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sto. Nino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tatalon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Gintong Silahis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "La Loma",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Lourdes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maharlika",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Matalahib",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Paang Bundok",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Salvacion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Isidro Labrador",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santa Teresita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sienna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "St. Peter",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Balingasa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Damar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manresa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Masambong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pag-ibig Sa Nayon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagbag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Bartolome",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sangandaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sauyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Talipapa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tandang Sora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Capri",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Gulod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Agustin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santa Monica",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1118",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fairview",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1118",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pasong Putik",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Silangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Matandang Balara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Payatas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1120",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "BF Homes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Commonwealth",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fairview (North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Novaliches Proper",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1122",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fairview (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1123",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Damong Maliit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1125",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Doña Faustina Subd.",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1125",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Nagkaisang Nayon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1126",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Batasan Hills",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1126",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Capitol Hills/Park",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1127",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Holy Spirit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1128",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Culiat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1128",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Vasra",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Makati CPO (Inc, Buendia Up To)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fort Bonifacio Naval Stn.",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Antonio Village (Inc. Malu)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "La Paz-Singkamas-Tejeros",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kasilawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Olympia And Carmona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Valenzuela (Inc. Santiago, San Miguel & Rizal Vill.)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bel-air",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Poblacion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1211",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Guadalupe Viejo (Inc. Palm Vil)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Guadalupe Nuevo (Inc. Visayan)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pinagkaisahan-pitogo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1214",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Cembo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1215",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Rembo (West)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1216",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Rembo (East) & Malapad Na Bato",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1217",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Comembo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1218",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pembo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1219",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Forbes Park (North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1220",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Forbes Park (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1221",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Dasmarinas Village (North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1222",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Dasmarinas Village (South)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1223",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Lorenzo Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1224",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Commercial Center",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1225",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Urdaneta Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1226",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ayala - Paseo De Roxas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1227",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Salcedo Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1228",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Greenbelt",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1229",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Legaspi Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1230",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pio Del Pilar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1231",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pasong Tamo 2000 Up, Ecology V",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1232",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Magallanes Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1233",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bangkal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1234",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1235",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Palanan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pasay City CPO Malibay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1301",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Domestic Airport PO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Rafael",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Roque",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santa Clara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "PICC (Reclamation Area)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manila Bay (Reclamation)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Villamor Airbase",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Caloocan City CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Baesa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Quiteria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Grace Park (East)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "1st Ave. to 7th Ave. - West",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1406",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Grace Park (West)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1407",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "University Hills",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sangandaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1409",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kaunlaran Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1410",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maypajo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1411",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fish Market",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1412",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Isla De Cocomo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kapitbahayan (East)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1420",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kaybiga/Deparo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1421",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagumbong/Pag-asa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1422",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Novaliches North (Camarin North)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1423",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Lilles Ville Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1424",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Capitol Parkland Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1425",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Amparo Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1426",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bankers Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1427",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tala Leprosarium",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1427",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Victory Heights",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1428",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bagong Silang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1440",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Malinta CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1441",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Karuhatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1442",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fortune Vil. - Paso De Blas - Gen. T. De Leon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1443",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Dalandan - West Canumay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1444",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Arkong Bato-Rincon-Pasolo-Malanday-Mabolo-Polo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1445",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Balangkas-Caloong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1446",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Lingunan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1447",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "East Canumay - Lawang Bato Pun",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1448",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Mapulang Lupa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1469",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Valenzuela P.O. Boxes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1470",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Malabon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1471",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Flores",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1472",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Longos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1473",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tonsuya",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1474",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Acacia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1475",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Potrero",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1476",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Araneta Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1477",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maysilo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1478",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santolan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1479",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Muzon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1480",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Dampalit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1485",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Navotas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1489",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tangos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1490",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tanza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Juan CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Greenhills PO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Greenhills North",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Eisenhower-Crame",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1550",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Mandaluyong CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1551",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Vergara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1552",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Shaw Boulevard",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1553",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Phil. Natl. Mental Hospital",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1554",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "East Edsa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1555",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Wack Wack Golf",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1556",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Greenhills South",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1600",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pasig CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1601",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Joaquin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1602",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pinagbuhatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1603",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Kapitolyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1604",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ugong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1605",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ortigas PO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1606",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Caniogan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1607",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maybunga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1608",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Lucia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1609",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1610",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Santolan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1611",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manggahan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1612",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Green Park",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1620",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Aguho",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1621",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sta. Ana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1630",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bicutan Western",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1631",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bicutan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1632",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bicutan Lower",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1633",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bicutan Upper",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1635",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bonifacio Global City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1636",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bay Breeze Exec. Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1637",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tuktukan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1639",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ususan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Parañaque CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tambo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1702",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Baclaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Marina Subd. (Reclamation)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Sto. Nino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ninoy Aquino Int’l. Airport",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pulo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1707",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Antonio Valley 11 & 12",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Multinational Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Merville Park",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Moonwalk",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "South Admiral Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1710",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Executive Heights Subd.",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Better Living Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1712",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Miramar Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1713",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "United Subd.",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Aeropark Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ireneville Ii",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1715",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Antonio Valley I",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1716",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maywood Village Ii",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1717",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manila Memorial Park",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1718",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bf Homes 2",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1719",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ireneville Subdivision I & Ii",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1719",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Maywood I",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1720",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bf Homes 1",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1740",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Las Piñas CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1741",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Remarville Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1742",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pulang Lupa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1742",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Zapote",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1743",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Cut-cut",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1744",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manuyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1745",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Gatchalian Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1746",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Verdant Acres Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1747",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Talon, Moonwalk",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1748",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Manila Doctors Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1749",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Angela Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1750",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Almanza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1751",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "T. S. Cruz Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1752",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Soldiers Hills Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1770",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Muntinlupa CPO",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1771",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bule/Cupang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1772",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Bayanan/Putatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1773",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tunasan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1774",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Susana Heights",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1775",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pearl Heights",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1776",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Poblacion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1777",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Pleasant Village",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1780",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ayala Alabang Subdivision",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1781",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Filinvest Corp. City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1799",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Ayala Alabang P.O. Boxes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Marikina CPO - Sta. Elena - Sto. Niño",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "San Roque - Calumpang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Industrial Valley",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Barangka",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tañong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "J. De La Peña",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Malanday",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Tumana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Concepcion 1",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Nangka",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Parang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Marikina Heights",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1811",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Concepcion 2",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1812",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5324,
+    "state_code": "00",
+    "locality_name": "Fortune",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1850",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "San Mateo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1860",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Rodriguez (Montalban)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1870",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Antipolo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1871",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Mayamot",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1872",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Bagong Nayon (Cogeo)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1874",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Langhaya",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1875",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Mambagat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1880",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Teresa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1900",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Cainta",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1910",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Pililla",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1920",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Taytay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1930",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Angono",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1940",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Binangonan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1950",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Cardona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1960",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Morong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1970",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Baras",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1980",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Tanay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "1990",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1271,
+    "state_code": "RIZ",
+    "locality_name": "Jalajala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Bacolor",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Santa Rita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Guagua",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Sasmuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2005",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Lubao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2006",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Floridablanca",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Basa airbase",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Porac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Angeles City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Mabalacat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Magalang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Arayat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Candaba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "San Simon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Apalit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Masantol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Macabebe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2019",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Minalin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2020",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Santo Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2021",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Mexico",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2022",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2023",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "CSEZ, Clark",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2025",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Santa Cruz, Lubao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2026",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1365,
+    "state_code": "PAM",
+    "locality_name": "Dau, Mabalacat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Limay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Lamao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "FAB (Freefort Area of Bataan)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Bagac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Cabcaben",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Dinalupihan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Hermosa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1344,
+    "state_code": "BAN",
+    "locality_name": "Abucay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Olongapo City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Iba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Botolan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Cabangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "San Felipe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "San Narciso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "San Marcelino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Castillejos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Subic",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Palauig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Candelaria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1297,
+    "state_code": "ZMB",
+    "locality_name": "Sta. Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Tarlac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Gerona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Sta. Ignacia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Mayantoc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "San Clemente",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Camiling",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Paniqui",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Moncada",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "San Manuel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2310",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Anao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2311",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Ramos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2312",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Pura",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2313",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Victoria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2314",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2315",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Capas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2316",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Concepcion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2317",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "Bamban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2318",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1295,
+    "state_code": "TAR",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Sual",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Alaminos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Anda",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Agno",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Mangatarem",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2414",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Urbiztondo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2415",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Aguilar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2419",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Santa Barbara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2420",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Carlos City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2425",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Alcala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2426",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Santo Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2427",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Villasis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2428",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Urdaneta",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2429",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Mapandan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2431",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Jacinto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2432",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Mangaldan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2433",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Fabian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2434",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Sison",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2435",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Pozorrubio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2438",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Manuel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2440",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Santa Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2441",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Rosales",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2443",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Umingan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2444",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Quintin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2445",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Tayug",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2446",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "Natividad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2447",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1364,
+    "state_code": "PAN",
+    "locality_name": "San Nicolas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "San Fernando City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Bauang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Caba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Aringay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Agoo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Santo Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Pugo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Tubao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Naguilian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2512",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Bagulin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "San Gabriel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2514",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2515",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Bacnotan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2516",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Santol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2517",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Balaoan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2518",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Luna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2519",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Bangar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2520",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1317,
+    "state_code": "LUN",
+    "locality_name": "Sudipen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2600",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Baguio City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2601",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "La Trinidad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2602",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Philippine Military Academy (PMA)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2603",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Tuba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2604",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Itogon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2605",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Bokod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2606",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Kabayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2607",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Buguias",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2608",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Mankayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2610",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Bakun",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2611",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Kibungan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2612",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Atok",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2613",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Kapangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2614",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Sablan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2615",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1363,
+    "state_code": "BEN",
+    "locality_name": "Tublay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Vigan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santa Catalina",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2702",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Caoayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Narvacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santa Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "San Esteban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2707",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santiago",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Banayoyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Galimuyod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2710",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Candon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Salcedo (Baugen)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2712",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2713",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Tagudin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2715",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Suyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2716",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Alilem",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2717",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Sugpon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2718",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Cervantes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2719",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Sigay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2720",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Gregorio del Pilar (Concepcion)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2721",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Quirino (Angkaki)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2722",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "San Emilio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2723",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Lidlidda",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2724",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2725",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Nagbukel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2726",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2727",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Bantay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2728",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "San Ildefonso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2729",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Santo Domingo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2730",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Magsingal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2731",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "San Juan (Lapog)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2732",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Cabugao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2733",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1321,
+    "state_code": "ILS",
+    "locality_name": "Sinait",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Bangued",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Dolores",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Lagangilang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Tayum",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Peñarrubia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Bucay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Pidigan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Langiden",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "San Quintin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Manabo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2811",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Villaviciosa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2812",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Pilar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2813",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Luba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2814",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Tubo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2815",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Boliney",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2816",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Daguioman",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2817",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Bucloc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2818",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Sallapadan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2819",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Licuan-Baay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2820",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Malibcong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2821",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Lacub",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2822",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Tineg",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2823",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2824",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Lagayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2825",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "Danglas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2826",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1324,
+    "state_code": "ABR",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2900",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Laoag City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2901",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "San Nicolas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2902",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Paoay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2903",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Currimao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2904",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Badoc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2905",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Pinili",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2906",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Batac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2907",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Marcos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2908",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Banna (formerly Espiritu)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2909",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Nueva Era",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2910",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Solsona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2911",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Carasi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2912",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Piddig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2913",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Dingras",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2914",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Sarrat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2915",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Vintar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2916",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Bacarra",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2917",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Pasuquin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2918",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2919",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Pagudpud",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2920",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Bangui",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2921",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Dumalneg",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "2922",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1298,
+    "state_code": "ILN",
+    "locality_name": "Adams",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Malolos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Paombong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Hagonoy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Calumpit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Plaridel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3005",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Pulilan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3006",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Baliuag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Bustos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "San Rafael",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Doña Remedios Trinidad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "San Ildefonso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Angat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Norzagaray",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Pandi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Guiguinto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Balagtas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Bulacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Bocaue",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3019",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Marilao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3020",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Meycauayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3021",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Obando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3022",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Sta. Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3023",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "San Jose Del Monte",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3024",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Sapang Palay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3025",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1278,
+    "state_code": "BUL",
+    "locality_name": "Cruz Na Daan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Cabanatuan City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Sta. Rosa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "San Leonardo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Peñaranda",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Gen. Tinio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Gapan City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Cabiao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3108",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Jaen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Zaragoza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Aliaga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Licab",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Talavera",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Guimba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Nampicuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Cuyapo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3118",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Talugtog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Muñoz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3120",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Central Luzon State University",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "San Jose City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3122",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Lupao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3123",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Carrangalan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3124",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Pantabangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3125",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Gen. M. Natividad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3126",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Llanera",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3127",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Rizal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3128",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Bongabon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3129",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Laur",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3130",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Fort Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3131",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Gabaldon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3132",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Palayan City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3133",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1360,
+    "state_code": "NUE",
+    "locality_name": "Sto. Domingo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Baler",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Maria Aurora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Dipaculao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Casiguran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Dilasag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Dinalungan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Dingalan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "City of Ilagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3301",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Gamu",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Naguillan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Reina Mercedes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Luna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "City of Cauayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Alicia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Angadanan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Guillermo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Echague",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3310",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3311",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Santiago CIty",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3312",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Cordon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3313",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Jones",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3314",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Agustin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3315",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Cabatuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3316",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Aurora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3317",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Manuel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3318",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Mateo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3319",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Ramon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3320",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Roxas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3321",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Quirino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3322",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3323",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Mallig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3324",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3325",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Tumauini",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3326",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Delfin Albano",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3327",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Sto. Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3328",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Cabagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3329",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Pablo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3330",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Sta. Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3331",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Benito Soliven",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3332",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "San Mariano",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3333",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Maconacon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3334",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Palanan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3335",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Divilacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3336",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1313,
+    "state_code": "ISA",
+    "locality_name": "Dinapigue",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Cabarroguis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Diffun",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Saguday",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Aglipay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Maddela",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1273,
+    "state_code": "QUI",
+    "locality_name": "Nagtipunan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Tuguegarao City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Enrile",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Peñablanca",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Solana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Iguig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Amulung",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Baggao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3507",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Alcala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Gattaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Lal-lo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Camalaniugan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Buguey",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3512",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Sta. Teresita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Gonzaga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3514",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Sta. Ana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3515",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Aparri",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3516",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Ballesteros",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3517",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Abulug",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3518",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Sanchez-Mira",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3519",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Claveria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3520",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Calayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3521",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Santa Praxedes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3522",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Pamplona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3523",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Allacapan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3524",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Lasam",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3525",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Santo Niño",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3526",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Rizal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3527",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Piat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3528",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1279,
+    "state_code": "CAG",
+    "locality_name": "Tuao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3600",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Lagawe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3601",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Banaue",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3602",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Mayoyao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3603",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Hungduan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3604",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Kiangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3605",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Lamut",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3606",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Aguinaldo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3607",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Hingyon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3608",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Alfonso Lista (formerly Potia)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3609",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Tinoc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3610",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1300,
+    "state_code": "IFU",
+    "locality_name": "Asipulo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Bayombong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Ambaguio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3702",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Bambang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Kasibu",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Aritao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Sta. Fe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Dupax del Norte",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3707",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Dupax del Sur",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Kayapa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Solano",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Bagabag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3712",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Diadi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3713",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1358,
+    "state_code": "NUV",
+    "locality_name": "Alfonso Castañeda",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Tabuk City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Balbalan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Lubuagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Pasil",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Tinglayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Tanudan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Pinukpok",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Conner",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1312,
+    "state_code": "KAL",
+    "locality_name": "Rizal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Kabugao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Flora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3811",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Santa Marcela",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3812",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Pudtol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3813",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Luna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3814",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1334,
+    "state_code": "APA",
+    "locality_name": "Calanasan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3900",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Basco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3901",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Mahatao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3902",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Ivana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3903",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Uyugan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3904",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Sabtang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "3905",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1352,
+    "state_code": "BTN",
+    "locality_name": "Itbayat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "San Pablo City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Alaminos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Nagcarlan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Rizal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Liliw",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4005",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Majayjay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4006",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Botocan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Magdalena",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Pagsanjan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Sta. Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Pila",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Victoria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Caluan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Cavinti",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Lumban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Kalayaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Paete",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Pakil",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Pangil",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4019",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Siniloan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4020",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Mabitac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4021",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Famy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4022",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Sta. Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4023",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "San Pedro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4024",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Biñan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4025",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Cabuyao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4026",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Sta. Rosa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4027",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Calamba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4030",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Los Baños",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4031",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "College Los Baños",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4032",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Luisiana",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4033",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Bay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4034",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1328,
+    "state_code": "LAG",
+    "locality_name": "Laguna Technopark",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Cavite City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Bacoor",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Imus",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Kawit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Noveleta",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Gen. Trias",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4108",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Tanza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Trece Martirez City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Naic",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Ternate",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Maragondon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Magallanes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4114",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Dasmariñas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4115",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Dasmariñas Resettlement Area",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4116",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Carmona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4117",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Gen. Mariano Alvarez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4118",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Silang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Amadeo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4120",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Tagaytay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Mendez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4122",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Indang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4123",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Alfonso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4124",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Gen. Aguinaldo (Bailen)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4135",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1307,
+    "state_code": "CAV",
+    "locality_name": "Molino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Batangas City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Bauan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Mabini",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Tingloy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "San Pascual",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Alitagtag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Sta. Teresita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "San Nicolas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Taal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Lemery",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4211",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Agoncillo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Calaca",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Balayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4214",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Tuy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4215",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Calatagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4216",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Lian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4217",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Lipa City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4218",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Fernando Airbase",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4219",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Balete",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4220",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Talisay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4221",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Laurel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4222",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Cuenca",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4223",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Mataas na Kahoy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4224",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Padre Garcia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4225",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4226",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4227",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4228",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Taysan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4229",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Lobo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4230",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Ibaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4231",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Nasugbu",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4232",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Tanauan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4233",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Malvar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4234",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1359,
+    "state_code": "BTG",
+    "locality_name": "Sto. Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Quezon Capitol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4301",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Lucena City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Pagbilao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Padre Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Agdangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Unisan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Plaridel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Gumaca",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Pitogo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Macalelon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4310",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "General Luna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4311",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Catanauan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4312",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Mulanay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4313",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "San Narciso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4314",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "San Andres",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4315",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4316",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Lopez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4317",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Hondagua",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4318",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Calauag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4319",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Guinayangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4320",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Buenavista",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4321",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Tagkawayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4322",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Sariaya",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4323",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Candelaria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4324",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4325",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Tiaong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4326",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Dolores",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4327",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Tayabas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4328",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Lucban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4329",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Sampaloc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4330",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Mauban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4331",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Atimonan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4332",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4333",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Alabat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4334",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Perez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4335",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Real",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4336",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Infanta",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4337",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Panukulan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4338",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "General Nakar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4339",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Polilio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4340",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Burdeos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4341",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Patnanungan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4342",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1275,
+    "state_code": "QUE",
+    "locality_name": "Jomalig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Naga City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Camaligan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Canaman",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Magarao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Bombon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Calabanga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4406",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Cabusao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4407",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Libmanan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Sipocot",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4409",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Lupi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4410",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Ragay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4411",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Del Gallego",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4412",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Gainza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Milaor",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4414",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Minalabac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4415",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4416",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Pamplona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4417",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Pasacao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4418",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Pili",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4419",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Ocampo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4420",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Tigaon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4421",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Sagnay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4422",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Goa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4423",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4424",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Presentacion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4425",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Lagonoy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4426",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Tinambac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4427",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Siruma",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4428",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Garchitorena",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4429",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Caramoan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4430",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Bula",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4431",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Iriga City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4432",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Baao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4433",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Buhi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4434",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Nabua",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4435",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Bato",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4436",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1287,
+    "state_code": "CAS",
+    "locality_name": "Balatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Legazpi City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Daraga (Locsin)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Camalig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Guinobatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Ligao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Oas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Polangui",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4507",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Libon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Sto. Domingo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Bacacay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Malilipot",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Tabaco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4512",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Malinao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Tiwi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4514",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Manito",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4515",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Jovellar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4516",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Pio Duran (Malacbalac)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4517",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1337,
+    "state_code": "ALB",
+    "locality_name": "Rapu-Rapu",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4600",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Daet",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4601",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Mercedes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4602",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Talisay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4603",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Vinzons",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4604",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Labo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4605",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Paracale",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4606",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Jose Panganiban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4607",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Capalonga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4608",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Basud",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4609",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4610",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "San Lorenzo Ruiz (formerly Imelda)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4611",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Sta. Elena",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4612",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1283,
+    "state_code": "CAN",
+    "locality_name": "Tulay na Lupa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Sorsogon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Bacon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4702",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Casiguran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Juban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Bulusan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Magallanes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Bulan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4707",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Irosin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Matnog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Sta. Magdalena",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4710",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Gubat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Prieto Diaz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4712",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Barcelona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4713",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Castilla",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Pilar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4715",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1281,
+    "state_code": "SOR",
+    "locality_name": "Donsol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Virac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Bato",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Baras",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Gigmoto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Viga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Panganiban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Bagamanoc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Caramoran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "Pandan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1301,
+    "state_code": "CAT",
+    "locality_name": "San Andres",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4900",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Boac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4901",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Mogpog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4902",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Sta. Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4903",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Torrijos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4904",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Buenavista",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "4905",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1329,
+    "state_code": "MAD",
+    "locality_name": "Gasan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Calintaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Rizal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Sablayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Sta. Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Mamburao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Palauan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5108",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Abra de Ilog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5109",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Lubang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5110",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Tilik",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5111",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1356,
+    "state_code": "MDC",
+    "locality_name": "Looc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Calapan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Baco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "San Teodoro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Puerto Galera",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Naujan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Victoria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Pola",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Socorro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Pinamalayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Gloria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Bansud",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5211",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Bongabong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Roxas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Mansalay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5214",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1354,
+    "state_code": "MDR",
+    "locality_name": "Bulalacao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Puerto Princesa City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5301",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Iwahig Penal Colony",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Aborlan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Narra (Panacan)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Brooke's Point",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Batazara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Balabac",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Roxas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5310",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Dumaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5311",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Araceli",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5312",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Taytay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5313",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "El Nido (Baquit)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5314",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Linapacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5315",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Culion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5316",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Coron",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5317",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Busuanga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5318",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Cuyo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5319",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5320",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Agutaya",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5321",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Cagayancillo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5322",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Kalayaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5323",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Rizal (Marcos)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5324",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1361,
+    "state_code": "PLW",
+    "locality_name": "Sofronio Española",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Masbate",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Mobo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Uson",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Dimasalang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Palanas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Cataingan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5406",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Pio V. Corpuz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5407",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Esperanza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Placer",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5409",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Cawayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5410",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Milagros",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5411",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Mandaon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5412",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Balud",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Baleno",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5414",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Aroroy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5415",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Batuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5416",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5417",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "San Jacinto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5418",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Monreal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5419",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "Claveria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5420",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1338,
+    "state_code": "MAS",
+    "locality_name": "San Pascual",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Romblon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "San Agustin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Sta. Maria (formerly Imelda)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Calatrava",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "San Andres",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Odiongan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Ferrol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5507",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Looc",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Sta. Fe",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Alcantara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Magdiwang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "San fernando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5514",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Corcuera",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5515",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Banton (Jones)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "5516",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1269,
+    "state_code": "ROM",
+    "locality_name": "Concepcion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Catbalogan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Jiabong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6702",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Motiong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Wright",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Tarangnan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Pagsanghan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Gandara",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6707",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "San Jorge",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Matuguinao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Sta. Margarita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6710",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Calbayog City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Sto. Niño",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6712",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Tagapul-an",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6713",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Hinabangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "San Sebastian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6715",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Calbiga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6716",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Pinabacdao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6717",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Villareal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6718",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Sta. Rita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6719",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Talalora",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6720",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Basey",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6721",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Marabut",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6722",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Daram",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6723",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "San Jose de Buan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6724",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Almagro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "6725",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 5115,
+    "state_code": "WSA",
+    "locality_name": "Zumarraga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Ozamis City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Clarin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Tudela",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Sinacaban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Jimenez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Panaon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Aloran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Oroquieta City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Lopez Jaena",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Plaridel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Calamba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7211",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Baliangao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Sapang dalaga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Concepcion",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7214",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Tangub City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7215",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Bonifacio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "7216",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1343,
+    "state_code": "MSC",
+    "locality_name": "Don Victoriano Chiongbian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Davao City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Digos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Matanao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8005",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Bansalan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8006",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Hagonoy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Padada",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Kiblawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Sulop",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Malalag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1309,
+    "state_code": "DVO",
+    "locality_name": "Santa Maria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1309,
+    "state_code": "DVO",
+    "locality_name": "Malita",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1309,
+    "state_code": "DVO",
+    "locality_name": "Don Marcelino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1309,
+    "state_code": "DVO",
+    "locality_name": "Jose Abad Santos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1309,
+    "state_code": "DVO",
+    "locality_name": "Sarangani",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Ateneo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Bunawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Calinan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8019",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Davao International Airport",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8020",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Mandug",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8021",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Matina",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8022",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Mintal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8023",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Talomo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8024",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Tibungco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8025",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "Toril",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8026",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1318,
+    "state_code": "DAS",
+    "locality_name": "University of Mindanao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Tagum",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Carmen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Asuncion (formerly Saug)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "New Corella",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8105",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Panabo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8106",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Braulio E. Dujali",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8107",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Talaingod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8112",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Santo Tomas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8113",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Kapalong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8118",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Babak",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8119",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Samal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8120",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "Kaputian",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8121",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1319,
+    "state_code": "DAV",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Mati",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Tarragona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Manay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Caraga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Baganga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Cateel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Boston",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Lupon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Banaybanay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1289,
+    "state_code": "DAO",
+    "locality_name": "Gov. Generoso",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8300",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Tandag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8301",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8302",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Tago",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8303",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Bayabas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8304",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Cagwait",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8305",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "San Agustin",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8306",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Marihatag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8307",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Lianga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8308",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Tagbina",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8309",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Barobo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8310",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Hinatuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8311",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Bislig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8312",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Lingig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8313",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Cortez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8314",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Lanuza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8315",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Carmen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8316",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Madrid",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8317",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Cantilan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8318",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Carrascal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8319",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1296,
+    "state_code": "SUR",
+    "locality_name": "Malixi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Surigao City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Malimono",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Tagana-an",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Sison",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Placer",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8406",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Tubod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8407",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Mainit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Bacuag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8409",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Gigaquit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8410",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Claver",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8411",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Cagdianao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8412",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Dinagat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Basilisa (formerly Rizal)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8414",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Libjo (formerly Albor",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8415",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Loreto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8416",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Socorro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8417",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Dapa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8418",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Del Carmen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8419",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Gen. Luna",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8420",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Pilar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8421",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "San Isidro",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8422",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Sta. Monica",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8423",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "San Benito",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8424",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Burgos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8425",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1286,
+    "state_code": "SUN",
+    "locality_name": "Alegria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8426",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "Tubajon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8427",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1291,
+    "state_code": "DIN",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Prosperidad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Bayugan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Sibagat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Trento",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Bunawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8507",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Loreto",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Veruela",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Talacogon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8512",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Sta. Josefa",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1326,
+    "state_code": "AGS",
+    "locality_name": "Esperanza",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8600",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Butuan City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8601",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Buenavista",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8602",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Nasipit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8603",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Carmen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8604",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Magallanes",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8605",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Cabadbaran",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8606",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Tubay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8607",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Jabonga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8608",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Santiago",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8609",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Kitcharao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8610",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Las Nieves",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8611",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Remedios T. Romualdez",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8700",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Malaybalay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8701",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Sumilao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8703",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Manolo Fortich",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8704",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Malitbog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8705",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Phillips",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8706",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Libona",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8708",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Talakag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8709",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Valencia",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8710",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Musuan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8711",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8714",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Maramag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8715",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Quezon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8716",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Kitaotao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8717",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1270,
+    "state_code": "BUK",
+    "locality_name": "Pangantucan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8722",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Lantapan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Nabunturan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Montevista",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Mawab",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Compostela",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "New Bataan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Monkayo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Maco",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Mabini",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Maragusan (formerly San Mariano)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Pantukan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "8810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1311,
+    "state_code": "COM",
+    "locality_name": "Laak (formerly San Vicente)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9000",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Cagayan de Oro City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9001",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1341,
+    "state_code": "AUR",
+    "locality_name": "Tagoloan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9002",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Villanueva",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9003",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Jasaan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9004",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Claveria",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9005",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Balingasag",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9006",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Lagonglong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9007",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Salay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9008",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Binuangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9009",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Sugbongcogon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9010",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Kinoguitan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9011",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Balingoan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9012",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Talisayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9013",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Medina",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9014",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Gingoog City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9015",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9016",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Opol",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9017",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "El Salvador",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9018",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Alubijid",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9019",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Laguindingan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9020",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Gitagum",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9021",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Libertad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9022",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Initao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9023",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Naawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9024",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Manticao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9025",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1348,
+    "state_code": "MSR",
+    "locality_name": "Lugait",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9100",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1285,
+    "state_code": "CAM",
+    "locality_name": "Mambajao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9101",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1285,
+    "state_code": "CAM",
+    "locality_name": "Mahinog",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9102",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1285,
+    "state_code": "CAM",
+    "locality_name": "Guinsiliban",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9103",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1285,
+    "state_code": "CAM",
+    "locality_name": "Sagay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9104",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1285,
+    "state_code": "CAM",
+    "locality_name": "Catarman",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9200",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Iligan City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9201",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Linamon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9202",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Kauswagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9203",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Matungao",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9204",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Poona Piagapo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9205",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Bacolod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9206",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Maigo",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9207",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Kolambugan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9208",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Pantao Ragat",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9209",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Tubod",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9210",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Baroy",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9211",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Lala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9212",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Salvador",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9213",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Sapad",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9214",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Kapatagan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9215",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Sultan Naga Dimaporo (formerly Karomatan)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9216",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Nunungan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9217",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Baloi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9218",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Pantar",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9219",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Munai",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9220",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Tangcal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9221",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Magsaysay",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9222",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1327,
+    "state_code": "LAN",
+    "locality_name": "Tagoloan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9400",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Kidapawan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9401",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Makilala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9402",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "M'lang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9403",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Tulunan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9404",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Magpet",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9405",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Pre. Roxas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9406",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Matalam",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9407",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Kabacan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9408",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Carmen",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9409",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Pikit",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9410",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Midsayap",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9411",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Libungan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9412",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Pigkawayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9413",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Alamada",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9414",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Antipas",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9415",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Aleosan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9416",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Banisilan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9417",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1320,
+    "state_code": "NCO",
+    "locality_name": "Arakan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9500",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Gen. Santos City",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9501",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Alabel",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9502",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Maasim",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9503",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Malungon",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9504",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Polomolok",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9505",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Tupi",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9506",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Koronadal",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9507",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Tampakan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9508",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Norala",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9509",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Sto. Niño",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9510",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Tantangan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9511",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Banga",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9512",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Surallah",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9513",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "T'boli",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9514",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1323,
+    "state_code": "AGN",
+    "locality_name": "Kiamba",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9515",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Maitum",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9516",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Malapatan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9517",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1277,
+    "state_code": "SAR",
+    "locality_name": "Glan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9518",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1280,
+    "state_code": "SCO",
+    "locality_name": "Lake Sebu",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9800",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Tacurong",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9801",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Columbio",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9802",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Mariano Marcos",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9803",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Lutayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9804",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Pres. Quirino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9805",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Isulan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9806",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Esperanza (Ampatuan)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9807",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Lebak (Salaman)",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9808",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Kalamansig",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9809",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Palimbang",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9810",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Bagumbayan",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  },
+  {
+    "code": "9811",
+    "country_id": 174,
+    "country_code": "PH",
+    "state_id": 1282,
+    "state_code": "SUK",
+    "locality_name": "Sen. Ninoy Aquino",
+    "type": "full",
+    "source": "phlpost-via-jayson-panganiban"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 1,391 Philippines postcodes spanning all 62 source provinces of
PHLPost's catalogue, redistributed via the
``jayson-panganiban/phzipcodes`` Python package.

- **Coverage**: 100% province resolution.
- **Granularity**: city/municipality level — one record per
  ``(zip code, city)`` pair.

## Source & licence

- Source URL: https://raw.githubusercontent.com/jayson-panganiban/phzipcodes/main/phzipcodes/data/ph_zip_codes.json
- Origin: PHLPost publicly published postcode index, redistributed by
  jayson-panganiban.
- Each row: ``"source": "phlpost-via-jayson-panganiban"``

## How it works

- Walks ``Region -> Province -> City -> [zip codes]`` tree and emits
  one row per ``(code, city)`` pair.
- Province name match is case-insensitive against ``states.json``.
- 5-entry ``STATE_ALIASES`` bridge handles parenthetical-suffix
  variants (Camarines Sur (Camsur), Davao De Oro (Formerly
  Compostela Valley), Cotabato (North)) and the Metro Manila ->
  National Capital Region exonym.

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 1,391 codes match ``country.postal_code_regex`` (``^(\d{4})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 174``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)