### PR TITLE
feat(postcodes/VN): bulk-import 63 Vietnam province postcodes via VNPost (#1039)

### DIFF
--- a/bin/scripts/sync/import_vietnam_postcodes.py
+++ b/bin/scripts/sync/import_vietnam_postcodes.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Vietnam -> contributions/postcodes/VN.json importer for #1039.
+
+Source data
+-----------
+The community ``navuitag/dvhcvn`` repository ships Vietnam's
+administrative-units catalogue, including province-level VNPost
+postcodes. The MySQL dump exposes a ``provinces`` table:
+
+    INSERT INTO `provinces` (`id`, `province_name`, `postcode`, ...)
+    VALUES ('01', 'Thành phố Hà Nội', '100000', ...);
+
+Source URL: https://raw.githubusercontent.com/navuitag/dvhcvn/master/database/database.sql
+
+What this script does
+---------------------
+1. Fetches the SQL dump via urllib (curl is blocked).
+2. Parses the ``provinces`` INSERT block with a tolerant regex.
+3. Ships country-only (no state_id): Vietnam's 2024-2025
+   administrative restructuring merged many of the source's 63
+   pre-2024 provinces into the post-merger 34 provinces represented
+   in CSC's ``states.json``, so a clean per-row state FK is no longer
+   possible from this dataset (matches the SE/SI/ZA/GR precedent).
+4. Writes contributions/postcodes/VN.json idempotently.
+
+License & attribution
+---------------------
+- Source: navuitag/dvhcvn; the postcodes are VNPost's publicly
+  published province-level codes.
+- Each row: ``source: "vnpost-via-navuitag"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_vietnam_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/navuitag/dvhcvn/"
+    "master/database/database.sql"
+)
+
+PROVINCES_INSERT_BLOCK = re.compile(
+    r"INSERT\s+INTO\s+`provinces`.*?VALUES\s*(.*?);",
+    re.IGNORECASE | re.DOTALL,
+)
+PROVINCE_ROW = re.compile(
+    r"\(\s*'(?P<id>\d+)'\s*,\s*'(?P<name>[^']+)'\s*,\s*'(?P<postcode>\d{6})'"
+)
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_text(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    vn_country = next((c for c in countries if c.get("iso2") == "VN"), None)
+    if vn_country is None:
+        print("ERROR: VN not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(vn_country.get("postal_code_regex") or ".*")
+    print(f"Country: Vietnam (id={vn_country['id']})")
+
+    block = PROVINCES_INSERT_BLOCK.search(text)
+    if block is None:
+        print("ERROR: provinces INSERT block not found", file=sys.stderr)
+        return 2
+    rows = list(PROVINCE_ROW.finditer(block.group(1)))
+    print(f"Source province rows: {len(rows)}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for m in rows:
+        code = m.group("postcode").strip()
+        name = m.group("name").strip()
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        # Strip "Tỉnh " or "Thành phố " administrative prefix
+        clean_name = re.sub(r"^(Tỉnh|Thành phố)\s+", "", name)
+        key = (code, clean_name.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(vn_country["id"]),
+            "country_code": "VN",
+        }
+        if clean_name:
+            record["locality_name"] = clean_name
+        record["type"] = "full"
+        record["source"] = "vnpost-via-navuitag"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/VN.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/VN.json
+++ b/contributions/postcodes/VN.json
@@ -1,0 +1,506 @@
+[
+  {
+    "code": "100000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hà Nội",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "160000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hưng Yên",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "170000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hải Dương",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "180000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hải Phòng",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "200000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Quảng Ninh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "220000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bắc Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "240000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Lạng Sơn",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "250000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Thái Nguyên",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "260000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bạc Liêu",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "270000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Cần Thơ",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "280000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Vĩnh Phúc",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "290000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Phú Thọ",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "300000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Tuyên Quang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "310000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hà Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "320000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Yên Bái",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "330000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Lào Cai",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "350000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hoà Bình",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "360000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Sơn La",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "390000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Lai Châu",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "390000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Điện Biên",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "400000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hà Nam",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "410000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Thái Bình",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "420000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Nam Định",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "430000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Ninh Bình",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "440000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Thanh Hóa",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "460000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Nghệ An",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "480000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hà Tĩnh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "510000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Quảng Bình",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "520000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Quảng Trị",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "530000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Thừa Thiên Huế",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "550000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Đà Nẵng",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "560000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Quảng Nam",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "570000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Quảng Ngãi",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "580000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Kon Tum",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "590000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bình Dương",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "600000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Gia Lai",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "620000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Phú Yên",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "630000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Đắk Lắk",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "640000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Đắk Nông",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "650000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Khánh Hòa",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "660000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Ninh Thuận",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "670000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Lâm Đồng",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "700000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hồ Chí Minh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "790000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bà Rịa - Vũng Tàu",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "790000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bắc Ninh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "800000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bình Thuận",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "810000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Đồng Nai",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "820000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bình Định",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "830000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bình Phước",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "840000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Tây Ninh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "850000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Long An",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "860000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Tiền Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "870000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Đồng Tháp",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "880000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "An Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "890000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Vĩnh Long",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "900000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Cao Bằng",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "910000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Hậu Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "920000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Kiên Giang",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "930000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bến Tre",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "940000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Trà Vinh",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "950000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Sóc Trăng",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "960000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Bắc Kạn",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  },
+  {
+    "code": "970000",
+    "country_id": 240,
+    "country_code": "VN",
+    "locality_name": "Cà Mau",
+    "type": "full",
+    "source": "vnpost-via-navuitag"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 63 Vietnam province-level postcodes parsed from the
``navuitag/dvhcvn`` MySQL dump.

- **Coverage**: country-only by design.
- **Granularity**: one record per pre-2024 province with VNPost's
  6-digit code.

## Why country-only

Vietnam's 2024-2025 administrative restructuring merged the source's
63 pre-2024 provinces into the post-merger 34 provinces represented
in CSC's ``states.json``. A clean per-row state FK is no longer
possible from this dataset — matches the SE/SI/ZA/GR precedent.

## Source & licence

- Source URL: https://raw.githubusercontent.com/navuitag/dvhcvn/master/database/database.sql
- Origin: VNPost publicly published province codes redistributed by
  navuitag.
- Each row: ``"source": "vnpost-via-navuitag"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 63 codes match ``country.postal_code_regex`` (``^(\d{6})$``).
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)