### PR TITLE
feat(postcodes/LV): bulk-import 671 Latvia postcodes via Latvijas Pasts (#1039)

### DIFF
--- a/bin/scripts/sync/import_latvia_postcodes.py
+++ b/bin/scripts/sync/import_latvia_postcodes.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Latvia -> contributions/postcodes/LV.json importer for #1039.
+
+Source data
+-----------
+The community ``IcebergBuilder/pasta_indeksi`` repository ships a
+flat list of every Latvijas Pasts ``LV-NNNN`` index across two
+files: ``Novadi`` (counties) and ``Riga`` (capital districts).
+
+Source URLs:
+- https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Novadi
+- https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Riga
+
+What this script does
+---------------------
+1. Fetches both files via urllib (curl is blocked).
+2. Strips the ``LV-`` prefix to obtain the canonical 4-digit form
+   that matches the country regex ``^(?:LV)*(\\d{4})$``.
+3. Ships country-only: source has no locality / state mapping.
+4. Writes contributions/postcodes/LV.json idempotently.
+
+License & attribution
+---------------------
+- Source: IcebergBuilder/pasta_indeksi; data is the publicly
+  published Latvijas Pasts index.
+- Each row: ``source: "latvijas-pasts-via-IcebergBuilder"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_latvia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URLS = [
+    "https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Novadi",
+    "https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Riga",
+]
+
+LV_LINE_RE = re.compile(r"^LV[-\s]?(\d{4})$")
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    lv_country = next((c for c in countries if c.get("iso2") == "LV"), None)
+    if lv_country is None:
+        print("ERROR: LV not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(lv_country.get("postal_code_regex") or ".*")
+    print(f"Country: Latvia (id={lv_country['id']})")
+
+    seen: set = set()
+    records: List[dict] = []
+    for url in SOURCE_URLS:
+        text = fetch_text(url)
+        for line in text.splitlines():
+            line = line.strip()
+            m = LV_LINE_RE.match(line)
+            if not m:
+                continue
+            code = m.group(1)
+            if not regex.match(code):
+                continue
+            if code in seen:
+                continue
+            seen.add(code)
+            records.append(
+                {
+                    "code": code,
+                    "country_id": int(lv_country["id"]),
+                    "country_code": "LV",
+                    "type": "full",
+                    "source": "latvijas-pasts-via-IcebergBuilder",
+                }
+            )
+
+    print(f"Records emitted: {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/LV.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/LV.json
+++ b/contributions/postcodes/LV.json
@@ -1,0 +1,4699 @@
+[
+  {
+    "code": "1001",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1002",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1003",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1004",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1005",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1006",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1007",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1009",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1010",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1011",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1012",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1013",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1014",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1015",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1016",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1019",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1021",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1023",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1024",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1026",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1029",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1030",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1034",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1035",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1039",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1044",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1045",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1046",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1048",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1050",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1053",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1055",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1057",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1058",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1063",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1064",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1067",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1069",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1073",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1076",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1079",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1081",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1082",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1083",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "1084",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2011",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2101",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2103",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2105",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2107",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2108",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2111",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2112",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2113",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2114",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2117",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2118",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2119",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2121",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2123",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2124",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2125",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2127",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2128",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2130",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2133",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2135",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2136",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2137",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2140",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2141",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2142",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2144",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2145",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2150",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2151",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2152",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2154",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2160",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2161",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2162",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2163",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2164",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2166",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2167",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2169",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "2170",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3001",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3002",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3003",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3004",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3008",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3011",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3014",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3016",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3017",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3018",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3020",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3021",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3022",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3023",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3026",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3028",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3031",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3034",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3036",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3037",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3040",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3042",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3043",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3045",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3101",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3104",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3110",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3113",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3118",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3119",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3120",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3122",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3123",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3124",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3128",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3129",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3131",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3132",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3133",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3134",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3135",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3137",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3139",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3140",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3142",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3145",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3146",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3147",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3148",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3201",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3251",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3253",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3257",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3258",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3260",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3261",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3262",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3264",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3270",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3275",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3280",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3281",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3283",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3284",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3285",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3287",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3291",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3292",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3294",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3297",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3298",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3301",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3306",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3307",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3309",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3310",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3312",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3313",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3314",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3317",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3319",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3320",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3321",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3322",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3323",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3324",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3325",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3326",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3328",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3329",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3330",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3332",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3333",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3430",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3431",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3433",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3434",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3435",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3436",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3438",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3440",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3441",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3442",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3443",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3444",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3445",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3446",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3447",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3452",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3453",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3455",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3456",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3457",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3461",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3463",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3466",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3473",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3474",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3475",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3476",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3477",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3480",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3482",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3484",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3485",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3486",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3487",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3601",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3612",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3613",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3614",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3615",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3617",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3619",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3620",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3621",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3623",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3624",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3626",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3627",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3701",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3708",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3709",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3710",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3711",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3713",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3714",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3716",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3717",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3718",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3719",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3721",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3722",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3723",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3724",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3725",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3729",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3730",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3731",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3732",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3801",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3851",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3852",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3853",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3861",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3862",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3871",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3873",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3875",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3876",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3880",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3882",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3883",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3890",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3891",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3892",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3893",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3894",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3895",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3896",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3897",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3898",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3899",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3901",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3905",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3906",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3907",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3908",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3910",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3913",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3914",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3915",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3917",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3918",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3921",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3924",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3925",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3926",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3927",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3929",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3930",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3931",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3932",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3933",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "3936",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4001",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4004",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4010",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4011",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4012",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4013",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4020",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4022",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4023",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4025",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4033",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4035",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4043",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4050",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4052",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4054",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4061",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4063",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4064",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4068",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4101",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4108",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4110",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4112",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4113",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4116",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4118",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4119",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4122",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4123",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4125",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4126",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4128",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4129",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4131",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4132",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4133",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4136",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4139",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4141",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4143",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4144",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4146",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4151",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4152",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4154",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4201",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4206",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4208",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4210",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4211",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4213",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4215",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4216",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4219",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4220",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4222",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4223",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4224",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4227",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4228",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4232",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4234",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4240",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4241",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4242",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4244",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4245",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4247",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4248",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4301",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4332",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4333",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4335",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4336",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4337",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4339",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4340",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4341",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4342",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4344",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4345",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4348",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4350",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4351",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4352",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4354",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4355",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4358",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4359",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4401",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4405",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4406",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4409",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4410",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4412",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4415",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4416",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4417",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4420",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4421",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4424",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4425",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4426",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4428",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4429",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4501",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4561",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4562",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4566",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4567",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4570",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4571",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4572",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4573",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4574",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4576",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4577",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4580",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4582",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4583",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4584",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4585",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4586",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4587",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4590",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4591",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4592",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4594",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4595",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4601",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4604",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4611",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4612",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4614",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4615",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4616",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4617",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4618",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4619",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4621",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4622",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4623",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4625",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4626",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4627",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4628",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4630",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4631",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4633",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4634",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4635",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4636",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4638",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4640",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4641",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4642",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4643",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4645",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4647",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4648",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4649",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4650",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4652",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4701",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4706",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4707",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4708",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4711",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4712",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4713",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4715",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4716",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4718",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4723",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4724",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4726",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4727",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4728",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4729",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4730",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4731",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4733",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4735",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4801",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4824",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4825",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4826",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4830",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4833",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4834",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4835",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4836",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4837",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4838",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4840",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4841",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4844",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4846",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4847",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4852",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4853",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4855",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4860",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4862",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4863",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4865",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4870",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4871",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4873",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4880",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "4884",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5001",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5011",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5012",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5015",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5016",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5020",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5022",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5033",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5041",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5044",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5045",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5047",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5052",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5060",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5062",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5064",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5065",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5070",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5071",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5101",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5106",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5108",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5109",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5110",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5111",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5112",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5113",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5115",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5118",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5120",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5123",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5124",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5125",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5128",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5129",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5130",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5133",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5134",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5135",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5201",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5202",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5204",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5208",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5209",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5210",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5211",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5212",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5214",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5215",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5216",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5217",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5218",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5220",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5221",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5222",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5223",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5224",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5226",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5228",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5229",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5230",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5232",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5236",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5237",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5238",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5239",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5301",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5304",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5305",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5311",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5312",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5315",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5316",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5318",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5320",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5323",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5325",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5326",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5327",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5328",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5329",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5330",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5331",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5333",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5334",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5335",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5337",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5413",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5422",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5438",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5439",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5440",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5441",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5442",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5443",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5444",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5447",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5449",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5450",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5451",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5456",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5458",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5459",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5460",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5461",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5462",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5463",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5465",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5469",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5470",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5471",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5473",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5474",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5477",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5481",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5601",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5651",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5652",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5653",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5655",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5656",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5660",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5662",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5664",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5666",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5668",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5671",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5674",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5676",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5677",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5680",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5681",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5685",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5687",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5692",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5695",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5696",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5697",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5698",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5701",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5704",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5705",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5706",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5707",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5709",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5711",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5716",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5717",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5719",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5722",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5725",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5726",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5729",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5730",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5732",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5733",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5735",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5736",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5737",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5739",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5740",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5742",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5745",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5748",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5750",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5751",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  },
+  {
+    "code": "5752",
+    "country_id": 120,
+    "country_code": "LV",
+    "type": "full",
+    "source": "latvijas-pasts-via-IcebergBuilder"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 671 Latvia postcodes (the full Latvijas Pasts index) sourced
from the ``IcebergBuilder/pasta_indeksi`` mirror.

- **Coverage**: country-only by design.
- **Format**: 4-digit canonical form (the source ships ``LV-NNNN``,
  the importer strips the prefix to match the country regex
  ``^(?:LV)*(\d{4})$``).

## Why country-only

The source file is a flat list of ``LV-NNNN`` codes with no
locality / county mapping. Ships country-only — matches the
SE/SI/ZA/GR/VN precedent.

## Source & licence

- Source URLs:
  - https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Novadi
  - https://raw.githubusercontent.com/IcebergBuilder/pasta_indeksi/master/Riga
- Origin: Latvijas Pasts publicly published index, redistributed by
  IcebergBuilder.
- Each row: ``"source": "latvijas-pasts-via-IcebergBuilder"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 671 codes match ``country.postal_code_regex``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)