### PR TITLE
feat(postcodes/NG): bulk-import 3,728 Nigeria postcodes via NIPOST (#1039)

### DIFF
--- a/bin/scripts/sync/import_nigeria_postcodes.py
+++ b/bin/scripts/sync/import_nigeria_postcodes.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Nigeria -> contributions/postcodes/NG.json importer for #1039.
+
+Source data
+-----------
+The community ``ifeLight/nigeria-lga-postalcodes`` repository ships
+NIPOST's catalogue keyed by State -> LGA -> [postcodes]:
+
+    {"Adamawa": {"Demsa": ["642108", ...], ...}, ...}
+
+Source URL: https://raw.githubusercontent.com/ifeLight/nigeria-lga-postalcodes/master/src/resources/state-lga-postcode-map.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Resolves ``state_id`` via case-insensitive name match against
+   states.json with a 1-entry alias for the FCT (source: "Federal
+   Capital Territory" -> CSC: "Abuja Federal Capital Territory").
+3. Emits one record per ``(postcode, LGA)`` pair (one LGA can hold
+   multiple unique 6-digit codes).
+4. Writes contributions/postcodes/NG.json idempotently.
+
+License & attribution
+---------------------
+- Source: ifeLight/nigeria-lga-postalcodes (open redistribution of
+  NIPOST's publicly published postcode index).
+- Each row: ``source: "nipost-via-ifeLight"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_nigeria_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/ifeLight/nigeria-lga-postalcodes/"
+    "master/src/resources/state-lga-postcode-map.json"
+)
+
+STATE_ALIASES: Dict[str, str] = {
+    "federal capital territory": "Abuja Federal Capital Territory",
+}
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    ng_country = next((c for c in countries if c.get("iso2") == "NG"), None)
+    if ng_country is None:
+        print("ERROR: NG not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(ng_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    ng_states = [s for s in states if s.get("country_id") == ng_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in ng_states}
+    print(f"Country: Nigeria (id={ng_country['id']}); states indexed: {len(ng_states)}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for state_name, lgas in data.items():
+        target = STATE_ALIASES.get(state_name.lower(), state_name).lower()
+        state = state_by_name.get(target)
+        if not isinstance(lgas, dict):
+            continue
+        for lga, codes in lgas.items():
+            for raw in codes or []:
+                code = str(raw).strip()
+                if not code:
+                    continue
+                if code.isdigit() and len(code) == 5:
+                    code = "0" + code
+                if not regex.match(code):
+                    skipped_bad_regex += 1
+                    continue
+                key = (code, lga.strip().lower())
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                record: Dict[str, object] = {
+                    "code": code,
+                    "country_id": int(ng_country["id"]),
+                    "country_code": "NG",
+                }
+                if state is not None:
+                    record["state_id"] = int(state["id"])
+                    record["state_code"] = state.get("iso2")
+                    matched_state += 1
+                else:
+                    skipped_no_state += 1
+
+                if lga:
+                    record["locality_name"] = lga.strip()
+                record["type"] = "full"
+                record["source"] = "nipost-via-ifeLight"
+                records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/NG.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/NG.json
+++ b/contributions/postcodes/NG.json
@@ -1,0 +1,37282 @@
+[
+  {
+    "code": "020261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "032119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "040111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "046113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "066102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "082016",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Batsari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "093011",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100216",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100218",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100245",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100246",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100247",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100248",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100265",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100267",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100268",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100269",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100274",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100275",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100276",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100278",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100311",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100312",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100313",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100314",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100322",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100323",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100324",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100331",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100341",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100351",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "100361",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101226",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101227",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101228",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101229",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101245",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101255",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "101283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Amuwo-Odofin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ojo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Amuwo-Odofin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ajeromi-Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102216",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102311",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102312",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102313",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102314",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102341",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "102361",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Lagos Mainland",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "103261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Badagry",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "104233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "105101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ibeju-Lekki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "105102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Kosofe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "106101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Epe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "106102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Epe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "106103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Epe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "106104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Epe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Asa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Obafemi Owode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "110282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Imeko Afon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Imeko Afon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Imeko Afon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "111109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Abeokuta North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ifo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ifo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ewekoro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ifo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112216",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112226",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112265",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "112272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ado-Odo/Ota",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "120282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu Ode",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "121101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Sagamu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "121102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Sagamu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "121103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ikorodu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "121104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Remo North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ijebu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ogun Waterside",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ogun Waterside",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ogun Waterside",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "122107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Ogun Waterside",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Lagelu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Egbeda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ido-Osi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200137",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200138",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200139",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200140",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Akinyele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200255",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200256",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200257",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200258",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "200285",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibadan North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201007",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibarapa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibarapa Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibarapa Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ona Ara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ona Ara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ibarapa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "201106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Tafa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iseyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iseyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iseyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Itesiwaju",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Itesiwaju",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Itesiwaju",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Kajola",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Kajola",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Kajola",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "202116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Iwajowa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Atisbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Atisbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Atisbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "203109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Saki East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Surulere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Surulere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Surulere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ori Ire",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "210271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Afijio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Afijio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Afijio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Afijio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Awe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Afijio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Atiba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211172",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "211273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Oyo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "212101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Irepo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "212102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Ogbomosho North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "212103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Orelope",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "212104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 296,
+    "state_code": "OY",
+    "locality_name": "Orelope",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220255",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220256",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220257",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220265",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ife Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220311",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220321",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220341",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220351",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220371",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "220381",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedaade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedaade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedaade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irewole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Isokan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "221106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Isokan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Olorunda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "230284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Osogbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Odo Otin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boripe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boripe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boripe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boripe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boluwaduro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boluwaduro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Boluwaduro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "231119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232015",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedire",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ede North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Iwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ede South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Iwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedire",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ede South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Shiroro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 306,
+    "state_code": "LA",
+    "locality_name": "Ojo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Aiyedire",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Egbedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ola Oluwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ejigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ejigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ejigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "232119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ejigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Atakunmosa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Oriade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Obokun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233226",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233227",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233236",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233285",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ilesa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233311",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233312",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233321",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233322",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233331",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233341",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233361",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233362",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233371",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "233381",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 323,
+    "state_code": "OG",
+    "locality_name": "Odogbolu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "234101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ila",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "234102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "234103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 322,
+    "state_code": "OS",
+    "locality_name": "Ifedayo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Asa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Asa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Asa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "240281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ilorin West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Moro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Moro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Moro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Moro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Moro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "241113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "242101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Baruten",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "242102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Baruten",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "242103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Baruten",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "242104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Baruten",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "242105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Baruten",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Edu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Edu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Edu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Pategi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Pategi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "243106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Pategi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "250101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Offa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "250102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Oyun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "250103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Oyun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Irepodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Isin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "251106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Isin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "252101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Oke Ero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "252102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Oke Ero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "252103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "252104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "252105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 295,
+    "state_code": "KW",
+    "locality_name": "Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "260101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Lokoja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "260102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Lokoja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "260103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Lokoja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "260104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Lokoja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "260105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kogi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ijumu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "261271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Kabba/Bunu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "262101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Yagba East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "262102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Yagba East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "262103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Yagba West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Okene",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Okene",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ogori/Magongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ajaokuta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ajaokuta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "263106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ajaokuta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "264101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Okehi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "264102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Okehi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "264103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Adavi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ankpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ankpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ankpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Olamaboro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Omala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Olamaboro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Olamaboro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "270109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Olamaboro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Idah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Idah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Idah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Idah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ibaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ofu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ofu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "271109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Ofu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Dekina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Dekina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Dekina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "272114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 298,
+    "state_code": "KO",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Oredo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Egor",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ikpoba Okha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ikpoba Okha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "300283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Orhionmwon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "301115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Uhunmwonde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "302121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Igueben",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Igueben",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Igueben",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "310120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "311116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan North-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Etsako Central",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "312123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Akoko-Edo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Ovia South-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "313111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "320242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika North East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "321281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ika South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ukwuani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "322137",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Uvwie",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Udu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ethiope East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ethiope East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "330106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ethiope East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ethiope West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ethiope West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "331262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Sapele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Burutu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "332281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Bomadi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Bomadi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Patani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Patani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "333117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ughelli South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "334118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Isoko North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Idanre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Idanre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Idanre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ifedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ifedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ifedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ifedore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "340284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akure North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Owo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ose",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "341119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "342232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Akoko North-West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Odigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Odigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Odigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Odigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Odigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "350113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Okitipupa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ondo West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ile Oluji/Okeigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ile Oluji/Okeigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ile Oluji/Okeigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ile Oluji/Okeigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "351111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ile Oluji/Okeigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Irele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Irele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Irele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Irele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Irele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tureta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ese Odo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ilaje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ilaje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ilaje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ilaje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "352120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 321,
+    "state_code": "ON",
+    "locality_name": "Ilaje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ilejemeje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ilejemeje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ilejemeje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "360282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ado Ekiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ise/Orun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Emure",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "361272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Irepodun/Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Irepodun/Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Irepodun/Ifelodun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Efon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "362222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ise/Orun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ise/Orun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Gbonyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Gbonyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Gbonyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Gbonyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Gbonyin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Oye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Oye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370226",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370227",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "370282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ikole",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ido-Osi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ido-Osi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ido-Osi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Oye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Oye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "371106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Oye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "372109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 309,
+    "state_code": "EK",
+    "locality_name": "Ijero",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "400281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Enugu North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401137",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401138",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401139",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401140",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401141",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401142",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401143",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401144",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401145",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Oji River",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401146",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Oji River",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401147",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Oji River",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401148",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401149",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Oji River",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "401150",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Oji River",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nkanu East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402137",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402138",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402139",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402140",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Aninri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402141",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Aninri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402142",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Aninri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402143",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Aninri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "402144",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Aninri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "410116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Nsukka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Owan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Etiti",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Oshimili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "411126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Uzo Uwani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Isi Uzo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Isi Uzo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Isi Uzo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Isi Uzo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Ezeagu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "412114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Udenu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "413111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Igbo Eze North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "420281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Awka North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "421112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "422124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "423199",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "430281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ogbaru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "431125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ihiala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anambra West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "432214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Anaocha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Oyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "433115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ayamelum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "434243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Onitsha North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Aguata",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ekwusigo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ekwusigo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ekwusigo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "435115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Ekwusigo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ikwuano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "440236",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umuahia North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isuikwuato",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umu Nneochi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umu Nneochi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umu Nneochi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Umu Nneochi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "441123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Bende",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "442115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "450272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "451117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "452116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Osisioma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Osisioma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Osisioma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Osisioma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ohafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Osisioma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "453120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ugwunagbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Aba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ngor Okpala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "460281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Owerri Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Mbaitoli",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "461122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Isiala Ngwa South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Aboh Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ezinihitte Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Onicha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "462124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Esan South-East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Obowo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 318,
+    "state_code": "ED",
+    "locality_name": "Oredo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Ukwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "463122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ahiazu Mbaise",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Orumba North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oguta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "464119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ohaji/Egbema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Unuimo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Unuimo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "470283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Okigwe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Obi Ngwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isiala Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nkwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nkwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nkwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nkwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nkwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Njikoka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nwangele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nwangele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "471125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Nwangele",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ehime Mbano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "472124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ihitte/Uboma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Nnewi South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Dunukofia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orsu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "473281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Orlu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 289,
+    "state_code": "EN",
+    "locality_name": "Awgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Aniocha South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Njaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Njaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Isu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Njaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "474128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ikeduru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "475122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Ideato South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Izzi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "480282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Abakaliki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "481123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ishielu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ebonyi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "482136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ikwo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "490101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Afikpo South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "490102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Afikpo South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "490103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Afikpo South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaozara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaozara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaozara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaozara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ohaozara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 303,
+    "state_code": "AB",
+    "locality_name": "Arochukwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Onicha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Onicha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Onicha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "491110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Onicha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Obio/Akpor",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Okrika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ogu/Bolo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500265",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "500272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Port Harcourt",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "501101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Eleme",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "501102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Tai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "501103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Gokana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "502101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Khana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "502102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Khana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "502103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Oyigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "502104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Oyigbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "503101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Bonny",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "503102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Andoni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "503103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Opobo/Nkoro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "504101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Asari-Toru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "504102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Degema",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "504103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Akuku-Toru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Abua/Odual",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ogba/Egbema/Ndoni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ogba/Egbema/Ndoni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "510281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ahoada West",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "511101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Ikwerre",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "511102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Emohua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "512101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 4926,
+    "state_code": "RI",
+    "locality_name": "Etche",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "512102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 308,
+    "state_code": "IM",
+    "locality_name": "Oru East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etim Ekpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uruan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uruan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uruan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Itu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "520271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Uyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Atai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibesikpo Asutan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "521110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibesikpo Asutan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etinan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etinan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etinan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "522110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Nsit-Ibom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Udung-Uko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Udung-Uko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Urue-Offong/Oruko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Urue-Offong/Oruko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Okobo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Urue-Offong/Oruko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oron",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Onna",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oron",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "523121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oron",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Onna",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Onna",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Esit Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Esit Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "524110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ibeno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Ekpene",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Ekpene",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Obot Akara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Obot Akara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Obot Akara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eket",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "530113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Essien Udim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "531119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Abak",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Abak",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Abak",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Abak",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Abak",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etim Ekpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etim Ekpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etim Ekpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Etim Ekpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "532112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ukanafun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ukanafun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ukanafun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ukanafun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "533114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Oruk Anam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Abasi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Abasi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Abasi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Abasi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ikot Abasi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eastern Obolo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Ini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Mbo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "534206",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 304,
+    "state_code": "AK",
+    "locality_name": "Eastern Obolo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "540281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Calabar Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "541115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bakassi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "542112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Akamkpa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "543107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Abi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Bekwarra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "550282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Boki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obubra",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "551252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552018",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "552111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Obudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Kolokuma/Opokuma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Southern Ijaw",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Southern Ijaw",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "560233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "561101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Sagbama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "561102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Ekeremor",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Brass",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Nembe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Ogbia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "562261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 314,
+    "state_code": "CR",
+    "locality_name": "Ikom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "569101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Jere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600230",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600235",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "600282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Maiduguri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Damboa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Chibok",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Askira/Uba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Kaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Damboa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "601107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Askira/Uba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "602101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Mobbar",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "602102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Gubio",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "602103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Abadam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "602104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Magumeri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Kwaya Kusar",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bayo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Zaki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Hawul",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Shani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Shani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Shani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Hawul",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "603253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Biu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Konduga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Gwoza",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Konduga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "610251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Bama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Dikwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Ngala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Kala/Balge",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Mafa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Marte",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Dikwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "611107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Ngala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "612101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Monguno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "612102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Kukawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "612103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Nganzai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "612104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Guzamala",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "620261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Damaturu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "621101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "621102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "622101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "622102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "622103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "622104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "622105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "630281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Nguru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "631101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "631102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "631103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "632101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "632102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Anka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640230",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "640284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Yola North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mayo Belwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mayo Belwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mayo Belwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Fufore",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "641127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Jada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Ganye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Lamurde",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mayo Belwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "642121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mayo Belwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Numan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "643112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gayuk",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Maiha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Maiha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Maiha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Maiha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 305,
+    "state_code": "BY",
+    "locality_name": "Yenagoa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "650272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Mubi North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Madagali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Madagali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Madagali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Madagali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "651113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Madagali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Girei",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gombi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Song",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gombi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "652109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Gombi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "657101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "657108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Michika",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "660271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Jalingo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "661109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "662107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "663101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "663102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "670111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "671101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "671102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "671103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "671104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "672101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "672102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "672103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "672104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 297,
+    "state_code": "YO",
+    "locality_name": "Bade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Tarauni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Tarauni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Gwale",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kumbotso",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Ungogo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "700282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kano Municipal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "701101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Dawakin Tofa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "701102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Rimin Gado",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "701103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Tofa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "701104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Bagwai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "702101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Gezawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "702102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Gabasawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "702103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Minjibir",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "702104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Dambatta",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "702105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Makoda",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "703101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Bichi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "703102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Tsanyawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "703103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kunchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "704101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Gwarzo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "704102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Shanono",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "704103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kabo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "704104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Karaye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "704105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Rogo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "705101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kazaure",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "705102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Yankwashi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "705103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Roni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "705104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Roni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "705105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Gwiwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "710101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Rano",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "710102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kibiya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "710103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Bunkure",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "710104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "710105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Doguwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "711101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "711102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Madobi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "711103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Garun Mallam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "711104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Bebeji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "711105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Kiru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "712101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Garko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "712102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Sumaila",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "712103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Takai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "712104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Albasu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Hong",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Ajingi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Dawakin Kudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Warawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "713281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 300,
+    "state_code": "KN",
+    "locality_name": "Wudil",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kiyawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Jahun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Jahun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Miga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "720281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Dutse",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "721101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Birnin Kudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "721102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Gwaram",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "721103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Buji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "730101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Malam Madori",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "730102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kaugama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kafin Hausa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kiri Kasama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Guri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Biriniwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Auyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "731281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Hadejia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Gumel",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Gumel",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Gagarawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Babura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Maigatari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "732106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Sule Tankarkar",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "733101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "733102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Ringim",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "733103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Taura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Toro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "740281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bauchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "741101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Dass",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "741102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Tafawa Balewa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "741103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Kafin Hausa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "741103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Tafawa Balewa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "741104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Bogoro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "742101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Ningi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "742102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Ningi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "742103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Warji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "742104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Ganjuwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "743101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Alkaleri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "743102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Alkaleri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "743103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Alkaleri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "743104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Kirfi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Misau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Misau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Shira",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Shira",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Giade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "750116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Darazo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "751101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Katagum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "751102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Katagum",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "751104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Giade",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "751105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Itas/Gadau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Damban",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Damban",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Damban",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Zaki",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Gamawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "752107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Gamawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kwami",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kwami",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Dukku",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Dukku",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Dukku",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "760253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Gombe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Yamaltu/Deba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Yamaltu/Deba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Yamaltu/Deba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Demsa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "761126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Balanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "762101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Funakaye",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "762102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Ndokwa East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "762103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Nafada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Shongom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 320,
+    "state_code": "AD",
+    "locality_name": "Toungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "770117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Kaltungo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "771101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Billiri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "771102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Akko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "771103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Akko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "771104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 310,
+    "state_code": "GO",
+    "locality_name": "Akko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Igabi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Igabi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Igabi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Chikun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kajuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kajuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kajuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Birnin Gwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800245",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800246",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800247",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800263",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800264",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800265",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "800283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaduna North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801136",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801138",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801139",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801140",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801141",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801142",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801143",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801144",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801147",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801148",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801149",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801150",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Jema'a",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801151",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801152",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801153",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801154",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801155",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801156",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "801157",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Jere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kudan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kudan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kudan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kagarko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802120",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802121",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802122",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802123",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802124",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802125",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802126",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802127",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802128",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802129",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802130",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802131",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802132",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802133",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802137",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802138",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802139",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802140",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802141",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802142",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802143",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802144",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802145",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802146",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802147",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802148",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802149",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802150",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802151",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802152",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802153",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zangon Kataf",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802155",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802156",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "802157",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Soba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Soba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sabon Gari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Giwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Giwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sabon Gari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Sabon Gari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810254",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "810282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Zaria",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kauru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kauru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kauru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 312,
+    "state_code": "BA",
+    "locality_name": "Tafawa Balewa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Lere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Lere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kubau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "811108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kubau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "812101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Ikara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "812102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Ikara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "812103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Makarfi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "812104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kudan",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Batagarawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kaita",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Jibia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Jibia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "820281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Katsina",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "821101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Dutsin Ma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "821103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kurfi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "821103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Safana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "821104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Dan Musa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "822101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kankia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "822102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kusada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "822103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Rimi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "822104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Charanchi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "822105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Bindawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "823101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Mani",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "823102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Mashi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "823103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Dutsi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "823104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Ingawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Sandamu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Zango",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Baure",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "824281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Daura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Faskari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Dandume",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Sabuwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830225",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830273",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830274",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830275",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "830282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "831101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Bakori",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "831102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Danja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "831266",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Funtua",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "832101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Malumfashi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "832102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kankara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "832103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Kafur",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "833101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Musawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "833102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 313,
+    "state_code": "KT",
+    "locality_name": "Matazu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Wamako",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Wamako",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Wamako",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840234",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840245",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "840283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sokoto North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "841101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tangaza",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "841102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Gudu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Wurno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Wurno",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Rabah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Rabah",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Goronyo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Sabon Birni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "842110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 311,
+    "state_code": "EB",
+    "locality_name": "Ezza North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "843101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Illela",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "843102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Toto",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "843103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Gwadabawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Kebbe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "850271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Tambuwal",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "851101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Yabo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "851102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Yabo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "851103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Shagari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "852101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Bodinga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "852103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Bodinga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "852106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Dange Shuni",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "852107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Kware",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "852211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "853101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Binji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "853102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Silame",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "853104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Bodinga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Gwandu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Gwandu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Gwandu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 299,
+    "state_code": "ZA",
+    "locality_name": "Gusau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "860281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Birnin Kebbi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Augie",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Augie",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Arewa Dandi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Arewa Dandi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "861281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Argungu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bunza",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bunza",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bunza",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Kalgo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Dandi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Kalgo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Suru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Suru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "862108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Suru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "863101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Jega",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "863102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Aleiro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "863102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Jega",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "863103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Maiyama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "863104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Aleiro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Ngaski",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Ngaski",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Shanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Shanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "870271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Yauri",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "871101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bagudo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "871102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bagudo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "871103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bagudo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "871104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Bagudo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "871105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 316,
+    "state_code": "DE",
+    "locality_name": "Warri North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Fakai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Wasagu/Danko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Wasagu/Danko",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Sakaba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872215",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "872281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 290,
+    "state_code": "KE",
+    "locality_name": "Zuru",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882283",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882284",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "882285",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "883101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 292,
+    "state_code": "SO",
+    "locality_name": "Isa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "888222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 319,
+    "state_code": "TA",
+    "locality_name": "Karim Lamido",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900243",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900244",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900245",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900246",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900247",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900285",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900286",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900287",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "900288",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "901101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Bwari",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "902101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Gwagwalada",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "903101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kuje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "903102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kuje",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "904109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "905101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "905102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "910101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Suleja",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "910102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Gurara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "910103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Tafa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "911101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Lapai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "911102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Lapai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "911103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Lapai",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "911104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Agaie",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "911105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Agaie",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Gbako",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Gbako",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Katcha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Borgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Katcha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "912241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bida",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "913101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Lavun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "913102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Lavun",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "913103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mokwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "913104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mokwa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "913106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Borgu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Bosso",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Paikoro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Paikoro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "920282",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Chanchaga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "921101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Shiroro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "921102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Shiroro",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "921103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Munya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Rafi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Rafi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Rafi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Rafi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mariga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mariga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "922107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Wushishi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Kontagora",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mashegu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Mashegu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Rijau",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Magama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Magama",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "923107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 317,
+    "state_code": "NI",
+    "locality_name": "Agwara",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bassa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 288,
+    "state_code": "JI",
+    "locality_name": "Buji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930119",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 307,
+    "state_code": "BO",
+    "locality_name": "Jere",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930253",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930262",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930271",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930272",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "930281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Jos North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Riyom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Riyom",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "931241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Barkin Ladi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mangu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "932116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Bokkos",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Pankshin",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanke",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanke",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanke",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanke",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Kwali",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "933112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanke",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Shendam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Shendam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Shendam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mikang",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mikang",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mikang",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Shendam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "940108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Mikang",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang South",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "941112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Langtang North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Kanam",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Wase",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Wase",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "942108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 302,
+    "state_code": "PL",
+    "locality_name": "Wase",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Lafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Lafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Doma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kachia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Doma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Doma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Doma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "950108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Lafia",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Awe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Awe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Awe",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Keana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Keana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Keana",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "951109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 294,
+    "state_code": "KD",
+    "locality_name": "Kaura",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Akwanga",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960134",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Wamba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960135",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Wamba",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960167",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa Egon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960168",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa Egon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "960169",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa Egon",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Keffi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Kokona",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 315,
+    "state_code": "AN",
+    "locality_name": "Idemili North",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abaji",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 293,
+    "state_code": "FC",
+    "locality_name": "Abuja Municipal Area Council",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "961106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Karu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Nasarawa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Toto",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Toto",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "962106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 301,
+    "state_code": "NA",
+    "locality_name": "Toto",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Guma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Guma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Guma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Guma",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "970261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Gwer East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Gwer East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Gwer East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Gwer East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Gwer East",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Obi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Konshisha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "971110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Konshisha",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ohimini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ohimini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ohimini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ohimini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ohimini",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Apa",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Agatu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972211",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972212",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972213",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972214",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972221",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972222",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972223",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972224",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972231",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972232",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972233",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972241",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972242",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972251",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972252",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972261",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Oturkpo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "972281",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Makurdi",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Okpokwu",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ado",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ado",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ado",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "973110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ado",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "980110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Logo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981113",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Tarka",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981114",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ushongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981115",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ushongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981116",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ushongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981117",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ushongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "981118",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Ushongo",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982101",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Kwande",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982102",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Kwande",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982103",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Kwande",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982104",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Kwande",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982105",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982106",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982107",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982108",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982109",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982110",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982111",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  },
+  {
+    "code": "982112",
+    "country_id": 161,
+    "country_code": "NG",
+    "state_id": 291,
+    "state_code": "BE",
+    "locality_name": "Vandeikya",
+    "type": "full",
+    "source": "nipost-via-ifeLight"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 3,728 Nigeria postcodes spanning all 37 states (including the
Federal Capital Territory), sourced from the
``ifeLight/nigeria-lga-postalcodes`` mirror of NIPOST's catalogue.

- **Coverage**: 100% state resolution.
- **Granularity**: LGA (Local Government Area) level — one record per
  ``(6-digit code, LGA)`` pair.

## How it works

State match is case-insensitive against ``states.json``. A 1-entry
``STATE_ALIASES`` bridge handles the FCT (source uses "Federal Capital
Territory"; CSC uses "Abuja Federal Capital Territory").

## Source & licence

- Source URL: https://raw.githubusercontent.com/ifeLight/nigeria-lga-postalcodes/master/src/resources/state-lga-postcode-map.json
- Origin: NIPOST publicly published postcode index, redistributed by
  ifeLight.
- Each row: ``"source": "nipost-via-ifeLight"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 3,728 codes match ``country.postal_code_regex`` (``^(\d{6})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 161``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)