### PR TITLE
feat(postcodes/DO): bulk-import 2,320 Dominican Republic postcodes via INPOSDOM (#1039)

### DIFF
--- a/bin/scripts/sync/import_dominican_republic_postcodes.py
+++ b/bin/scripts/sync/import_dominican_republic_postcodes.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Dominican Republic -> contributions/postcodes/DO.json importer for #1039.
+
+Source data
+-----------
+The community ``manuelpgs/localidades-postales-rd`` repository ships
+INPOSDOM's catalogue across two CSV files:
+
+- ``provincias.csv``: ``id, ?, name``
+- ``localidades.csv``: ``id, prov_id, name, postcode, ?, ?``
+
+Source URLs:
+- https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/master/csv/provincias.csv
+- https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/master/csv/localidades.csv
+
+What this script does
+---------------------
+1. Fetches both CSVs via urllib (curl is blocked).
+2. Builds a source-prov-id -> CSC iso2 map by ASCII-fold name match
+   with a 2-entry STATE_ALIASES bridge for "BAHORUCO" -> "Baoruco"
+   (source spelling differs by an extra ``h``) and "SAN JUAN DE LA
+   MAGUANA" -> "San Juan" (CSC drops the "de la Maguana" suffix).
+3. Emits one record per ``(postcode, locality)`` pair.
+4. Writes contributions/postcodes/DO.json idempotently.
+
+License & attribution
+---------------------
+- Source: manuelpgs/localidades-postales-rd; data is the publicly
+  published INPOSDOM postcode catalogue.
+- Each row: ``source: "inposdom-via-manuelpgs"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_dominican_republic_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL_PROVINCES = (
+    "https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/"
+    "master/csv/provincias.csv"
+)
+SOURCE_URL_LOCALITIES = (
+    "https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/"
+    "master/csv/localidades.csv"
+)
+
+STATE_ALIASES: Dict[str, str] = {
+    "bahoruco": "Baoruco",
+    "san juan de la maguana": "San Juan",
+}
+
+
+def _fold(value: str) -> str:
+    s = "".join(
+        c for c in unicodedata.normalize("NFKD", (value or "").lower())
+        if not unicodedata.combining(c)
+    )
+    return s.strip()
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    do_country = next((c for c in countries if c.get("iso2") == "DO"), None)
+    if do_country is None:
+        print("ERROR: DO not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(do_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    do_states = [s for s in states if s.get("country_id") == do_country["id"]]
+    state_by_fold: Dict[str, dict] = {_fold(s["name"]): s for s in do_states}
+    print(f"Country: Dominican Republic (id={do_country['id']}); states indexed: {len(do_states)}")
+
+    prov_text = fetch_text(SOURCE_URL_PROVINCES)
+    src_prov_to_state: Dict[str, dict] = {}
+    for row in csv.reader(io.StringIO(prov_text)):
+        if len(row) < 3:
+            continue
+        src_id = (row[0] or "").strip()
+        name = (row[2] or "").strip()
+        # Strip parenthetical alternate names ("SANTO DOMINGO (GRAN)" etc.)
+        clean = name.split("(")[0].strip()
+        target = STATE_ALIASES.get(_fold(clean), clean)
+        state = state_by_fold.get(_fold(target))
+        if state is not None:
+            src_prov_to_state[src_id] = state
+    print(f"Source provinces resolved: {len(src_prov_to_state)}")
+
+    loc_text = fetch_text(SOURCE_URL_LOCALITIES)
+    rows = list(csv.reader(io.StringIO(loc_text)))
+    print(f"Source localities: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        if len(row) < 5:
+            continue
+        prov_id = (row[1] or "").strip()
+        locality = (row[2] or "").strip()
+        code = (row[3] or "").strip().zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(do_country["id"]),
+            "country_code": "DO",
+        }
+        state = src_prov_to_state.get(prov_id)
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "inposdom-via-manuelpgs"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/DO.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/DO.json
+++ b/contributions/postcodes/DO.json
@@ -1,0 +1,23202 @@
+[
+  {
+    "code": "05751",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Padre Granjero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "05751",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Atlantica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "09205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Reparadero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10100",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4095,
+    "state_code": "01",
+    "locality_name": "Distrito Nacional",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Centro de Los Heroes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mata Hambre",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Universitaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Geronimo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Universitaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Robles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Vergel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Esperilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Manguito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Esperilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Embajador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10113",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sarasota",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10114",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mirador Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Atala",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Portal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rocamar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "30 de Mayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Ganadera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. La Paz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Honduras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10118",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Antillas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10118",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Costa Brava",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10118",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Cacique",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10118",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Arrecifes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10119",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10120",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Yuca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Arboleda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Centro Olimpico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10123",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10124",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10125",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lope de Vega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10126",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10127",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Piantini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10128",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Carmelita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10129",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Fernandez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10130",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Julieta Morales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10130",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Praditos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10131",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Prados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10132",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Prados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10133",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Castellana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10134",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Geronimo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10135",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Moderna",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10135",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Encarnacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10135",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Las Praderas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10136",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Rosmil",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10137",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Restauradores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10138",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Manganagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10139",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Millones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10140",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Millones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10141",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Millones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10142",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Millones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10143",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Estela Marina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10144",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Millones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10145",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Quisqueya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10146",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Quisqueya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10147",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Evaristo Morales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10148",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Piantini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10149",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Millon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10150",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Piantini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Don Bosco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Don Bosco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Miraflores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Gazcue",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ensanche Independencia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Primavera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10208",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10209",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Lugo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10210",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Colonial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10211",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Lazaro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10212",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10213",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Borojol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10214",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Francisca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10215",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Francisca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10216",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10217",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10218",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Reparto Aguedita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Guachupita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Fuente",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maria Auxiliadora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Martin de Porres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Cienaga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Domingo Savio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Guandules",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "27 de Febrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Agua Dulce",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maria Auxiliadora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Maria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10308",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Consuelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10309",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Consuelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Espaillat",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Gualey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "24 de Abril",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Simon Bolivar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10406",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10407",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Capotillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10408",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Zurza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10409",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villas Agricolas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10410",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Caridad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10410",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villas Agricolas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10411",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Ensanchito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10412",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Juana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10413",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Juana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cristo Rey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Caliche",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Trueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Cuarenta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Yaquito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Parque Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Arroyo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cuesta Hermosa III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Isabel Villas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Arroyo Manzano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Buenavista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cuesta Brava",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Fundacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Meseta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Manzano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pista de Motocros La Yuca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Puerta de Hierro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Arroyo Hondo II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas de Arroyo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cuesta Hermosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Puya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lomas de Arroyo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Arroyos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Pino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Aldaba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Carmen Amelia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Agustinita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Caminos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Viejo Arroyo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10511",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10513",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Kennedy",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10514",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cachiman",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10514",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10515",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Obrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10516",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Agustina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10516",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Cementera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10516",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lanina Gautier",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Constelacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Proceres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Jardines Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Villas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Rios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10605",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Arroyo Hondo I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10605",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Arroyo Hondo III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10605",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Arroyo Hondo III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10606",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas Del Seminario",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10606",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. La Yuca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10607",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Don Honorio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10607",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Condado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10607",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Ceiba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10607",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Guayabos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10607",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Claudina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10608",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Colinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10608",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10608",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pradera Hermosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10608",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Elena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10608",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Marina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10700",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Santo Domingo Oeste",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Batey Palmarejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Redencion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lotificacion Vista Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pantoja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Angeles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Girasoles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Peralejos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Palma Real",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Reparto Miguelina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Reparto Samaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Brisa Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Palma Real",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Chavon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio La Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio La Torre",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio La Union",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Tamarindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lebron",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Alcarrizos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Obras Publicas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Gran Poder de Dios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio La Piña",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barriolandia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Compuerta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Piita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Alcarrizos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Americanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Libertadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Valle Encantado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa San Felipe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Franca de Los Alcarrizos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "24 de Abril",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Las Mercedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Chucho",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Savica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Las Mercedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Varia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos Del Oeste",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El 14",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Catorce",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Cienaga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Concordia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villas Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Arenoso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Progreso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Palmarejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Codiana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Crorias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nuevo Amanecer",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nuevo Horizonte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Palmarejito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. San Rafael",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Caliche",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Olimpo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Aura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Alameda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Antillano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Batey Bienvenido",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Bella Colina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Buenas Noches",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Hato Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Venta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Manoguayabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Alameda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Almendra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Peravia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Bayona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Paraiso Del Caribe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rivera Del Haina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Nazaret",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Abanico de Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Palmar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Engombe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Ivan Guzman Klan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lotificacion Engombe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Loyola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rosa Maria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10905",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Agraria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10905",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Caobas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "10905",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Capbotas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Industrial de Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Enriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Holguin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Juan Pablo Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Galaxia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Luz Divina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. El Rosal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Josue",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Libertador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "16 de Agosto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Aesa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Atlantida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Buenos Aires Del",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Costa Caribe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Gacela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mirador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Jose Contreras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Km. 8",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Miramar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nordesa III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Acacias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mar Azul",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Dominicanos Ausentes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Jardines Del Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Km. 7",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Tropicana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Loteria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Enriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Pedregal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Luz Consuelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sandra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sandra I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Cacicazgos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mirador Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Renacimiento",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Renacimiento",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Real",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11113",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Industrial de Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11114",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Altagracia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11114",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Santo Domingo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas de Canaan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Cafe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "12 de Haina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Canaan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villas Del Cafe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Costa Azul",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Costa Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Placeta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Manresa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Puerto de Haina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11200",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Santo Domingo Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Mamey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Haras Nacionales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Jardines de Genovena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maraon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rep. Villa Maria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Sarah Gabriela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Valle Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Carmela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Mella",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Satelite",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Vista Bella",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Carlos Alvarez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maraon II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mata Los Indios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. El Dorado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. El Remanso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colonia de Los Doctores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maria Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Primavera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Fundo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Conucos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Suriel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Santa Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Torito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Sol de Luz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Maximo Gomez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Industrial de la Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Buena Vista I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Buena Vista II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ceuta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Industrial de Villa Mella",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Campechito II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cruz Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Eden",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Antena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Javilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Julia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Radiante",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Reparto Rudima",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Guaricanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Modelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nueva Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Proyecto Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos Del Parque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Hermanas Mirabal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Jacagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Palmeras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Casabes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ponce",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Proyecto Bnv",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Majagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lotes Y Servicios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Chavon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de la Yuca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Milloncito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Mina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Noelia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Libertad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Palmares",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Progreso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Charles de Gaulle",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "2 de Enero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Sabana Perdida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros de Sabana Perdida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas Del Ozama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Cristal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Barquita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sabana Centro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sabana Perdida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Enriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Coordinadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Loteria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Salome Urea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Blanca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11500",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Santo Domingo Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Ozama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Molinuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Alma Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Jardines de Alma Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ens. Alma Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Faro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Alma Rosa II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Rosal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ivette",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Italia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ralma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Savica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Franconia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Loteria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Paraiso Oriental",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Amanda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11508",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Vecinos Unidos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Alpes I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Bello Campo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Hamarap",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Isabel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mi Sueo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Oriente",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11509",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sol Naciente",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Carolina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Brisal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mendoza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mi Hogar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11510",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11511",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11511",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rep. Alma Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cancino I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cancino II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Trinitarios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mandinga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11512",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Narcisa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11513",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cabirma Del Este I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11513",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Lomisa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11514",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Idalia A 1",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11515",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Cachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11515",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Prados Del Cachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11516",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cancino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11516",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lucerna",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11517",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cancino Adentro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11517",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Colinas Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11517",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Cachon de la Rubia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11517",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Don Oscar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11517",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Vista Hermosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11518",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Amapola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11518",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Pablo II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11519",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Altos de Cancino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Calero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Francia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Simonico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Molinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Parque Del Este I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sans Souci",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Faro A Colon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Maquiteria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Parque Mirador Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Parque Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11605",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Tres Ojos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11606",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Americas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11606",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Olimpica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11704",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Corales Del Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11704",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Teresa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11704",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Tropical Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11705",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Arismar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11705",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Frailes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11705",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Marbella III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11706",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Frailes II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11706",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Reparto Caribe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11706",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Bartolo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11707",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Lotificacion Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11707",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Adela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11707",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Eloisa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11708",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mirador Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ana Virginia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Invfapol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Molinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Trinitarios II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad de Los Trabajadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Eugenio M. de Hostos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Invivienda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rep. Villa Carmen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Trabajadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Carmen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Brisa de Charles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Brisa Del Eden",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Clarimar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Jose de Mendoza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Amarilis III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nuevo Amanecer",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Fernandez Oriental",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Mirador Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Kennedy",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Buenaventura II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Restauradores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Villa Esfuerzo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11806",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Del Almirante I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11806",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Ciudad Del Almirante II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11806",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Zona Franca Industrial de Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Hainamosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Invi Cea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Invimosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Nuevo Renacer",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Parque Ind. Nueva Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Urb. Ana T. Balaguer",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11808",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Batey La Balsa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11808",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Batey Piragua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11808",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Sabaneta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Barrio Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cabirma Del Este II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "El Tamarindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Rosales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Res. Don Oscar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "La Milagrosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Mina Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Pidoca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Felicidad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Vietnam",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Katanga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Mina Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Cerros Del Ozama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Francisco Del",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Frutas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Rosario Sanchez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11905",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los 3 Brazos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11905",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Mil Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11906",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Las Enfermeras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "11906",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4093,
+    "state_code": "32",
+    "locality_name": "Los Mina Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio El Toconal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Japon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio La Filipina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio La Urea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Las Piedras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Miramar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Boca Del Soco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Farrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Evaristo Sanchez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. La Roca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Los Cajones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Plan Porvenir",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Sarmiento",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Guayacanes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Enrriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Universitaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "La Punta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Zona Franca Industrial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio 24 de Abril",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Azul",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio La Puerta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Ingenio Porvenir",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Juan Dolio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Invicea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Los Cuatros Caminos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Batey Central",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Buenos Aires",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Ensanche Vega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Villa Magdalena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Villa Olimpica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Cerveceria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio El 3 I/2",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Lindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Villa Progreso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Ortiz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Restauracion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Cerveceria Nacional Dominicana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Independencia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Jhon F. Kennedy",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Mexico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Villa Providencia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Evangelina Rodriguez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio El Silencio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio La Punta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Obrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Barrio Placer Bonito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Punta de Garza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Urb. Vicini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21100",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "San Jose de Los Llanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Cayacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "El Guayabal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Los Jibaros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Los Montones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "San Geronimo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Ajagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Los Lorenes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Magarin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Alejandro Bass",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Las Callas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Pajarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Los Montones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Zorra Buena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Caonabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Malulani",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "21406",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4110,
+    "state_code": "23",
+    "locality_name": "Gautier Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Aleton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Ensanche Chicago",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Ensanche Miramar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Quisqueya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Villa Pereira",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Deposito Central Romana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Ensanche La Paz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Guaymate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Don Juan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio La Caleta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Central Romana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Isla Saona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Reparto Benjamin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Res. Melissa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Altos de Chavon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Balneario El Calenton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Buena Vista Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Buena Vista Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Buena Vista Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Altos Del Rio Dulce",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Las Piedras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Papagayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Preconca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio Bancola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio Rio Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio Santa Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Ensanche La Hoz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio San Carlos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Barrio York",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Ens. Almeyra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Villa Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Nueva Zona Franca Industrial II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Zona Franca Industrial I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Madrigal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Urb. Torres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "Sabana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "22201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4087,
+    "state_code": "12",
+    "locality_name": "10 de Cumayasa Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Chino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Los Sotos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio San Martin de Porres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Bejucal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Juan Pablo Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Los Rosales I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Los Rosales II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Lotificasion Don Eusebio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Lotificasion La Altagracia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Res. Ana Amelia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Res. Freijo Mil",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Urb. Luisa Perla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Urb. San Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Vista Hermosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Zona Franca Industrial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Antonio Guzman",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Cambelen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio El Neranjo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Hoyo Caliente",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio La Aviacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio La Florida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Los Coquitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Los Platanitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Mama Tingo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio Obispo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio San Francisco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Barrio San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Basilica Nustra Sra. de la Alt.",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Lotificacion Levanto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Mama Tingo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Res. 21 de Enero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Santana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Urb. La Virgen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "El Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Jima Jaragua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Los Rios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Mata Chalupa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Bayahibe Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Boca de Yuma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Gato",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "La Piita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Boca de Yuma Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Caada Honda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "El Barrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Las Guamas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Otra Banda Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "El Bonao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Duyey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Cruz Del Isleo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Bavaro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "23302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4109,
+    "state_code": "11",
+    "locality_name": "Punta Cana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Arroyo Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Caada Francisca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Las 500",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Los Cajuiles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Los Hoyos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Centro de la Cuidad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Capotillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio El Retiro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio Jina Andiana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Barrio La Manicera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Buenos Aires",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Campia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Ens. Palo Hincado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Mirador Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Candelaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Las Cuchillas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "El Cuey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Magarin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Mata de Palma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "San Francisco Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Santa Lucia Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Vicentillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Anama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "El Jovero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "El Morro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Las Lilas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Isabelita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "24105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4086,
+    "state_code": "08",
+    "locality_name": "Pedro Sanchez Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Las Guazumas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Don Lpez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Gualey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Los Barriola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Guayabo Dulce Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Zona Franca Industrial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Las Malvinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Barrio Ondina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Manchado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Villa Canto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Mata Palacio Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "El Centro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Magua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Yerba Buena Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Las Claras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "El Mamn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Los Hatillos Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Elupina Cordero de las Caitas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "La Pia de Joya Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Arenita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Rincn Fogn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "San Rafael",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "25204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4106,
+    "state_code": "30",
+    "locality_name": "Elupina Cordero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Azul",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Gregorio Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Colon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "El Gallinero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanches Getsemani",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanches William Mieses",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Almanzar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Alvarez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Caonabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Caonabo II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Los Ciruelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Vista Del Valle",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "El Tejar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Cruz de Cenovi Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Guira",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Res. Neftaly",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Alma Salime",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Andujar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Brugal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Campo Fernandez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Caperuza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Caperuza II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. El Silencio I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. El Silencio II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. La Fortuna",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Mirador Del Jaya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Pia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Pia III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Guiza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Res. Los Rieles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Felix",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Francisco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Lora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Alto de la Javiela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanche Martin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Jaya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Toribio Piantini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Villa Olimpica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Hermanas Mirabal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Jobo Bonito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio San Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanche Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanche Madrigal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Bejucos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ventura Grullon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Cuesta Blanca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio El Hormiguero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Las Colinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Los Jibaritos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Rivera Del Jaya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Ugamba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio Villa Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Guazumas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Weber",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Estancia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Fernandez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Riveras Del Jaya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barrio El Capacito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ensanche Capotillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Malena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Res. El Dorado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Urb. Seorita Ana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "El Aguacate Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Coles Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Carreras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Jagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Agua Santa Del Yuna Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barranquito Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Cristo Rey de Guaraguao Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Barraquito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Guaraguao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Peynado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Aguayos Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Gina Clara",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Juan Diaz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Cachones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Llanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Rincon Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Taranas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Yaiba Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Acicate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Cerrejon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Sabana Grande Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Caobete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Cuaba Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "San Felipe Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ceiba de Los Pajaros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Chiringo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Las Taranas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Yeiba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Enea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "El Hato",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Rincon de Los Genaos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Los Riveras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Callejon de Tilo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Paraguay",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31703",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Reforma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Bajada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Majagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Dichoso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Laguna de Coto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Mesa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31806",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Patao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "La Pea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31808",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ponton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "31809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4113,
+    "state_code": "06",
+    "locality_name": "Ramonal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Acosta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Barrio El Millon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Barrio La Fortaleza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Barrio New York",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Barrio Wilmore",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Villa Salma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Arroyo Barril Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Las Garelas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Los Cacaos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Honduras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Juana Vicenta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "El Limon Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Las Pacualas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "La Majagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Las Garitas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Agua Santa Dal Yuma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "Majagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "El Jaimito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "El Coson",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "La Barbacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "32204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4103,
+    "state_code": "20",
+    "locality_name": "El Naranjo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Doralisa Ulloa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Las Carcobas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "El Guayabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Capitalista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio El Eden",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio La 500",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Libertad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Prd",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Quisqueyano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Roberto Fermin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Santisima Trinidad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Barrio Universitaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Las Gordas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Abreu",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Arroyo Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "La Entrada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "La Jaguita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "El Pozo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "El Papagayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Los Pajones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "El Telanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Los Indios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "San Jos de Maranza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Payita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Caja de Jobo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Cruce Del Rincon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Los Yayales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "La Entrada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Arroyo Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "La Gorda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "33307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4094,
+    "state_code": "14",
+    "locality_name": "Arroyo Al Medio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio Bietnam",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio El Hoyo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio La Caoba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barriolos Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barriolos Mangos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Jamao Adentro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Urb. Los Almendros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Alto de Piedra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio Clavijo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio El Chucho",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Barrio San Lorenzo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Jamao Afuera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Loa Cacaos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Boba Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Canete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "La Gran Parada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Paso Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "El Placer",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "La Ceiba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Los Limones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "34301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4089,
+    "state_code": "19",
+    "locality_name": "Blanco Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Altos Del Hatico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Bacui",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Barrio La Primavera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Barrio San Martin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Napoles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Maria Estrella II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Urb. Ana Magalis",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Francisca I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Francisca II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Turey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Barrio Maria Auxiliadora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Bayacanes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Don Bosco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Guarionex",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Juan Pablo Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Arboleda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Arboleda II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Cigua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Los Barrancones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Puerto Chiquito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Residensial El Vedado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Terrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Urb. Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Burende",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Caminito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Las Colinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Gamundi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Prado Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Margarita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Cabirmota",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Rivera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Mera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Cafe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Manguito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Enrriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Los Pomos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Pepito Garcia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Don Zoilo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Res. Santa Maria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Lora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Villa Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Mamey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Guarey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Jamo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Peda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Las Cabuyas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Las Canas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Licey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Ponton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41014",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Sabaneta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41015",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Tavera Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Maldonado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Palero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Tireo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "5",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Arroyo Frio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Descubierta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Las Palomas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Rio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Tireo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Tireo Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Sabina Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Buena Vista Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Corocito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Estancia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Hatillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Junumucu",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Los Corozos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Manabao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41208",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Los Dajaos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41209",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Cienega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41210",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Paso Bajito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41211",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Pedregal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41212",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Piedra Blanca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41213",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Pina Quemado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41214",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Los Forosos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41215",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Cabirma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41216",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Rio Verde Arriba Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41217",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Arroyo Hondo Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41218",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Mirador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41219",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "El Naranjal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41220",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Pueblo Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41221",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Rio Vrede Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41222",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Rio Vrede Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Frontera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Jima Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "San Bartolo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Rincon Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "La Curbita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "41306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4116,
+    "state_code": "13",
+    "locality_name": "Junumucu",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Arroyo Toro Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Prosperidad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Salvia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Urb. Falcombridge",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Urb. Jacaranda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Urb. La Salvia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Hato",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio La Altagracia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio La Fortunas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio La Privada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Los Olimpicos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Los Transformadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio San Martin de Porres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Santa Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Vietnam",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Bejucal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Ensanche Libertad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Reparto Quisqueya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Reparto Yuna",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Zona Franca de Bonao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Villa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Las Delicias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Urb. Miriam",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Urb. San Pablo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Felito Mena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "El Centro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "El Fundo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "El Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Jayaco Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Juma Bejucal Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Salvia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Masipedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Sabana Del Puerto Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Los Martinez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Arroyo Vuelta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "El 77",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Juan Adrian Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Rincon de Yuboa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "42205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Villa Sonador Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Acapulco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio La Cotorra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Libertad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Cocos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Espaoles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Caballero Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Chacuel Maldonado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio La Yuca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Algodones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Tocones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Hatillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio La Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Cajuiles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Los Mineros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4088,
+    "state_code": "24",
+    "locality_name": "Barrio Santa Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Las Lagunas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Los Cerros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Platanal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Sabana Grande Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Zambra Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Abadesa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Batero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Sierra Prieta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Angelina Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Cueva Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Sabana Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Angelina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Vija Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "La Cana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Las Corozas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Hernando Alonzo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43406",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Platanal Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "43407",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4099,
+    "state_code": "28",
+    "locality_name": "Quita Sueo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Aguacate de Jacagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Canabacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Ingenio Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Papayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Ranchito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Estancia Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Gurabo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jagaua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Bucara",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Cienaga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Herradura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Zurza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Zurza II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Monumento",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Javilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Pepines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Parte Alta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Zurza III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Charcas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Tavares Oeste",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51014",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Matanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51015",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Monte Adentro Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51016",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Palo Marrillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51017",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Palo Quemado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51018",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontezuela Al Medio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51019",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51020",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "San Francisco de Jacagua Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Ensueo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Nibaje",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Retiro I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Retiro II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51022",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ens. Ortega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51022",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Villa Jagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Botanico Y Zoologico Regional",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Camboya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Conani",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Corea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cristo Rey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Lotereia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Girasoles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Martires",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pequin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urbanisacion Fernandez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urbanisacion Fernando Valerio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51032",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Barrio Lindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51032",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Canabacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51032",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Hato Mayor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51032",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Arboleda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51032",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Thomen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51033",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Embrujo II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51033",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Embrujo III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51033",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Alamos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51033",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Quinta de Rincon Largo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51033",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Imperial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51034",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Universitario",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51034",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Universidad Central Madre Y Maestra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Barrio La Gallera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Esmeralda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Flamboyan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Rinconada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Rosaleda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Copal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Copal II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Franco Bid",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Amopolas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Palomas Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Laureles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Alba Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Monumental",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Sarah",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51042",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Villa Olga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Despertar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Despertar II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Rosal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jardines Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Espaola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Palomas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Sabaneta de la Paloma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. El Despertar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. El Embrujo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51043",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Villas Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Moraleja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Limonal Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Monte Adentro Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontezuela Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Res. Vargas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Brisa Del Palmar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Fineta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Villa Alba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Brisas Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cruce de Don Pedro Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Don Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Don Pedro Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Dorado II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Hoya Del Caimito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Damas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Cajuiles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Carritos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Hidalgos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontezuela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Hache",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51052",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Kokette",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerro Hermoso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerros de Gurabo I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerros de Gurabo II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerros de Gurabo III",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Dorado I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Casilda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Mainardi Reyna",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51053",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Villa Progreso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Flor de Gurabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Llanos de Gurabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Perez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontezuela Al Medio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51054",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Eliseo Perez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Gurabo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Consuelo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Eden",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. El Paraiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Miraflor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Noreda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Paraiso I",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerro Alto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Brisol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Francisco Del Rosario Sanchez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Res. Julissa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Los Reyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51062",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Miraflor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51063",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Bo. Cadete Manolo Tavares Justo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51063",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerro de Jacagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51063",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Gregorio Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51063",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jardines Del Rey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51063",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Salados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Bo. Los Santos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Terraza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Altos Del Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche La Rotonda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Colina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Ciruelitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Manhattan",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51072",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Tierra Alta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Altos de Virella",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Barrio Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cuesta Colorada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Libertad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Ramos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Libertad II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Jardines Del Oeste",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Las Americas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Las Antillas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51073",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Alto de Rafey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Bo. Cienfuego",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Bo. La Gloria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ciudad Satelite",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Espaillat",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ingenio Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Monte Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51074",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Zona Franca Industrial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Aeropuerto Cibao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Barrio Pedro Francisco Bono",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Montero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Fernandez Dominguez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Henriquez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Barrio Hermanas Mirabal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Jido",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Bolivar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Platanitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51082",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Perello",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51083",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Canabacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Bermudez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Roman",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51092",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Centro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51092",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Joya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cuesta Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Hatillo San Lorenzo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jardines Metropolitano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Urb. Bermudez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ensanche Julia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Eugenio Perdomo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Hato Del Yaque Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Oquet",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Guama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Colegios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Panorama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Sabana Grande de Batey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Caafistol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Inoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Celestina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mata Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Corocito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Montones Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Diferencia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pedregal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jicome",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Plasetas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Magua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Manacla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Yerba Buena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mata Del Dajao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Rincon Largo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerro Del Castillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Trinitaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Naranjo Bajon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Santiago Apostol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51113",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Rubio Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51120",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Arroyo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Franco Bid",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Jazmines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Valle Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Valle Verde II",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Altos de Peralta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cerros de Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Janey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Barranquita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Yaguita de Pastor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mirador Del Yaque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pastor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pia de Oro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Peralta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Reparto Primavera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51123",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Campo de Golf",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51123",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Juncalito Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51123",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Otra Banda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51124",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Corona Plaza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51124",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Herradura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51124",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Rincón Largo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51125",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Rincon Llano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Cagueyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Ceb",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Dicayagua Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Guama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Jagua Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Loma Del Corral",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51207",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mesetas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51208",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pinalito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51209",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Yaque Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51210",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Sabana Iglesia Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51211",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Caimito Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51212",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Baitoa Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Caada Bonita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Estancia Del Yaque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Lomota",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Villa Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Mejia de Navarrete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontoncito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Vuelta Larga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Cruz de Maria Francisca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Licey Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Licey Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Palomas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "La Cruz de Izalguez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Boca de Maizal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Canca La Piedra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Carlos Diaz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Guazumal Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Bocas de Licey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Licey Al Medio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51507",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Pontezuela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "El Limon Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Lavas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Macoris Del Limon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Palmar Abajo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51605",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Quinigua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Auyamas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Sabana Iglesia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Los Ranchos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Las Zanjas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Baitoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "Lopez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "San Jos Adentro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "51904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4108,
+    "state_code": "25",
+    "locality_name": "San Jos Afuera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "53071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio La Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Canca Reina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Aguacate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Agarrobo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Higuero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Luan Lpez Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Las Lagunas Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Llenas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Monte de la Jagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Paso de Moca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Zafarraya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio El Toro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Horacio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Pueblo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Quijada Quieta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Res. Irka",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Batuto",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Euripides",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Gauchupita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Ley Lama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Los Caceres",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Los Profecionales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Moronta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Res. Montreal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Urbanaizacion Lolita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Urb. Don Bosco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Carolina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Estela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Del Resex Dabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Pueblo Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Pulin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Caimito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Semillero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Entrada de la Soledad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Hincha",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Llenas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Mirador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Recidencial Maria Del Carmen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Reparto Amelia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Res. Ambar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Urb. Del Este",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Urb. Grabiela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Elsa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56051",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Emely",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Calaf",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Guaci",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio La Estancia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Los Rieles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio San Luis",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Del Rosario",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Olga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Av. Sosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio El Bolsillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Joan Lopito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Muerto Borracho",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Barrio Sal Si Puedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Res. Cabrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Delia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Villa Estancia Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "La Guama de Guananao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Los Octavios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Bejuco Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Jobo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Magante",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Ojo de Agua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Veragua Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Camarones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Palma Herrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Rancho de Los Platanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Jamao Al Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Jamao Al Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Los Brazos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "San Victor Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Los Amaceyes Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Puesto Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "La Ceiba de Madera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "El Higuero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "Jagua Clara",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "56603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4102,
+    "state_code": "09",
+    "locality_name": "La Piragua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "El Copey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Los Mameyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Maimn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Sabana Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Tubagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Yasica Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "El Toro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio El Avispero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Loa Mameyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Loa Sufridos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Bordas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Violon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Padre Las Casas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Reparto Oliva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Cristo Rey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Cuzada de Amor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Las Yaguitas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Mirador Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. El Cerro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57021",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urbbanizacion Reyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57031",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Sabana Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Buenaventura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. La Estancia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57041",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Torre Alta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Arceno Urtado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57061",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Costa Atlantica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Bayardo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57071",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Juan Brugal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Ensanche Loa Castillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57081",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Ensanche Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Arenoso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio La Zona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrrio Loa Guandules",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Ens. Miramar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57091",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Reyes Caminero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Eduardo Brito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio La Rigola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Candelon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Escalera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Higuero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Las Isabela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Los Llanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Palmar Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "El Mamey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Pescado Bono",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Caada Honda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Bahia de Puerto Plata",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Dubeau",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio La Viara",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Playa Oeste",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Haiti",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Las Mercedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Coquitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Gregorio Luperon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57131",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Costabar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57131",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Zona Franca Industrial",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57141",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Sector Sin Nombre",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Habitad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Rieles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Silos Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio San Marcos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Monasterio Monte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57151",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Cuesta Amarilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57161",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Altos de Chavon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57161",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Dominguez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57161",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Barrio Los Limones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57161",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Ortega Brugal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57171",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Urb. Ginebra Arzeno",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57171",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Villa Progreso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Fundacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "5",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "La Cabirma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Hoya Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Paradero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57206",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Rancho Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Cabia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Caonabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Las Canas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Prez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Saballo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Marmolesjos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Unijica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Cambiaso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "El Higo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "El Estrecho",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "La Sabana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57505",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Los Bellosos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Ranchito de Los Vargas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Madre Vieja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Sabaneta de Cangrejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Sabaneta de Ysica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Cabarete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Gualete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "La Jaiba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57703",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Las Guaranas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Boca Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Cangrejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Caraballo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Los Ciruelos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Mozavi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "57902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4092,
+    "state_code": "18",
+    "locality_name": "Rancho Manuel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Coral Gissel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Desiderio Aria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio La Codal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Los Medicos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Obras Publicas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "El Aserradero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Jaibon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Los Laureles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Villa Olimpica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio La Cuarenta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Las 300",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Maria Auxiliadora",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Pericles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio de Oficiales E.n",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barriolos Cajuiles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Los Quemados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Res. Los Querubines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Villa Bogaert",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Calorina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio La Hora de Dios",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Los Cayucos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Bello Atardeser",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Brisa Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Buenos Aires",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Caada de Piedra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Cerro Marino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Guatapanal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Villa Diego",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio El Hatico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio El Tronco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Enriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Militar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Barrio Rincon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "El Batey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Potrero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Yerba de Guinea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Hundidero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Damajagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Loma de Damajagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Loma Del Aguacate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Maizal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Peuela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Villa Heneken",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Loma de Maimn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Guayacanes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "La Caya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Ranchete",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Jaibon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Amina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "61302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4104,
+    "state_code": "27",
+    "locality_name": "Entrada de Mao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Altos de la Palomas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio Salomon Jorge",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Rincon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Los Angeles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Los Jazmines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Salinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio Francisco Javier",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio La Aviacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio San Fernando",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Barrio San Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Cerros de San Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Cristo Rey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Guatapanal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Las Aguas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Las Colinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Las Peas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Duro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Baitoal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Ahogado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Lomas de Castauela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Castauelas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "La Magadalena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Vigiador",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Cana Chapeton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Cerro Gordo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Juan Gmez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Martin Garcia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62205",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Sabana Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Los Almaceyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "La Horca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Carbonera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Copey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Botoncillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Los Conucos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Villa Garcias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Copey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Guajaca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Hato Del Medio Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "El Papallo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Hatillo Palma Adentro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Los Derramadores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "62703",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4115,
+    "state_code": "15",
+    "locality_name": "Doa Antonia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Barrio Benito Moncion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Caongo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Cayuco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Barrio La Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Barrio Militar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Plaza Beller",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Sabana Larga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Barrio La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Barrio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Clavelina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "El Aguacate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Capotillo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "El Cajil",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "La Ceyba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Hipolito Billini",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Monte Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Santiago de la Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Partido Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Baca Gorda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "La Gorra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Chacuey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Cruz de Cabrera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "El Carrizal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "La Pocilga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Los Cerezos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "Manuel Bueno Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "63402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4107,
+    "state_code": "05",
+    "locality_name": "El Rodeo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Arroyo Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Cambelen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio La Joya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio La Manicera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Alejandro Bueno",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio El Millon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio El Tamarindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Las Espinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barrio Simo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Barriolas Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "La Caobas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Los Tomines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Urb. Merien",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Villa Polin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Los Cercadillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Clavijo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Coqui",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Estancia Vieja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Mata de Jobo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Palmarejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Toma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "La Ceiba de Boneti",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "El Dajao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "El Fundo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Ginita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Inaje",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "La Lona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "El Mamoncito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "Gurado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "La Cacique",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "64204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4100,
+    "state_code": "26",
+    "locality_name": "El Rodeo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barreras Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio Los Cartones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio Simon Estridel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Macos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Parceleros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Pueblo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Savica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Alto de las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio Buenos Aires",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio El Prado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio La Frontera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio Pajarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Clavellinas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "La Colonia Espaola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "5",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio El Hoyo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio El Trompo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio La Bombita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barrio La Cuchilla",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Las Lomas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Jobillos Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Puerto Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Emma Balaguer Vda.b.",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Las Barias Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "La Estancia Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Ganaderos Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Tabara Abajo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Barro Arriba Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Pueblo Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Naranjito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Rosario Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Caada Cimarrona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Hatillo de Azua Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Palmar de Ocoa Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Hato Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Magueyal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Oregano Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Viajama",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Arroyo Cano Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Las Lagunas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Las Caitas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "La Siembra Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Monte Bonito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Villarpando Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Carrizal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Majagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Puerto Viejo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Proyecto 2-C",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Proyecto 4 Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Proyecto D-1",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Tabara Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Amiama Gmez Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Las Guanabanos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71703",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Toros Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71704",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Sajanoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Memiso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Rancho Del Pino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71803",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "La China",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71804",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Arroyo Colorado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71805",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Limon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71806",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El Cruce de Estebania",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71807",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "El 8",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71808",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Rio Grande",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71809",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Los Quemados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "71810",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4114,
+    "state_code": "02",
+    "locality_name": "Sabana de Miguel Martin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Barrio Guachupita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Barrio Los Mojados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Barrio Quija Quieta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Chalona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Francisco Del Rosario Sanchesz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Urb. Manoguayabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Villa Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Guanito Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Grimgos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Villa Felicia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Villa Ofelia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Ens. La Fe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Hato Del Padre",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Barrio Cepillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Barrio Gualey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "El Baden",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Ens. Anacaona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Ens. Mesopotamia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Hato Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Montes de Oca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "La Jagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Las Zanjas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Caafistol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Mogollon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Guazumal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Rio Arriba Del Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Sabana Alta Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "El Rosario Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Arroyo Cano Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Yaque Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Al Pinal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "La Cienega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Derrumbadero Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Batista Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Jinova Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Sosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Montones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Hato Del Padre Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Las Managuas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Sabaneta Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "La Jagua Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Carrera de Yegua Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "La Estancia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Yabonico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Matayaya Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72406",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Babor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72407",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Las Charcas de Maria Nova Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72408",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Mabrigida",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72409",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Pedro Corto Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72410",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Punta Cana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72411",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Pozo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72412",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Ladrillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72413",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Limones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72414",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Sabanecierra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72415",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Los Jovillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72416",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Catanamatia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72417",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Pan de Azucar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Jorgillo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "72502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4098,
+    "state_code": "22",
+    "locality_name": "Rio Arriba Del Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Galindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Guayabo Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "La Primaria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Los Rinconcitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Pedro Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Angostura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "La Jagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Juan Felipe",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Macasia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Las Patillas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "El Pino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Pinzon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Potrozo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Puello",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73014",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Sabana Larga Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Las Caitas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Higuerito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Sabana Cruz Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Sabana Mula",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Guaroa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Guayabal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Los Yareles",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Tabacal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Sabana Higuero Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Reboso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Guanito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Las Lagunas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Aniceto Martnes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Los Guineos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Rancho de la Guardia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Ranco de Pedro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Las Palmas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "El Hoyo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Guayacajuco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Nicola Joca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Rio Limpio Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73406",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Rio Limpio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73407",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "La Cierrecita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73408",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Billiguin",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Juan de la Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Sabana de la Loma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Monte Mayor",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "73504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 5539,
+    "state_code": "07",
+    "locality_name": "Rancho de la Guardia Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Alto Velo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Cachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Baitoita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Las Guazaras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Villa Estela",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Barrio Enriquillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Barrio La Playa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Manuel Diaz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Parte Norte de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "30 de Mayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "El Arco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Naco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Aeropuerto Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Barrio Jarro Sucio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Barrio Juan Pablo Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Barrio Los Block",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Batey Central",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Invi-Cea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Zona Franca de Barahona",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Lotificacion Blanquisales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Savica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Camboya",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Palo Alto Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Tierra Blanca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Caon Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Lemba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Los Saladillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Arroyo Dulce Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Caleton",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "El Pino",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "NO DISPONIBLE",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "El Platon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "La Zanja Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Leonardo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Los Patos Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81405",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Ojeda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Las Auyamas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Los Charquitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Polo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Fondo Negro Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Quita Coraza Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Canoa Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Bombita",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Peon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Peon Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81801",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Batey Altagracia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81802",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "La Hoya Pescaderia Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81901",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "El Arroyo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81902",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Bahoruco Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81903",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Guayuyal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "81904",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4090,
+    "state_code": "04",
+    "locality_name": "Juan Esteban",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Apolinar Perdomo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Jose Alberto Caamao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "La Cuaba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Villa Paja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Estero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Tanque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Tejal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Las Malbinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Los Coquitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Te Jinca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Cachon Seco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "La Botella",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "La J",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Los Guineos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Plaza Cacique",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Manguito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Las Petacas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Los Roas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Copey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Aguacate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Mamn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Majagual",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Las Tejas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Tamarindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Las Clavelinas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Higo de la Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Los Moquitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Barranca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Cabeza de Toro Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Jobo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Mena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Moncerrat Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Santana Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Uvilla Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Palmar Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "El Barro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Las Caitas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Pie de Loma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "82404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4105,
+    "state_code": "03",
+    "locality_name": "Mata de Naranja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Arroyo Blanco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "El Invi",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "La 50",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Viejo Jimani",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Barrio Para Militares",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Boca de Cachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "La K",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Solidaridad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Barrio El Cerro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Boca Del Cachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "El Limon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "El Limon Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Tierra Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Tierra Nueva",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "La Colonia Mixta Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Puerto Escondido",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Vengan A Ver Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Angel Feliz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Bartolom",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Angostura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Loa Bolos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Batey 7",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Batey 8",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83503",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Batey 9",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83504",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Cabeza de Rio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "El Maniel",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "83602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4097,
+    "state_code": "10",
+    "locality_name": "Raiz Picada",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Babo Rojo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Nicolas Feliz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Las Mercedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Milital",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Alcoha",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Mencia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Jose Francisco Pea Gomez Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Villa Del Mar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Miramar Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Miramar Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Ines",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Los Guayacanes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Las Mercedes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Jose Francisco Pea Gomez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Los Altagracianos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84013",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Savica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84014",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84015",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Verde",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84016",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Los Cayucos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84017",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Campo de Aviacion Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84018",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Campo de Aviacion Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84019",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "El Tanque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84020",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Los Tres Charcos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "84201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4101,
+    "state_code": "16",
+    "locality_name": "Colonia Villa Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Nueva Esperanza",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio San Isidro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Borbon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Conani",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "El Cerro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio La Coquera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Caada Honda",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Canatica",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Hatillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Lava Pie",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "San Antaonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Arena",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Concentracion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Favidrio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio La Pia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Ens. Constitucion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Ens. Juan Pablo Duarte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Hato Damas Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Madre Vieja Norte",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Madre Vieja Sur",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Urb. Las Arecas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Urb. Santes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Jeringa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Las Flores",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Ingenio Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio 5 de Abril",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio La Constitucion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Los Nova",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Barrio Puerto Rico",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Naranjo Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Urb. Colina Hermosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Villa Fundacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Sainagua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Santa Maria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Medina Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "La Cuchilla Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "El Carril Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "La Pared",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "El Ingenio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Los Naranjos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Cambita El Pueblecito Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Calderon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Humachon",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "La Colonia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Los Manantiales",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "El Tablazo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Boca de Nigua",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Najayo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Juan Barn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Sabana Palenque",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Las Gallardas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Najayo Al Medio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Mana de Yaguate",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91701",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Catarey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91702",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Mana de Haina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91703",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Medina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91704",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "Pino Herrado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "91705",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4091,
+    "state_code": "21",
+    "locality_name": "San Jos Del Puerto Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Barrio La Ceja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Barrio Vietnam",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "El Cacique Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Barrio 30 de Mayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Barrio La Gallera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Centro de la Ciudad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "El Centro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "El Dean Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Hato Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Lisa Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Rio Boy Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Yabacao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "San Jose",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Antn Snchez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Cojobal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Comatillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Hidalgo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Trinidad",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92201",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Cabeza de Toro",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92202",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Juan Snchez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92203",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Majagual Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92204",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Payabo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Gallina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Los Jobillos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Pantoja",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Esperalvillo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Centro Penso",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Cuaba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92403",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Guazuma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92404",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Placeta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92501",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Los Limones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92502",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Batey La Tarana Larga de G",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92506",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Yautia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92601",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Los Botados",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92602",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "Camaron",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92603",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Cola",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "92604",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4111,
+    "state_code": "29",
+    "locality_name": "La Mayas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Barrio Rafael",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Vija",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Las Auyamas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Clavellina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Gina",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Pueblo Abajo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Morones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Nuestro Esfuerzo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Res. Los Maestros",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Juan Luis",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Arroyo Caa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Mahoma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Banilejo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Quita Pea",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Quita Sueo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Arroyo Bonito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Bocana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Arroyo Manteca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Las Avispas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Marca",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Cumbre",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Nizao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93105",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Cienaga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93106",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "El Rosalito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93107",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Naranjal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93108",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Derrumbao",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93109",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Peas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93110",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "El Tamarindo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93111",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Anones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93112",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Limn",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93113",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Monte Arriba",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93114",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Ranchitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93115",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "El Pinar",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93116",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Bejucal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93117",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Cienaga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93118",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Caimitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93119",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Manaclares",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93120",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Horma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93121",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Nuez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93122",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Las Auyamas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "93123",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Arroyo Caa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "30 de Mayo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Las Barias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94001",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Mejoramiento Social",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Barrio Santa Ana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Boca Canasta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Marias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Res. Claudia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94002",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Res. Maria Del Carmen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Las Calderas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Res. Brisas Del Canal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Res. Hermanos Serret",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94003",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Urb. Maximo Gomez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Brisas Del Guazuma",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Caafistol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94004",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Villa Majega",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "El Carreton Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Fundo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Los Barrancones",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Villa Carmen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94005",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Villa David",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94006",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Los Cateyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94007",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Boca Canasta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94008",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Honduras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94009",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Iguana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94010",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "Limonal Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94011",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "El Llano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94012",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4112,
+    "state_code": "31",
+    "locality_name": "La Montera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94101",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Don Gregorio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94102",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Lucas Diaz",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94103",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Santana Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94104",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Yiyos Gomez",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94301",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Carreras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94302",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Los Ranchitos",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94303",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Quija Quieta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94304",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Arroyo Hondo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94305",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Calderas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94306",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Dunas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94307",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Salinas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94308",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Matanza Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94309",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Villa Guerra",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94310",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Sabana Indio",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94311",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "La Montera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94312",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Arroyo La Angostura",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94313",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Galen",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94314",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Loma Las Tablas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94315",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Cruce de Ocoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94316",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Carreras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94317",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Honduras",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94318",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Matadero",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94319",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "La Catalina Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94320",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "La Noria",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94321",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Carreton Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94322",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Escondido",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94323",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Paya Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94324",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Fundacion",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94325",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Boca Canasta",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94326",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Llano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94327",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Caafistol",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94327",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Villa Sombrero Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94328",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Tablas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94329",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Buey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94330",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Los Cateyes",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94331",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Loma de Valvacoa",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94332",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Monte Llano",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94333",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "La Bejuquera",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94334",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Valdesia",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94335",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Recodo",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94336",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Iguana",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94337",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Barias",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94338",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Las Yeguas",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94339",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Arroyo Salado",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94340",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Roblegal",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94341",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Sabana Larga",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94342",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Limonal Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94343",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Pizarrete Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94344",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Santana Dm",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94401",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "El Palmarito",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  },
+  {
+    "code": "94402",
+    "country_id": 62,
+    "country_code": "DO",
+    "state_id": 4096,
+    "state_code": "17",
+    "locality_name": "Gualey",
+    "type": "full",
+    "source": "inposdom-via-manuelpgs"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 2,320 Dominican Republic postcodes spanning all 32 INPOSDOM
provinces, sourced from the ``manuelpgs/localidades-postales-rd``
CSVs.

- **Coverage**: 100% province resolution (32/32 in states.json).
- **Granularity**: locality (sector/barrio) level — one record per
  ``(5-digit code, locality)`` pair.

## How it works

- Pre-builds a source-prov-id -> CSC iso2 map from
  ``provincias.csv`` (ASCII-fold name match, parenthetical-suffix
  strip).
- 2-entry ``STATE_ALIASES`` bridge for ``BAHORUCO`` -> ``Baoruco``
  (source spelling differs by one ``h``) and
  ``SAN JUAN DE LA MAGUANA`` -> ``San Juan`` (CSC drops the suffix).
- Walks ``localidades.csv``; emits one row per
  ``(postcode, locality)`` pair.

## Source & licence

- Source URLs:
  - https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/master/csv/provincias.csv
  - https://raw.githubusercontent.com/manuelpgs/localidades-postales-rd/master/csv/localidades.csv
- Origin: INPOSDOM publicly published catalogue.
- Each row: ``"source": "inposdom-via-manuelpgs"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 2,320 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 62``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)