### PR TITLE
feat(postcodes/MY): bulk-import 2,933 Malaysia postcodes via Pos Malaysia (#1039)

### DIFF
--- a/bin/scripts/sync/import_malaysia_postcodes.py
+++ b/bin/scripts/sync/import_malaysia_postcodes.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Malaysia -> contributions/postcodes/MY.json importer for #1039.
+
+Source data
+-----------
+The community ``AsyrafHussin/malaysia-postcodes`` repository ships
+the Pos Malaysia catalogue as a nested JSON keyed by State -> City ->
+[postcodes]:
+
+    { "state": [
+        {"name": "Selangor", "city": [{"name": "...", "postcode": ["..."]}]},
+        ...
+    ]}
+
+Source URL: https://raw.githubusercontent.com/AsyrafHussin/malaysia-postcodes/master/all.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Resolves ``state_id`` via case-insensitive name match against
+   states.json with a 5-entry STATE_ALIASES bridge for Federal
+   Territories (Wp prefix) and Malay-spelling variants.
+3. Emits one record per ``(postcode, city)`` pair.
+4. Writes contributions/postcodes/MY.json idempotently.
+
+License & attribution
+---------------------
+- Source: AsyrafHussin/malaysia-postcodes (MIT) which redistributes
+  the publicly published Pos Malaysia index.
+- Each row: ``source: "pos-malaysia-via-AsyrafHussin"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_malaysia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/AsyrafHussin/malaysia-postcodes/"
+    "master/all.json"
+)
+
+# Source name (lowercased) -> CSC states.json "name"
+STATE_ALIASES: Dict[str, str] = {
+    "wp kuala lumpur": "Kuala Lumpur",
+    "wp putrajaya": "Putrajaya",
+    "wp labuan": "Labuan",
+    "melaka": "Malacca",
+    "pulau pinang": "Penang",
+}
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    my_country = next((c for c in countries if c.get("iso2") == "MY"), None)
+    if my_country is None:
+        print("ERROR: MY not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(my_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    my_states = [s for s in states if s.get("country_id") == my_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in my_states}
+    print(f"Country: Malaysia (id={my_country['id']}); states indexed: {len(my_states)}")
+
+    src_states = data.get("state", []) if isinstance(data, dict) else []
+    print(f"Source states: {len(src_states)}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for st in src_states:
+        nm = (st.get("name") or "").strip()
+        target_name = STATE_ALIASES.get(nm.lower(), nm).lower()
+        state = state_by_name.get(target_name)
+        for city in st.get("city", []) or []:
+            city_name = (city.get("name") or "").strip()
+            for raw_code in city.get("postcode", []) or []:
+                code = str(raw_code).strip()
+                if not code:
+                    continue
+                if not regex.match(code):
+                    skipped_bad_regex += 1
+                    continue
+                key = (code, city_name.lower())
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                record: Dict[str, object] = {
+                    "code": code,
+                    "country_id": int(my_country["id"]),
+                    "country_code": "MY",
+                }
+                if state is not None:
+                    record["state_id"] = int(state["id"])
+                    record["state_code"] = state.get("iso2")
+                    matched_state += 1
+                else:
+                    skipped_no_state += 1
+
+                if city_name:
+                    record["locality_name"] = city_name
+                record["type"] = "full"
+                record["source"] = "pos-malaysia-via-AsyrafHussin"
+                records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/MY.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/MY.json
+++ b/contributions/postcodes/MY.json
@@ -1,0 +1,29332 @@
+[
+  {
+    "code": "01000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "01694",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kuala Perlis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Padang Besar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kaki Bukit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Kangar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Arau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Arau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Arau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "02800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1938,
+    "state_code": "09",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05580",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05621",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05675",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05696",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "05990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Jitra",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Jitra",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Jitra",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Changloon",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bukit Kayu Hitam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kodiang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Ayer Hitam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kuala Nerang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pokok Sena",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pokok Sena",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langgar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langgar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kuala Kedah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Simpang Empat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Alor Setar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Simpang Empat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Pendang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kota Sarang Semut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Yan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "06910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Yan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "07000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langkawi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "07007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langkawi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "07009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langkawi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "07100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Langkawi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sungai Petani",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sungai Petani",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sungai Petani",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sungai Petani",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bedong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bedong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Gurun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Jeniang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08330",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Gurun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08340",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Merbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08407",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Merbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Merbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kota Kuala Muda",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kota Kuala Muda",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kota Kuala Muda",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Sungai Petani",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Jeniang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "08800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Gurun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kulim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kulim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kulim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kulim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kulim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Baling",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kuala Pegang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kupang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kuala Ketil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Kuala Ketil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Padang Serai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Padang Serai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Lunas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Karangan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Serdang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "09810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Serdang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10470",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10566",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10593",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10790",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10830",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10840",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "10990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Balik Pulau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Balik Pulau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Balik Pulau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Batu Ferringhi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Tanjong Bungah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Penang Hill",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Ayer Itam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Jelutong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Jelutong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Gelugor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Usm Pulau Pinang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bayan Lepas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bayan Lepas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bayan Lepas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bayan Lepas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "11960",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Batu Maung",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "12990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Penaga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Penaga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Kepala Batas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Tasek Gelugor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Tasek Gelugor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Permatang Pauh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Perai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Perai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "13800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Butterworth",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bukit Mertajam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bukit Mertajam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bukit Mertajam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Bukit Mertajam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14101",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Simpang Ampat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Sungai Jawi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14290",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bandar Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Nibong Tebal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Nibong Tebal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Nibong Tebal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14390",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bandar Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "14400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1939,
+    "state_code": "07",
+    "locality_name": "Kubang Semang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15159",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15616",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15623",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15624",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "15990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Wakaf Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tumpat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16090",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kota Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tumpat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tumpat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Wakaf Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16266",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Wakaf Bharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16370",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16390",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Bachok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Melor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Ketereh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kem Desa Pahlawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pulai Chondong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Cherang Ruku",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Puteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "16810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Selising",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Pasir Mas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Rantau Panjang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17599",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Tanah Merah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Jeli",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kuala Balah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "17700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Ayer Lanas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kuala Krai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kuala Krai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Kuala Krai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Dabong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Gua Musang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Temangan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "18500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1946,
+    "state_code": "03",
+    "locality_name": "Machang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20554",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20566",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20568",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20618",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20656",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20698",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20914",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20916",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20918",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20922",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20924",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20926",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20928",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20930",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "20999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21090",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Terengganu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Bukit Payong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Chalok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Sungai Tong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Marang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Marang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Berang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ajil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ajil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "21820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ajil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Jerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Jerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Jerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Jerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Jerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Permaisuri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Permaisuri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Permaisuri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Permaisuri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Permaisuri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kampung Raja",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Besut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Besut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "22309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kuala Besut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Dungun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Dungun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Dungun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Dungun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Paka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Bukit Besi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ketengah Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23345",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ketengah Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "23400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Al Muktatfi Billah Shah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Cukai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ayer Puteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Ceneh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kijal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kijal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kijal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kemasek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kemasek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kemasek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kemasek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kemasek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "24300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1942,
+    "state_code": "11",
+    "locality_name": "Kerteh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25584",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25656",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "25990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bukit Goh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Balok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26090",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bukit Goh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Balok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26140",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Balok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26180",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuantan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26190",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Balok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Sungai Lembing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jaya Gading",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26330",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26340",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26360",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26370",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Gambang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26420",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26430",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26440",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26485",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26490",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Maran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26640",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Pekan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Chini",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Muadzam Shah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Tun Abdul Razak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "26999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Tun Abdul Razak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Damak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bandar Pusat Jengka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27090",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Padang Tengku",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Jerantut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Lipis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Lipis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Lipis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Lipis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Benta",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Benta",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Dong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Sungai Ruan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Sungai Koyan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Sega",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "27670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Raub",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Temerloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kuala Krau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Chenor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28330",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28340",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kemayan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Triang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28380",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Kemayan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Mentakab",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28407",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Mentakab",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Mentakab",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Lanchang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Karak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Karak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Karak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bentong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "28800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Lurah Bilut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30205",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30554",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30580",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30621",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30656",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30682",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30790",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30830",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30840",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "30990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Siput",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Siput",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Siput",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ulu Kinta",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31199",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ulu Kinta",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Chemor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Rambutan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampung Kepayang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31407",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pusing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pusing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Gopeng",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Gopeng",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Malim Nawar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tronoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Tualang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Jeram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31909",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "31950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sitiawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sitiawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sitiawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Seri Manjung",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Seri Manjung",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "TLDM Lumut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lumut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pangkor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ayer Tawar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Changkat Keruing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bota",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bandar Seri Iskandar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bruas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Parit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Parit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lambor Kanan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "32999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lambor Kanan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kangsar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pengkalan Hulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Gerik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Gerik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Gerik",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lenggong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lenggong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33420",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Lenggong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sauk",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Enggor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Padang Rengas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "33800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Manong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Taiping",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selama",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selama",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34130",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selama",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34140",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Rantau Panjang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Parit Buntar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Piandang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bagan Serai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bagan Serai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Kurau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Simpang Ampat Semanggol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Kurau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Kurau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Batu Kurau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kamunting",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kuala Sepetang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Simpang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Matang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Trong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Changkat Jering",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pantai Remis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Pantai Remis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "34950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1947,
+    "state_code": "02",
+    "locality_name": "Bandar Baharu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tapah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tapah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tapah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Chenderiang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Temoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tapah Road",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bidor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungkai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Trolak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Slim River",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Slim River",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Malim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Malim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35909",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Malim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Tanjong Malim",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "35950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Behrang Stesen",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Bagan Datoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Teluk Intan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selekoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selekoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Selekoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Sumun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Sumun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Sungai Sumun",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Hutan Melintang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Ulu Bernam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Chenderong Balai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Langkap",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Chikus",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampung Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "36810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1943,
+    "state_code": "08",
+    "locality_name": "Kampung Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Tanah Rata",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Tanah Rata",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Tanah Rata",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Tanah Rata",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Brinchang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "39200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Ringlet",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40140",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40169",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40170",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40179",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40440",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40470",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40490",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40675",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40702",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40704",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40706",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40712",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40714",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40716",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40718",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40722",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40724",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40726",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40728",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40732",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40802",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40804",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40806",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40808",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40915",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "40990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41205",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41299",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41301",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41914",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41916",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41918",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "41990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pelabuhan Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pelabuhan Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pelabuhan Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pelabuhan Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Klang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kapar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kapar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Bandar Puncak Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42425",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Telok Panglima Garang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Shah Alam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Telok Panglima Garang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Telok Panglima Garang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Telok Panglima Garang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Jenjarom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Jenjarom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42619",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Jenjarom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Banting",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Tanjong Sepat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Indah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Indah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Indah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42940",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Ketam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42960",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Carey",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "42999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Pulau Carey",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kajang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kajang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kajang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Hulu Langat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cheras",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cheras",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Seri Kembangan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43399",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Seri Kembangan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Serdang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Semenyih",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kajang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Bangi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Bandar Baru Bangi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Beranang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43701",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Beranang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Dengkil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Dengkil",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sepang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Pelek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "43999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Pelek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Kubu Baru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Kubu Baru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Kubu Baru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kerling",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Kubu Baru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rasa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Kali",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Kali",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "44330",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Kali",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Selangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Kuala Selangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Ayer Tawar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sabak Bernam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sabak Bernam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sabak Bernam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Besar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sekinchan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Tanjong Karang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Berjuntai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Berjuntai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Berjuntai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Berjuntai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batang Berjuntai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Bukit Rotan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "45800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Jeram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46547",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46549",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46667",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46675",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46692",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46781",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46782",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46783",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46784",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46785",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46786",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46787",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46788",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46789",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46790",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46791",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46792",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46793",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46794",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46795",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46796",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46797",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46798",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46799",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46801",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46802",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46803",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46804",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46805",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46806",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46860",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46870",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46960",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46962",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46964",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46966",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46968",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46970",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46972",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46974",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46976",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46978",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "46990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Buloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Buloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47031",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Sungai Buloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47130",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47140",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47170",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47180",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47190",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Puchong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Airport",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Airport",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47301",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47304",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47308",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47430",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47601",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47618",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47640",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47801",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47829",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47830",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "47850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Petaling Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Serendah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Serendah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "48302",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Rawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "49000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Bukit Fraser",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50088",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50420",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50470",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50480",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50489",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50490",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50515",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50528",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50530",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50544",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50554",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50562",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50566",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50568",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50580",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50588",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50599",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50603",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50605",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50621",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50623",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50636",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50638",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50640",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50642",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50652",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50653",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50656",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50666",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50677",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50678",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50682",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50684",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50688",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50694",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50702",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50704",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50706",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50712",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50714",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50716",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50718",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50722",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50724",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50726",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50728",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50732",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50734",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50736",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50738",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50742",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50744",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50746",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50748",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50752",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50754",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50758",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50762",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50764",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50766",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50768",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50772",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50774",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50776",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50778",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50782",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50784",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50786",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50788",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50790",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50792",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50794",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50796",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50798",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50802",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50804",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50806",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50808",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50812",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50814",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50816",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50818",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50901",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50903",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50909",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50911",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50913",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50914",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50915",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50916",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50917",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50918",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50919",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50921",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50922",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50923",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50924",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50925",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50926",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50927",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50928",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50929",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50930",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50931",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50932",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50933",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50934",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50935",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50936",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50937",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50938",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50939",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50940",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50941",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50942",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50943",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50944",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50945",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50946",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50947",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50948",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50949",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50989",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "50990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51640",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "51990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "52220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Setapak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "53990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "54000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "54050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "54100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "54200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "54540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55188",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55330",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55555",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Subang Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55914",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55916",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55918",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55922",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55924",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55926",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55928",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55930",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55932",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55934",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "55990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "56000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "56100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "57000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "57100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "57200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "57700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "57990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "58990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59001",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59206",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "59990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "60000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1949,
+    "state_code": "14",
+    "locality_name": "Kuala Lumpur",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62052",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62522",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62524",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62526",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62527",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62530",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62539",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62574",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62584",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62602",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62605",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62616",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62618",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62623",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62624",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62652",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62654",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62657",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62675",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62677",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62686",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62692",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "62988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1945,
+    "state_code": "16",
+    "locality_name": "Putrajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "63000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cyberjaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "63100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cyberjaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "63200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cyberjaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "63300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Cyberjaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "64000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "KLIA",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "68000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Ampang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "68100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1944,
+    "state_code": "10",
+    "locality_name": "Batu Caves",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "69000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1940,
+    "state_code": "06",
+    "locality_name": "Genting Highlands",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70674",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "70990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Si Rusa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71059",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Si Rusa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rantau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rantau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Linggi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71159",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Linggi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rantau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rantau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Si Rusa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71259",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Si Rusa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rembau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rembau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kota",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71359",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kota",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rembau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rembau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71459",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tanjong Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tanjong Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tanjong Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71559",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tanjong Ipoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Klawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Klawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Klawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71659",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Klawang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Mantin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Mantin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Mantin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Mantin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71759",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Mantin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bandar Baru Enstek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Nilai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Nilai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71809",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Nilai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Nilai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Labu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Labu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71909",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Labu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Seremban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71960",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "71999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Port Dickson",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bahau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bahau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bahau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bandar Seri Jempol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72127",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bandar Seri Jempol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72129",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Bandar Seri Jempol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Batu Kikir",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Batu Kikir",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Batu Kikir",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Simpang Pertang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Simpang Pertang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Simpang Pertang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Simpang Durian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Simpang Durian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "72509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Kuala Pilah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tampin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tampin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Tampin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Johol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Johol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemencheh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemencheh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemencheh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemencheh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemencheh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73420",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73430",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Pusat Bandar Palong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73440",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Pusat Bandar Palong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Pusat Bandar Palong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Pusat Bandar Palong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73470",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Pusat Bandar Palong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73480",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Gemas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "73509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1948,
+    "state_code": "05",
+    "locality_name": "Rompin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75260",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75430",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Ayer Keroh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "75460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Durian Tunggal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Durian Tunggal",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Kem Trendak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Sungai Udang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Tanjong Kling",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Tanjong Kling",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "76450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Melaka",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Jasin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Jasin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Jasin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Jasin",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Asahan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Asahan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Bemban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Merlimau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Sungai Rambai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "77500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Selandar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Alor Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Alor Gajah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Lubok China",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Kuala Sungai Baru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Masjid Tanah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Masjid Tanah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "78309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1941,
+    "state_code": "04",
+    "locality_name": "Masjid Tanah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79511",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79513",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79521",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79523",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79555",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79575",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79601",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79603",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79605",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79681",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "79683",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Iskandar Puteri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80530",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80536",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80542",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80548",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80568",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80584",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80664",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80888",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ibrahim International Business District",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "80990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kulai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81310",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Johor Bahru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Senai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Senai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81440",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bandar Tenggara",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Gugusan Taib Andak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pekan Nenas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Gelang Patah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Gelang Patah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pengerang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pengerang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pengerang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pasir Gudang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Masai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Masai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ulu Tiram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ulu Tiram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Layang-Layang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kota Tinggi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kota Tinggi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kota Tinggi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81920",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ayer Tawar 2",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81930",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bandar Penawar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "81960",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bandar Penawar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pontian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pontian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pontian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pontian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ayer Baloi",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Benut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "82300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kukup",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Rengit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Senggarang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Seri Gading",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Seri Medan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Parit Sulong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Semerah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Semerah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Yong Peng",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "83710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Yong Peng",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84040",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Parit Jawa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84160",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Parit Jawa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bukit Pasir",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Sungai Mati",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Sungai Mati",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Muar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Panchor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Pagoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Gerisek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Gerisek",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bukit Gambir",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Tangkak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "84990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Tangkak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85060",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85080",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Segamat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Anam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Jementah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85210",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Jementah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Labis",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "85400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Chaah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kluang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kluang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Ayer Hitam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Simpang Rengam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Rengam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Batu Pahat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Parit Raja",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Bekok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Paloh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Kahang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Mersing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Tioman",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Mersing",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Endau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "86999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1950,
+    "state_code": "01",
+    "locality_name": "Endau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87011",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87012",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87013",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87014",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87015",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87016",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87017",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87018",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87019",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87021",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87022",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87023",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87024",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87025",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87026",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87027",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87028",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87029",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87031",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87032",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "87033",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1935,
+    "state_code": "15",
+    "locality_name": "Labuan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88220",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88458",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88460",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88512",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88526",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88527",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88534",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88538",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88546",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88554",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88562",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88566",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88568",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88580",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88598",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88602",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88617",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88618",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88621",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88622",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88624",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88630",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88644",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88646",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88656",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88673",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88675",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88676",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88680",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beverly",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88721",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Putatan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88722",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Putatan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88723",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Putatan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88724",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Putatan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88725",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Putatan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88757",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88758",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88759",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88761",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88762",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88763",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88764",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88765",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88766",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88767",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88768",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88769",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88770",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88771",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88772",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88773",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88774",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88775",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88776",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88777",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88778",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88779",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88780",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88781",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88782",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88783",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88784",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88785",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88786",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88787",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88788",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88789",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88790",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88801",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88802",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88803",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88804",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88805",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88806",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88808",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88809",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88810",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88811",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88812",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88813",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88814",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88815",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88816",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88817",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88818",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88819",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88820",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88821",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88822",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88823",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88824",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88825",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88826",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88827",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88828",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88829",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88830",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88831",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88832",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88833",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88834",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88835",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88836",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88837",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88838",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88839",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88840",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88841",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88842",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88843",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88844",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88845",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88846",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88847",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88848",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88849",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88851",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88852",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88853",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88854",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88855",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88856",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Likas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88857",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Inanam",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88858",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tanjung Aru",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88860",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88861",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88862",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88863",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88865",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88866",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88867",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88868",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88869",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88870",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88871",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88872",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88873",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88874",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88875",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88901",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88903",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88905",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88988",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88991",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88992",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88993",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88994",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88995",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88996",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88997",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88998",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "88999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabalu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Keningau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Keningau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Keningau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Keningau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kudat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89057",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kudat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89058",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kudat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89059",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kudat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Marudu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Marudu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89108",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Marudu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Marudu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Belud",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89157",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Belud",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89158",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Belud",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89159",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Belud",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tuaran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tuaran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89208",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tuaran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tuaran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tamparuli",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89257",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tamparuli",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89258",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tamparuli",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89259",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tamparuli",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89260",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beverly",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89260",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tenghilan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89308",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89320",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89357",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Ranau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Penampang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Penampang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Penampang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Penampang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Papar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89607",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Papar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Papar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Papar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tambunan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89657",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tambunan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tambunan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89659",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tambunan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Bongawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Bongawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Bongawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Bongawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Membakut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89727",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Membakut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89728",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Membakut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89729",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Membakut",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kuala Penyu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89747",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kuala Penyu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89748",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kuala Penyu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89749",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kuala Penyu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Menumbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89767",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Menumbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89768",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Menumbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89769",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Menumbok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beaufort",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beaufort",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89808",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beaufort",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89809",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beaufort",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sipitang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89857",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sipitang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89858",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sipitang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89859",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sipitang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tenom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89907",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tenom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tenom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89909",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tenom",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Nabawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89957",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Nabawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89958",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Nabawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "89959",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Nabawan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beluran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beluran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Beluran",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kota Kinabatangan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Pamol",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90701",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90702",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90703",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90704",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90705",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90706",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90711",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90712",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90713",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90714",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90715",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90716",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90717",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90718",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90719",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90721",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90722",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90723",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90724",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90725",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90726",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90727",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90728",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90729",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90731",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90732",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90733",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90734",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90735",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90736",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90737",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90738",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90739",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "90741",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Sandakan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91011",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91012",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91013",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91014",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91015",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91016",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91017",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91018",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91019",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91020",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91021",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91022",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91023",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91024",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91025",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91026",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91027",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91028",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91029",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91031",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91032",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91033",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91034",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91035",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91045",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91056",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Tawau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91108",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91110",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91111",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91112",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91113",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91114",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91115",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91116",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91117",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91118",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91119",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91120",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91121",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91122",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91123",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91124",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91125",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91126",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91127",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91128",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Lahad Datu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kunak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91207",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kunak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91209",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Kunak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Semporna",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Semporna",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91308",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Semporna",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "91309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1936,
+    "state_code": "12",
+    "locality_name": "Semporna",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93030",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93450",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93502",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93503",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93504",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93505",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93506",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93514",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93516",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93517",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93518",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93519",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93520",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93527",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93529",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93532",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93540",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93550",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93551",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93552",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93554",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93556",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93558",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93560",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93564",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93566",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93570",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93572",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93576",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93578",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93582",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93586",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93590",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93592",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93594",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93596",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93604",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93606",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93608",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93609",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93610",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93612",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93614",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93618",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93619",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93620",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93626",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93628",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93632",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93634",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93648",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93658",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93660",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93661",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93662",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93668",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93670",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93672",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93677",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93690",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93694",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93702",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93704",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93706",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93710",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93712",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93714",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93716",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93718",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93720",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93722",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93724",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93726",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93728",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93730",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93732",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93734",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93736",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93738",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93740",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93742",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93744",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93746",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93748",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93752",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93754",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93756",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93758",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93762",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93764",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93902",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93904",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93906",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93908",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93910",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93912",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93914",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93916",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "93990",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kuching",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Siburan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kota Samarahan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lundu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lundu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lundu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Asajaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94650",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kabong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Serian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Serian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Serian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Serian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94760",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Serian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Simunjan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Simunjan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94809",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Simunjan",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sebuyau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lingga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "94950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Pusa",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sri Aman",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sri Aman",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sri Aman",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sri Aman",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Roban",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Saratok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95407",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Saratok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95409",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Saratok",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Debak",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Spaoh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Betong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Betong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Betong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Engkilili",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "95900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lubok Antu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sibu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sibu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sibu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sibu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sibu Jaya",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sarikei",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sarikei",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96108",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sarikei",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sarikei",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Belawai",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Daro",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96250",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Matu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Dalat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96307",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Dalat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96309",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Dalat",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96350",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Balingian",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96400",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Mukah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96410",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Mukah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96500",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96507",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96508",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96509",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96510",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintangor",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96600",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Julau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kanowit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kanowit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kanowit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kapit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96807",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kapit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96809",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Kapit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96900",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Belaga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96950",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Belaga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "96999",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Belaga",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97004",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97010",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97011",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97012",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97013",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97014",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97015",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sebauh",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Tatau",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "97300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bintulu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98000",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Miri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98007",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Miri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98008",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Miri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98009",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Miri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98050",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Baram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98057",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Baram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98058",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Baram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98059",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Baram",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98070",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Pusat Mel Miri",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98100",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lutong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98107",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lutong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98109",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lutong",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98150",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bekenu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98157",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bekenu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98159",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Bekenu",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98200",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Niah",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98300",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Long Lama",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98700",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Limbang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98707",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Limbang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98708",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Limbang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98709",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Limbang",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98750",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Nanga Medamit",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98800",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Sundar",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98850",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lawas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98857",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lawas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  },
+  {
+    "code": "98859",
+    "country_id": 132,
+    "country_code": "MY",
+    "state_id": 1937,
+    "state_code": "13",
+    "locality_name": "Lawas",
+    "type": "full",
+    "source": "pos-malaysia-via-AsyrafHussin"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 2,933 Malaysia postcodes spanning all 16 states and federal
territories of Pos Malaysia's catalogue, redistributed via the
MIT-licensed ``AsyrafHussin/malaysia-postcodes`` mirror.

- **Coverage**: 100% state resolution.
- **Granularity**: city level — one record per ``(postcode, city)``
  pair.

## Source & licence

- Source URL: https://raw.githubusercontent.com/AsyrafHussin/malaysia-postcodes/master/all.json
- Licence: MIT (community redistribution of Pos Malaysia data).
- Each row: ``"source": "pos-malaysia-via-AsyrafHussin"``

## How it works

- Walks ``state -> city -> [postcodes]`` tree.
- 5-entry ``STATE_ALIASES`` bridge handles the Federal Territory ``Wp``
  prefix (``Wp Kuala Lumpur`` -> ``Kuala Lumpur``, etc.) and the Pulau
  Pinang/Penang and Melaka/Malacca exonyms.

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 2,933 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 132``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)