### PR TITLE
feat(postcodes/CR): bulk-import 481 Costa Rica postcodes via Correos de Costa Rica (#1039)

### DIFF
--- a/bin/scripts/sync/import_costa_rica_postcodes.py
+++ b/bin/scripts/sync/import_costa_rica_postcodes.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Costa Rica -> contributions/postcodes/CR.json importer for #1039.
+
+Source data
+-----------
+The community ``llperez/codigos_cr`` repository ships Correos de
+Costa Rica's 5-digit catalogue:
+
+    CodigoPostal,Provincia,Canton,Distrito
+    10101,San José,San José,Carmen
+
+Source URL: https://raw.githubusercontent.com/llperez/codigos_cr/master/postal.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Resolves ``state_id`` via case-insensitive name match against
+   states.json — all 7 CR provinces match directly.
+3. Emits one record per ``(postcode, distrito)`` pair.
+4. Writes contributions/postcodes/CR.json idempotently.
+
+License & attribution
+---------------------
+- Source: llperez/codigos_cr; data is the publicly published Correos
+  de Costa Rica catalogue.
+- Each row: ``source: "correos-de-costa-rica-via-llperez"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_costa_rica_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/llperez/codigos_cr/master/postal.csv"
+)
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    cr_country = next((c for c in countries if c.get("iso2") == "CR"), None)
+    if cr_country is None:
+        print("ERROR: CR not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(cr_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    cr_states = [s for s in states if s.get("country_id") == cr_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in cr_states}
+    print(f"Country: Costa Rica (id={cr_country['id']}); states indexed: {len(cr_states)}")
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        code = (row.get("CodigoPostal") or "").strip().zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        province = (row.get("Provincia") or "").strip()
+        distrito = (row.get("Distrito") or "").strip()
+        canton = (row.get("Canton") or "").strip()
+        locality = ", ".join(p for p in (distrito, canton) if p)
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(cr_country["id"]),
+            "country_code": "CR",
+        }
+        state = state_by_name.get(province.lower())
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "correos-de-costa-rica-via-llperez"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/CR.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/CR.json
+++ b/contributions/postcodes/CR.json
@@ -1,0 +1,4812 @@
+[
+  {
+    "code": "10101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Carmen, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Merced, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Hospital, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Catedral, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Zapote, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10106",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Francisco de Dos Ríos, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10107",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Uruca, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10108",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Mata Redonda, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10109",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Pavas, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10110",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Hatillo, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10111",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Sebastian, San José",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Escazú, Escazú",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Antonio, Escazú",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael, Escazú",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Desamparados, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Miguel, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Juan de Dios, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael Arriba, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Antonio, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Frailes, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Patarra, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Cristobal, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10309",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Rosario, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10310",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Damas, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10311",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael Abajo, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10312",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Gravilias, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10313",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Los Guido, Desamparados",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Santiago, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Mercedes Sur, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Barbacoas, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Grifo Alto, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10405",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10406",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Candelaria, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10407",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Desamparaditos, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10408",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Antonio, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10409",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Chires, Puriscal",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Marcos, Tarrazu",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Lorenzo, Tarrazu",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Carlos, Tarrazu",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Aserrí, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Tarbaca, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Vuelta de Jorco, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Gabriel, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10605",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Legua, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10606",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Monterrey, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10607",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Salitrillos, Aserrí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Colón, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Guayabo, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Tabarcia, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10704",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Piedras Negras, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10705",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Picagres, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10706",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Jaris, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10707",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Quitirrisi, Mora",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Guadalupe, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Francisco, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Calle Blancos, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Mata de Platano, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10805",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Ipis, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10806",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Rancho Redondo, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10807",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Purral, Goicoechea",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Santa Ana, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10902",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Salitral, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10903",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Pozos, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10904",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Uruca, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10905",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Piedades, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "10906",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Brasil, Santa Ana",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Alajuelita, Alajuelita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Josecito, Alajuelita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Antonio, Alajuelita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Concepción, Alajuelita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11005",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Felipe, Alajuelita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Isidro, Vázquez de Coronado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael, Vázquez de Coronado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Dulce Nombre de Jesús, Vázquez de Coronado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Patalillo, Vázquez de Coronado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Cascajal, Vázquez de Coronado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Ignacio de Acosta, Acosta",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Guaitil, Acosta",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Palmichal, Acosta",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Cangrejal, Acosta",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Sabanillas, Acosta",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Juan, Tibás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Cinco esquinas, Tibás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Anselmo Llorente, Tibás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Leon XIII, Tibás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Colima, Tibás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Vicente, Moravia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Jeronimo, Moravia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Trinidad, Moravia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Pedro, Montes de Oca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Sabanilla, Montes de Oca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Mercedes, Montes de Oca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Rafael, Montes de Oca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Pablo, Turrubares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Pedro, Turrubares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Juan de Mata, Turrubares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Luis, Turrubares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11605",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Carara, Turrubares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Santa María, Dota",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Jardin, Dota",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Copey, Dota",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Curridabat, Curridabat",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Granadilla, Curridabat",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Sánchez, Curridabat",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Tirrases, Curridabat",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Isidro del General, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11902",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "El General, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11903",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Daniel Flores, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11904",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Rivas, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11905",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Pedro, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11906",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Platanares, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11907",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Pejibaye, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11908",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Cajón, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11909",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Barú, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11910",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Río Nuevo, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11911",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Páramo, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "11912",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "La Amistad, Pérez Zeledón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Pablo, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Andres, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Llano Bonito, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Isidro, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12005",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "Santa Cruz, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "12006",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1214,
+    "state_code": "SJ",
+    "locality_name": "San Antonio, León Cortés",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Alajuela, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San José, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Carrizal, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Antonio, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Guacima, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20106",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Isidro, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20107",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Sabanilla, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20108",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Rafael, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20109",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Río Segundo, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20110",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Desamparados, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20111",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Turrucares, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20112",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Tambor, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20113",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Garita, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20114",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Sarapiquí, Alajuela",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Ramón, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Santiago, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Juan, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Piedades Norte, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Piedades Sur, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20206",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Rafael, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20207",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Isidro, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20208",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Ángeles, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20209",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Alfaro, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20210",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Volio, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20211",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Concepción, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20212",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Zapotal, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20213",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Peñas Blancas, San Ramón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Grecia, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Isidro, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San José, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Roque, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Tacares, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Río Cuarto, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Puente de Piedra, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Bolivar, Grecia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Mateo, San Mateo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Desmonte, San Mateo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Jesús María, San Mateo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Labrador, San Mateo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Atenas, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Jesús, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Mercedes, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Isidro, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20505",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Concepcion, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20506",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San José, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20507",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Santa Eulalia, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20508",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Escobal, Atenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Naranjo, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Miguel, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San José, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Cirri Sur, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20605",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Jeronimo, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20606",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Juan, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20607",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Rosario, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20608",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Palmitos, Naranjo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Palmares, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Zaragoza, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Buenos Aires, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20704",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Santiago, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20705",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Candelaria, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20706",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Esquipulas, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20707",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "La Granja, Palmares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Pedro, Poás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Juan, Poás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Rafael, Poás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Carrillos, Poás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20805",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Sabana Redonda, Poás",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Orotina, Orotina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20902",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Mastate, Orotina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20903",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Hacienda Vieja, Orotina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20904",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Coyolar, Orotina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "20905",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Ceiba, Orotina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Quesada, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Florencia, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Buenavista, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Aguas Zarcas, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21005",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Venecia, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21006",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Pital, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21007",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Fortuna, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21008",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Tigra, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21009",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Palmera, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21010",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Venado, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21011",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Cutris, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21012",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Monterrey, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21013",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Pocosol, San Carlos",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Zarcero, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Laguna, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Tapezco, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Guadalupe, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Palmira, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21106",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Zapote, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21107",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Brisas, Zarcero",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Sarchí Norte, Sarchí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Sarchí Sur, Sarchí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Toro Amarillo, Sarchí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Pedro, Sarchí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Rodríguez, Sarchí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Upala, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Aguas Claras, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San José, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Bijagua, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Delicias, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Dos Ríos, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Yolillal, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Canalete, Upala",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Los Chiles, Los Chiles",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Caño Negro, Los Chiles",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "El Amparo, Los Chiles",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Jorge, Los Chiles",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "San Rafael, Guatuso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Buenavista, Guatuso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Cote, Guatuso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "21504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1215,
+    "state_code": "A",
+    "locality_name": "Katira, Guatuso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Oriental, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Occidental, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Carmen, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Nicolas, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Aguacaliente (San Francisco), Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30106",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Guadalupe (Arenilla), Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30107",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Corralillo, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30108",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tierra Blanca, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30109",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Dulce Nombre, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30110",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Llano Grande, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30111",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Quebradilla, Cartago",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Paraíso, Paraíso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Santiago, Paraíso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Orosi, Paraíso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Cachí, Paraíso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Llanos de Santa Lucia, Paraíso",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tres Ríos, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Diego, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Juan, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Rafael, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Concepcion, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Dulce Nombre, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Ramón, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Río Azúl, La Uníón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Juan Viñas, Jiménez",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tucurrique, Jiménez",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Pejibaye, Jiménez",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Turrialba, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "La Suiza, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Peralta, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Santa Cruz, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30505",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Santa Teresita, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30506",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Pavones, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30507",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tuis, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30508",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tayutic, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30509",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Santa Rosa, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30510",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tres Equis, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30511",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "La Isabel, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30512",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Chirripo, Turrialba",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Pacayas, Alvarado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Cervantes, Alvarado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Capellades, Alvarado",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Rafael, Oreamuno",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Cot, Oreamuno",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Potrero Cerrado, Oreamuno",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30704",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Cipreses, Oreamuno",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30705",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Santa Rosa, Oreamuno",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tejar, El Guarco",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "San Isidro, El Guarco",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Tobosi, El Guarco",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "30804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1211,
+    "state_code": "C",
+    "locality_name": "Patio de Agua, El Guarco",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Heredia, Heredia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Mercedes, Heredia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Francisco, Heredia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Ulloa, Heredia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Varablanca, Heredia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Barva, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Pedro, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Pablo, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Roque, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santa Lucia, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40206",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San José de la Montaña, Barva",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santo Domingo, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Vicente, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Miguel, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Paracito, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santo Tomas, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santa Rosa, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Tures, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Pará, Santo Domingo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santa Bárbara, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Pedro, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Juan, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Jesús, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40405",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santo Domingo, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40406",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Purabá, Santa Bárbara",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Rafael, San Rafael",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Josecito, San Rafael",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Santiago, San Rafael",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Los Ángeles, San Rafael",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40505",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Concepción, San Rafael",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Isidro, San Isidro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San José, San Isidro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Concepcion, San Isidro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Francisco, San Isidro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Antonio, Belén",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Ribera, Belén",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "La Asunción, Belén",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Joaquín de Flores, Flores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Barrantes, Flores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Llorente, Flores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "San Pablo, San Pablo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "40902",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Rincón de Sabanilla, San Pablo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "41001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Puerto Viejo, Sarapiquí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "41002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "La Virgen, Sarapiquí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "41003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Horquetas, Sarapiquí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "41004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Llanuras del Gaspar, Sarapiquí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "41005",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1212,
+    "state_code": "H",
+    "locality_name": "Cureña, Sarapiquí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Liberia, Liberia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Cañas Dulces, Liberia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Mayorga, Liberia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Nacascolo, Liberia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Curubandé, Liberia",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Nicoya, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Mansion, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "San Antonio, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Quebrada Honda, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Samara, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50206",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Nosara, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50207",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Belen de Nosarita, Nicoya",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Santa Cruz, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Bolson, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Veintisiete de Abril, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Tempate, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Cartagena, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Cuajiniquil, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Diria, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Cabo Velas, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50309",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Tamarindo, Santa Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Bagaces, Bagaces",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Fortuna, Bagaces",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Mogote, Bagaces",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Río Naranjo, Bagaces",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Filadelfia, Carrillo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Palmira, Carrillo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Sardinal, Carrillo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Belén, Carrillo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Cañas, Cañas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Palmira, Cañas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "San Miguel, Cañas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Bebedero, Cañas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50605",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Porozal, Cañas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Juntas, Abangares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Sierra, Abangares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "San Juan, Abangares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50704",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Colorado, Abangares",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Tilarán, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Quebrada Grande, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Tronadora, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Santa Rosa, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50805",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Libano, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50806",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Tierras Morenas, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50807",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Arenal, Tilarán",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Carmona, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50902",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Santa Rita, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50903",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Zapotal, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50904",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "San Pablo, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50905",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Porvenir, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "50906",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Bejuco, Nandayure",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "La Cruz, La Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Santa Cecilia, La Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Garita, La Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Santa Elena, La Cruz",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Hojancha, Hojancha",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Monte Romo, Hojancha",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Puerto Carrillo, Hojancha",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "51104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1209,
+    "state_code": "G",
+    "locality_name": "Huacas, Hojancha",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Puntarenas, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Pitahaya, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Chomes, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Lepanto, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60105",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Paquera, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60106",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Manzanillo, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60107",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Guacimal, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60108",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Barranca, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60109",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Monte Verde, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60110",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Isla del Coco, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60111",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Cobano, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60112",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Chacarita, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60113",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Chira, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60114",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Acapulco, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60115",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "El Roble, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60116",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Arancibia, Puntarenas",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Espíritu Santo, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "San Juan Grande, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Macacona, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "San Rafael, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "San Jerónimo, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60206",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Caldera, Esparza",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Buenos Aires, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Volcan, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Potrero Grande, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Boruca, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Pilas, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Colinas, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60307",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Changena, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60308",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Briolley, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60309",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Brunka, Buenos Aires",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Miramar, Montes de Oro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "La Uníón, Montes de Oro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "San Isidro, Montes de Oro",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Puerto Cortes, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Palmar, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Sierpe, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60504",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Bahia Ballena, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60505",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Bahía Drake, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60505",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Piedras Blancas, Osa",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Quepos, Aguirre",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Savegre, Aguirre",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Naranjito, Aguirre",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60701",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Golfito, Golfito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60702",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Puerto Jiménez, Golfito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60703",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Guaycara, Golfito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60704",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Pavón, Golfito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60801",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "San Vito, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60802",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Sabalito, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60803",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Aguabuena, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60804",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Limoncito, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60805",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Pittier, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60806",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Gutierrez Brown, Coto Brus",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "60901",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Parrita, Parrita",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61001",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Corredor, Corredores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61002",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "La Cuesta, Corredores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61003",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Canoas, Corredores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61004",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Laurel, Corredores",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Jacó, Garabito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "61102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1210,
+    "state_code": "P",
+    "locality_name": "Tárcoles, Garabito",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70101",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Limón, Limón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70102",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Valle La Estrella, Limón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70103",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Río Blanco, Limón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70104",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Matama, Limón",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70201",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Guapiles, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70202",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Jiménez, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70203",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Rita, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70204",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Roxana, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70205",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Cariari, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70206",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Colorado, Pococí",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70301",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Siquirres, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70302",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Pacuarito, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70303",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Florida, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70304",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Germania, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70305",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Cairo, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70306",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Alegría, Siquirres",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70401",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Bratsi, Talamanca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70402",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Sixaola, Talamanca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70403",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Cahuita, Talamanca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70404",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Telire, Talamanca",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70501",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Matina, Matina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70502",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Battan, Matina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70503",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Carrandi, Matina",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70601",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Guácimo, Guácimo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70602",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Mercedes, Guácimo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70603",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Pocora, Guácimo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70604",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Río Jiménez, Guácimo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  },
+  {
+    "code": "70605",
+    "country_id": 53,
+    "country_code": "CR",
+    "state_id": 1213,
+    "state_code": "L",
+    "locality_name": "Duacari, Guácimo",
+    "type": "full",
+    "source": "correos-de-costa-rica-via-llperez"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 481 Costa Rica postcodes covering every distrito of Correos de
Costa Rica's catalogue, sourced from the ``llperez/codigos_cr``
mirror.

- **Coverage**: 100% province resolution (7/7 in states.json).
- **Granularity**: distrito level — one record per
  ``(5-digit code, distrito)`` pair.

## Source & licence

- Source URL: https://raw.githubusercontent.com/llperez/codigos_cr/master/postal.csv
- Origin: Correos de Costa Rica publicly published catalogue.
- Each row: ``"source": "correos-de-costa-rica-via-llperez"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 481 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 53``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)