### PR TITLE
feat(postcodes/KE): bulk-import 630 Kenya postcodes via Posta Kenya (#1039)

### DIFF
--- a/bin/scripts/sync/import_kenya_postcodes.py
+++ b/bin/scripts/sync/import_kenya_postcodes.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Kenya -> contributions/postcodes/KE.json importer for #1039.
+
+Source data
+-----------
+The community ``njoguamos/kenya-postal-codes`` repository ships
+Posta Kenya (Postal Corporation of Kenya) office codes:
+
+    {"id": 1, "code": 40101, "office": "Ahero"}
+
+Source URL: https://raw.githubusercontent.com/njoguamos/kenya-postal-codes/master/src/kenya-postal-codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Pads codes to the 5-digit canonical form.
+3. Ships country-only: source has no county / region mapping.
+4. Writes contributions/postcodes/KE.json idempotently.
+
+License & attribution
+---------------------
+- Source: njoguamos/kenya-postal-codes (open redistribution of
+  Posta Kenya's publicly published office index).
+- Each row: ``source: "posta-kenya-via-njoguamos"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_kenya_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/njoguamos/kenya-postal-codes/"
+    "master/src/kenya-postal-codes.json"
+)
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    rows = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    ke_country = next((c for c in countries if c.get("iso2") == "KE"), None)
+    if ke_country is None:
+        print("ERROR: KE not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(ke_country.get("postal_code_regex") or ".*")
+    print(f"Country: Kenya (id={ke_country['id']})")
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for row in rows:
+        raw = row.get("code")
+        if raw is None:
+            continue
+        code = str(raw).strip().zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        office = (row.get("office") or "").strip()
+        key = (code, office.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(ke_country["id"]),
+            "country_code": "KE",
+        }
+        if office:
+            record["locality_name"] = office
+        record["type"] = "full"
+        record["source"] = "posta-kenya-via-njoguamos"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/KE.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/KE.json
+++ b/contributions/postcodes/KE.json
@@ -1,0 +1,5042 @@
+[
+  {
+    "code": "00100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "G.P.O Nairobi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Jamia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "City Square",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kenyatta N.Hospital",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Athi River",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magadi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiserian",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Namanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngong Hills",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Loitokitok",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00216",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Githunguri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00217",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Limuru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00218",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngecha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00219",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karuri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00220",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kijabe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00221",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Matathia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00222",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Uplands",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00223",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kagwe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00227",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kinari",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00229",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nderu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00232",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ruiru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00240",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gathugu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00241",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kitengela",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ronald Ngala St",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tom Mboya St",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karungu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Enterprise Road",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "J.K.I. Airport",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00502",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karen",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00503",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbagathi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00504",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mchumbi Rd",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00505",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngong Road",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00506",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyayo Stadium",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00507",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Viwandani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00508",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Yaya Towers",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00509",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Langata",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00510",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Makongeni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00511",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ongata Rongai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00515",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Buruburu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00516",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Dandora",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00517",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Uhuru Gardens",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00518",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kayole",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00519",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mlolongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00520",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ruai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00521",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Embakasi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00600",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngara Road",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00601",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gigiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00603",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lavington",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00604",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lower Kabete",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00605",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Uthiru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00606",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sarit Centre",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00607",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kamiti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00609",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kenyatta University",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00610",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Eastleigh",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00611",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mathare Valley",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00614",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wangige",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00618",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ruaraka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00619",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muthaiga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00620",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mobil Plaza",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00621",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Village Market",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00623",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Parklands",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00625",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kangemi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00800",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Westlands",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00900",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiambu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00901",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngewa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "00902",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kikuyu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01000",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Thika",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01001",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kalimoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01002",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Madaraka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01003",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gituamba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01004",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kanjuku",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01013",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gatura",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01015",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ithanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01016",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndithini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01018",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kirwara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01020",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kenol",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01027",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Donyosabuk",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01028",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gatukuyu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01030",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gatundu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01031",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kindaruma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01033",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kagundu-Ini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01034",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kandara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kajiado",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bissel",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mashuru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "01214",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kahuti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "02201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabianga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "04332",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kosele",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "09013",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyeri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karatina",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiganjo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mukurweini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mweiga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Naro Moru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Othaya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Endarasha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Giakanja",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gakere Road",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10111",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gakindu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10114",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gatitu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10122",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiamariga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10129",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mugunda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10133",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ruringu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10140",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kimathi Way",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muranga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kahuro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kangema",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10203",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kigumo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiriaini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maragua",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kahuhia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kihoya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Saba-Saba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gitugi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10210",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gacharage-Ini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10213",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gikoe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10218",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kangari",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10226",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kambiti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10230",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sagana",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10233",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10234",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kora",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10239",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gakungu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kerugoya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kianyaga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Baricho",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wanguru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kutus",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10306",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kagio",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10307",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kagumo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10309",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiamutugu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10310",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kimbimbi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nanyuki",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Doldol",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "10406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Timau",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nakuru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bondeni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Elburgon",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Eldama Ravine",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Menengai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mogotio",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Molo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Njoro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rongai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Subukia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20110",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Timber Mills",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20112",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lanet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20113",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bahati",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20114",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabazi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20115",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Egerton",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20116",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gilgil",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Naivasha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20123",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Milton Siding",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20124",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mirangine",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20128",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Solai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20131",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Keringet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20133",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiptangwanyi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20134",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kamara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20142",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Naishi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20147",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maai Mahiu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20151",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sulmac",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20152",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Olenguruone",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20157",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabarak",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kericho",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kipkelion",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20203",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Londiani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Roret",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sosiot",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiptugumo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Fort Ternan",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20210",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Litein",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapsoit",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20213",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiptere",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20214",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapkatet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20215",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Cheborge",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20217",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chesinendet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20220",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kedowa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20222",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chemamul",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20225",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kimulot",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyahururu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Miharati",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Oljoro-Orok",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ol-Kalou",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaheho",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wanjohi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20306",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndaragwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20307",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Igwamiti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20313",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rurii",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20317",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndunyu Njeru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20318",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "North-Kinangop",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20319",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "South-Kinangop",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20320",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kinamba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20321",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rumuruti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20322",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Marmanet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20328",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karandi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20330",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Laikipia Campus",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bomet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chebunyo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20402",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Longisa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mogogosiek",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndanai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sigor",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sotik",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20407",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chemaner",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20422",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Silibwet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20423",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Siongiroi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20424",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Amalo (Formerly Oloomirani)",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Narok",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Keekorok",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20503",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ololulunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20504",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nairage Enkare",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20600",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maralal",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20601",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Baragoi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20602",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Suguta Mar Mar",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "20603",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wamba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Eldoret",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ainabkoi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Burnt Forest",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kipkabus",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Moiben",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Soy",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Turbo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Moi University",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Timboroa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Huruma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30112",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Langas",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30114",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaptagat",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30128",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kimwarer",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30129",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chepkorio",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30133",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chepkoilel",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kitale",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Endebess",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mois Bridge",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapcherop",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Matunda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapsara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiminini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30214",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ziwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30215",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kesogon",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapsabet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nandi Hills",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lessos",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabiyet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapcheno",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kobujoi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30306",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Baraton",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30307",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mosoriot",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabarnet",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabartonjo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Marigat",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nginyang",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tenges",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kampi-Ya-Samaki",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30407",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Seretunin",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lodwar",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kakuma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30502",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kalokol",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30503",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lokichoggio",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30504",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lokitaung",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30600",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapenguria",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30601",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kacheliba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30602",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ortum",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30603",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wei-Wei",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30605",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chepareria",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30700",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Iten",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30701",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaptarakwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30704",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tambach",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30705",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapsowar",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30706",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chebiemit",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "30707",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tot",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kisumu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ahero",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kombewa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kondele",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Koru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maseno",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muhoroni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sondu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40110",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Songhor",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40111",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Pap-Onditi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40112",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Dago",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40116",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chemelil",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Daraja Mbili",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40118",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Katito",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40122",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Awasi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40123",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mega City",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40124",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyabondo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40126",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyangande",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40127",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyangori",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40131",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Paw Akuche",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40132",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rabuor",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40133",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Reru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40137",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ratta",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40139",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Akala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40141",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Winam (Kisumu Gpo Extn.)",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kisii",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gesusu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Keroka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40203",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyamache",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ogembo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyambunwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyamarambe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Etago",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Igare",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kenyenya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40212",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Keumbu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40218",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyangusu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40220",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Riosiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40221",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Omogonchoro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40222",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Oyugis",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40223",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kadongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40228",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Uriri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40229",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tabaka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Homa Bay",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kendu Bay",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndhiwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rangwe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kandiege",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbita",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40307",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40308",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sindo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40309",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Asumbi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40310",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mawego",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40311",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyangweso",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40319",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mfangano",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40320",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mirogi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40323",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ogongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40326",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rodi Kopany",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40333",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyandhiwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Suna",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40402",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyatike",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rapogi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sare",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40409",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muhuru Bay",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40412",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ranen",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40413",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kehancha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40414",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Isibania",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40418",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Suba-Kuria",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyamira",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ikonge",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40502",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyansiongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40503",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gesima",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40506",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kebirigo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40507",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magombo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40508",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magwagwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40510",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mokomoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40511",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rigoma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40512",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Riochanda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40514",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyaramba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40516",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magena",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40600",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Siaya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40601",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bondo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40602",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndori",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40603",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngiya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40604",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ragengni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40605",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sidindi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40606",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ugunja",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40607",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ukwala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40608",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Uranga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40609",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Usenge",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40610",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Yala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40611",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyilima",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40612",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sawagongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40613",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Madiany",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40614",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sega",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40615",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nango",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40620",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Boro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40623",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Luhano",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40628",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mutumbu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40632",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyamonye",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40635",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sigomre",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40640",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Hawinga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40700",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kilgoris",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "40701",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lolgorian",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kakamega",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Butere",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mumias",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Malava",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Khayega",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bukura",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Shianda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Shinyalu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lugari",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bulimbo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50115",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kakunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50116",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kambiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Koyonzo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50118",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lubao",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50119",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lunza",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50125",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Musanda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50127",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nambacha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50135",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Khwisero",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50137",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Booker",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50138",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Milimani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bungoma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Cheptais",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chwele",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50203",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kapsokwony",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kimilili",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Webuye",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bokoli",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Misikhu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sirisia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Malakisi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50210",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Buyofu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Naitiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50212",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndalu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50216",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kamukuywa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50218",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lugulu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50220",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lwakhakha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50225",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mukhe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50226",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Myanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50230",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lukusi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50235",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mabusi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50240",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Luandeti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50241",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kipkarren River",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50242",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lumakanda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50244",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Amagoro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50245",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Brigadier",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maragoli",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chamakanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gisambai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaimosi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50307",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Luanda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50308",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Serem",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50309",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tiriki",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50310",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Vihiga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50311",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wodanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50312",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Hamisi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50313",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiritu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50314",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Emuhaya",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50315",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kilingili",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50316",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Banja",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50317",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chavakali",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50318",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gambogi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50325",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mago",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Busia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Amukura",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bumala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Butula",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Funyula",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50408",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kamuriai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50409",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nambale",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50410",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Port Victoria",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "50423",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mubwayo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Embu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Manyatta",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ishiara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Runyenjes",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Siakago",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karaba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60113",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiritiri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60114",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kithimu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Karurumo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60118",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kanja",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60121",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wachoro",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60122",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kianjokoma",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60125",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kubu Kubu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Meru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kibirichia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nkubu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mitunguu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Githongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kanyakine",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kiirua",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gaitu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kionyo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60212",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gitemene",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60213",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tunyai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60214",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nkondi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60215",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Marimanti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60216",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kinoru",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Isiolo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Garba Tulla",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Merti",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chuka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chogoria",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60402",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Igoji",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magumoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gatunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ikuu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kathwana",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60407",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Magutuni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60408",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Marima",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60409",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chiakariga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60410",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chiakanyinga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Marsabit",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Loiyangalani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60502",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Laisamis",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60600",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maua",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60601",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Laare",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60602",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kianjai",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60604",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Miathene",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60605",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muthara",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60607",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mikinduri",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "60700",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Moyale",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Garissa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Hola",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Modo Gashe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Dadaab",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bura Tana",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Masalani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wajir",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Habaswein",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Griftu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mandera",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Elwak",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Rhamu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "70303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Takaba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mombasa G.P.O",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Bamburi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Changamwe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Coast Gen. Hospital",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Docks",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaloleni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mkomani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kilindini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kilifi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80109",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mtwapa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80110",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Likoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80111",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mtongwe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80112",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Makupa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80113",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mariakani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80114",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mazeras",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80115",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Moi Airport",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mtopanga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80118",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nyali.",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80119",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Vipingo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80120",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Samburu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80122",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kengeleni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Malindi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Garsen",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Watamu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ganze",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80206",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gongoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Madina",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80208",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Gede",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Vitengeni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Voi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Taveta",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Werugha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wundanyi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mwatate",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80306",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mgange",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80308",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sagalla",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80309",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tausa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80311",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngambwa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80313",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mgambonyi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80314",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chumvini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80317",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Maungu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ukunda",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Diani Beach",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80402",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lunga Lunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kwale",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80404",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Msambweni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80405",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kinango",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80406",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Matuga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80407",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Shimba Hills",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80409",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Shimoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80410",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kikoneni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80500",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Lamu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80501",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Faza",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80502",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mokowe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80503",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mpeketoni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "80504",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Witu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90100",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Machakos",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90101",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Masii",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90102",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mwala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90103",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Wamunyu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90104",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mitaboni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90105",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kathiani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90106",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Katangi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90107",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kaviani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90108",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kola",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90110",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbiuni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90111",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kivunga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90112",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Miu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90113",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Muthetheni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90115",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kangundo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90117",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mutituni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90118",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndalani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90119",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Matuu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90120",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Iiani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90121",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Emali",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90122",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kalamba",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90123",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kasikeu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90124",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kithimani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90125",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kikima",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90127",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbumbuni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90128",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mtitu Andei",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90129",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ngwata",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90130",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nunguni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90132",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Sultan Hamud",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90133",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tawa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90134",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Yoani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90135",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ikalaasa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90136",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nzeeka",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90137",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kibwezi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90138",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Makindu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90139",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ekalakala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90140",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Matiliku",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90141",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Masinga",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90143",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nziu",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90144",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kithyoko",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90145",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Daystar",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90147",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Chumvi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90200",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kitui",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90201",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mutomo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90202",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ndooa",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90203",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Tulia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90204",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kisasi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90205",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kabati",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90207",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Ikutha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90209",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kyeni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90211",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mutha",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90213",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Zombe",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90214",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mbitini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90220",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kyatune",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90300",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Makueni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90301",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Okia",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90302",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kathonzweni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90303",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kitise",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90304",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mavindini",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90305",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kilala",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90400",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Mwingi",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90401",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kyuso",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90402",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Migwani",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90403",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Kamuwongo",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  },
+  {
+    "code": "90407",
+    "country_id": 113,
+    "country_code": "KE",
+    "locality_name": "Nguni",
+    "type": "full",
+    "source": "posta-kenya-via-njoguamos"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 630 Kenya postcodes from the Posta Kenya office index sourced
from the ``njoguamos/kenya-postal-codes`` mirror.

- **Coverage**: country-only by design.
- **Granularity**: post-office level — one record per
  ``(5-digit code, office)`` pair.

## Source & licence

- Source URL: https://raw.githubusercontent.com/njoguamos/kenya-postal-codes/master/src/kenya-postal-codes.json
- Origin: Postal Corporation of Kenya office codes, redistributed by
  njoguamos.
- Each row: ``"source": "posta-kenya-via-njoguamos"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 630 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)