### PR TITLE
feat(postcodes/RS): bulk-import 1,170 Serbia postcodes via Pošta Srbije (#1039)

### DIFF
--- a/bin/scripts/sync/import_serbia_postcodes.py
+++ b/bin/scripts/sync/import_serbia_postcodes.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Serbia -> contributions/postcodes/RS.json importer for #1039.
+
+Source data
+-----------
+The community ``nebjak/serbia-zip-codes-js`` package ships Pošta
+Srbije's catalogue as a flat JSON list of city + zip_code pairs:
+
+    [{"city": "Beograd", "zip_code": "11000"}, ...]
+
+Source URL: https://raw.githubusercontent.com/nebjak/serbia-zip-codes-js/master/data/serbia_zip_codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Ships country-only (the source has no okrug / district mapping).
+3. Writes contributions/postcodes/RS.json idempotently.
+
+License & attribution
+---------------------
+- Source: nebjak/serbia-zip-codes-js (MIT) which redistributes the
+  publicly published Pošta Srbije index.
+- Each row: ``source: "posta-srbije-via-nebjak"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_serbia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/nebjak/serbia-zip-codes-js/"
+    "master/data/serbia_zip_codes.json"
+)
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    rows = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    rs_country = next((c for c in countries if c.get("iso2") == "RS"), None)
+    if rs_country is None:
+        print("ERROR: RS not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(rs_country.get("postal_code_regex") or ".*")
+    print(f"Country: Serbia (id={rs_country['id']})")
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for row in rows:
+        code = (row.get("zip_code") or "").strip()
+        if not code:
+            continue
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        city = (row.get("city") or "").strip()
+        key = (code, city.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(rs_country["id"]),
+            "country_code": "RS",
+        }
+        if city:
+            record["locality_name"] = city
+        record["type"] = "full"
+        record["source"] = "posta-srbije-via-nebjak"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/RS.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/RS.json
+++ b/contributions/postcodes/RS.json
@@ -1,0 +1,9362 @@
+[
+  {
+    "code": "11000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11010",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Voždovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11030",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Čukarica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11050",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Zvezdara",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11060",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Palilula",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11070",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Beograd",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11080",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Zemun",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11090",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beograd Rakovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11130",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kaluđerica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11194",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rušanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Borča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ovča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Padinska Skela",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beli Potok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrčin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zuce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pinosava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ripanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ralja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Požarevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ostružnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremčica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Umka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11261",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mala Moštanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Moštanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11271",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Surčin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11272",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobanovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11275",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Boljevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11276",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jakovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11277",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ugrinovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11279",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bečmen",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11280",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Progar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11282",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Petrovcic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Smederevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grocka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Boleč",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Begaljica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Leštane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lipe",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mihajlovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mala Krsna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Osipaonica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Saraorci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Golobok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11317",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lozovik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Miloševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11319",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krnjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Plana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lugavcina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Skobalj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Orašje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Staro Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Markovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11326",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Livadica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11327",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rakinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11328",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vodanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11329",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vranovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11351",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vinča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11400",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mladenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11406",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlaška",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11407",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Selevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11408",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Krsna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11409",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kovačevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11411",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ratari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11412",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jagnjilo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11413",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pružatovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11414",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Ivanča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11415",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Koraćica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11420",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Smederevska Palanka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11423",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Azanja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11424",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banicina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11425",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kusadak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11426",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Meljak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11427",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vranić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11430",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Umčari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11431",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kolari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11432",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Drugovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11433",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šepšin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11450",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sopot",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11453",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rogača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11454",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sibnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11460",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barajevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11461",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beljina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11462",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Borak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11500",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Obrenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11504",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barič",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11505",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zabrežje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11506",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Draževac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11507",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stubline",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11508",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grabovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11509",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Skela",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11550",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lazarevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11560",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vreoci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11561",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dudovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11562",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Junkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11563",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Crljeni",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11564",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stepojevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11565",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barosevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11566",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rudovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "11567",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mirosaljci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Požarevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bradarac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dubravica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kostolac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kličevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Gradište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Majilovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Braničevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Golubac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobra",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bratinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Topolovnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brnjica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kučevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Neresnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srednjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rabrovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Duboka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Voluja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klenje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Petrovac Na Mlavi",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ranovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Melnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Laole",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Burovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šetonje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Malo Crniće",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Smoljinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bozevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rašanac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krepoljin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12317",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Osanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vukovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žagubica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Laznica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Suvi Do",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12370",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksandrovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12371",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlaški Do",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12372",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Poljana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12373",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Simićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12374",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žabari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "12375",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Porodin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Valjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brankovina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rajković",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dračić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Divčibare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lelić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Poćuta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pećka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ub",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brgule",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pambukovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banjani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Popučke",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Divci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Slovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lajkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogovadja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jabučje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljig",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mionica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Toplica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezde",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Slavkovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belanovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pricevic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Osečina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Komirić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "14255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stave",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šabac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mačvanski Pričinović",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Drenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Orid",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Debeljača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Provo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Koceljeva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svileuva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Cerovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vladimirci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Draginje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Crniljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Varna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Metlić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tekeriš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobrić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Loznica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15302",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Korenita",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15303",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tršić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Petlovača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lipolist",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prnjavor Mačvanski",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lešnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jadranska Lešnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezjak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ribari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Draginac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zavlaka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bela Crkva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krupanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zajaca",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banja Koviljača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15317",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Borina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Zvornik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15319",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Uzovnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljubovija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radalj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Orovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Drlace",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15350",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogatić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15352",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zminjak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15353",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Majur",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15354",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Štitar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15355",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crna Bara",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15356",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Glušci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15357",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klenje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15358",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Badovinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15359",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dublje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "15362",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banovo Polje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Leskovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Manojlovce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vučje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Miroševce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bojnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kosančić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlasotince",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svođe",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sastav Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crna Trava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grdelica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Grabovnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Predejane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ruplje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lebane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Turekovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bosnjace",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Orane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medvedja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Brestovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sijarinska Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16247",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tulare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16248",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lece",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pecanjevce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Razgojna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "16253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brestovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17500",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vranje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17507",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlase",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17508",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sveti Ilija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17510",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vladičin Han",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17511",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Priboj Vranjski",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17512",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stubal",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17513",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lepenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17514",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Džep",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17520",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bujanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17521",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ristovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17522",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Biljaca",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17523",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Preševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17524",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klenike",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17525",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trgovište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17526",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donji Stajevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17529",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Muhovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17530",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Surdulica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17531",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jelašnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17532",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlasina Okruglica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17533",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlasina Rid",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17534",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlasina Stojkovićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17535",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klisura",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17537",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bozica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17538",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Lisina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17540",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bosilegrad",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17542",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vranjska Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17543",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kriva Feja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17544",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Ljubata",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17545",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Korbevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17546",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bistar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17547",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Tlamino",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17556",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Reljan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17557",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Oraovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "17567",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bujanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Niš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lalinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Toponica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Matejevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Niška Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jelašnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Malča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Guševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medoševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žitkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trupale",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tešica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gredetin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kulina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Bonjince",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Korman",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljuberadja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18219",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grejac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Draževac(kod Aleksinca)",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rutevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Katun",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksinacki Rudnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Subotinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Luzane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mozgovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Soko Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čitluk",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jošanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šarbanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dugo Polje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gadžin Han",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Barbes",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donji Dušnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zaplanjska Toponica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lički Hanovi",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravna Dubrava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mramor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Merošina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jugbogdanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Medurovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pukovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Balajinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jovanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Popovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pirot",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crnokliste",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Visoka Rzana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krupač",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bela Palanka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ostrovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crvena Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dolac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Babin Kal",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dimitrovgrad",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gradina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Smilovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18326",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Poganovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Babusnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18332",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Strelac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18333",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zvonce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18355",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Temska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18360",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svrljig",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18363",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Palilula",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18365",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prekonoga",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18366",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Niševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18368",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Burdimo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18400",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prokuplje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18403",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Plana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18404",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Rečica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18405",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Džigolj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18406",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dubovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18407",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žitni Potok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18408",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobri Do",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18409",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kruševica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18410",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Doljevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18411",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belotinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18412",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žitoradja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18413",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pejkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18414",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Crnatovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18415",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Malošište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18417",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Cecina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18420",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Blace",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18421",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Trnava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18423",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mala Plana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18424",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beloljin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18425",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Draguša",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18426",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barbatovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18430",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kuršumlija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18432",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barlovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18433",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prolom",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18435",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kuršumlijska Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18436",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Merćez",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18437",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18438",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zuc",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18440",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "18445",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Merdare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zaječar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Metovnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gradskovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Izvor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Planinica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lubnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Jasenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Bela Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rgotina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zlot",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brestovačka Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19219",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krivelj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donji Milanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klokočevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Koprivnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Salaš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sikole",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zvezdan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gamzigradska Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Borski Brestovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Borsko Bucje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Luka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Jasikova",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Halovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Majdanpek",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rudna Glava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Negotin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19303",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Štubik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jabukovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Urovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trnjane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nikolićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vražogrnac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brusnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rajac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bracevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kobišnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19317",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mokranja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rogljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kladovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Podvrška",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mihajlovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brza Palanka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Slatina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tekija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19326",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sip",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19328",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velesnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19329",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Korbovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prahovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19334",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radujevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19335",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dušanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19340",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Minićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19341",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grljan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19342",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grlište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19343",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19344",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vratarnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19345",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Zuniće",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19347",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Izvor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19350",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Knjaževac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19352",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19353",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kalna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19362",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Podvis",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19366",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beli Potok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19367",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vasilj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19369",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bucje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19370",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Boljevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19371",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19372",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogovina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19373",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šarbanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19375",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krivi Vir",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19376",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sumrakovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19377",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Savinac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19378",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Osnić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "19379",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šarbanovac Timok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Sad",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21131",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Petrovaradin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rumenka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veternik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremski Karlovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stari Ledinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ledinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremska Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bukovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kisač",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stepanovićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zmajevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sirig",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Turija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nadalj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačko Gradište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bečej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radičević",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačko Petrovo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mileševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žabalj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čenej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Jarak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Temerin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gospođinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21238",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čurug",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21239",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Đurdjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Titel",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kać",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Budisava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kovilj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šajkaš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mošorin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vilovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21247",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gardinovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21248",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21299",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rakovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beočin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čerević",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banoštor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Susek",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Neštin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lug",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21400",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačka Palanka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21410",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Futog",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21411",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Begeč",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21412",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gložan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21413",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čelarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21420",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bač",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21421",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Karađorđevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21422",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mladenovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21423",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Obrovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21424",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tovariševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21425",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Selenča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21426",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vajska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21427",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bodjani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21428",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Plavna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21429",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačko Novo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21431",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nova Gajdobra",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21432",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gajdobra",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21433",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Silbaš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21434",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Parage",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21460",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrbas",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21465",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačko Dobro Polje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21466",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kucura",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21467",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Savino Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21468",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Despotovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21469",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pivnice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21470",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Petrovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21471",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravno Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21472",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kulpin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21473",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Maglić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "21480",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srbobran",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremska Mitrovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zasavica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mačvanska Mitrovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Noćaj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Salaš Noćajski",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravnje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radenković",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ležimir",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mandjelos",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Radinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bešenovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grgurevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bosut",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Laćarak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Martinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kuzmin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kukujevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bacinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Erdevik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čalma",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Divoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šid",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vasica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Berkasovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sot",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Adasevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Morović",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Višnjićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22247",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremska Rača",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22248",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jamena",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ilinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Batrovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bingula",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bikić Do",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljuba",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Molovin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Privina Glava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gibarac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stara Pazova",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22303",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banovci Dunav",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Banovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stari Banovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belegiš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Surduk",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Golubinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šimanovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vojka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krnješevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Inđija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Karlovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Slankamen",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Beška",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krčedin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22326",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čortanovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22327",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Maradik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22328",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krušedol",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22329",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stari Slankamen",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nova Pazova",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22400",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ruma",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22404",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Putinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22405",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stejanovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22406",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Irig",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22408",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrdnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22409",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jazak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22410",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pećinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22411",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kraljevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22412",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobrinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22413",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sremski Mihaljevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22414",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Subotište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22416",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ogar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22417",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Obrez",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22418",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Asanja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22419",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kupinovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22420",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Platičevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22421",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Budjanovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22422",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nikinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22423",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grabovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22424",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klenak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22425",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šašinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22427",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Hrtkovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22428",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Popinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22429",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Voganj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22431",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vitojevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22440",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sibač",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22441",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dec",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22442",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prhovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "22443",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Karlovčić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zrenjanin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mihajlovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ečka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stajićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belo Blato",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Muzlja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aradac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Elemir",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Taraš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Žitište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Klek",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravni Topolovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatski Dvor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Torda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Cestereg",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatsko Karađorđevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksandrovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23218",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nova Crnja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23219",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vojvoda Stepa",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srpska Crnja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Radojevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Toba",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lukino Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jaša Tomić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krajišnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Begejci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srpski Itebej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Hetin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Itebej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatsko Višnjićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sečanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lazarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatski Despotovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Botos",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sutjeska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Neuzina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jarkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatska Dubica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Boka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Konak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Surjan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zlatica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Perlez",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23261",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lukićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tomaševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23263",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Orlovat",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23264",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Farkaždin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23265",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Knićanin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23266",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ćenta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23270",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Melenci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23271",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kumane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23272",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Bečej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23273",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novo Miloševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23274",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bocar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kikinda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mokrin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nakovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatsko Veliko Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Kozarci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rusko Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatska Topola",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Basaid",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čoka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Iđos",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sajan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Padej",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23326",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ostojićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23327",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jazovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23328",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crna Bara",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23329",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrbica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Kneževac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23331",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sanad",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23332",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatsko Arandjelovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23333",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Majdan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23334",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srpski Krstur",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "23335",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Đala",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Subotica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24104",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kelebija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kelebija-granični prelaz",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bikovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Orom",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bajmok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mišićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Đurđin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tavankut",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljutovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mala Bosna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čantavir",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Višnjevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Zednik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stari Žednik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačka Topola",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Karadjordjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Beograd",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Njegoševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gunaroš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pobeda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mali Idjoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lovćenac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Feketić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Panonija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24331",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bajša",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24340",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stara Moravica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24341",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krivaja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24342",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pačir",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24343",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Sokolac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24344",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Oresković",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24351",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novo Orahovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24352",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tornjoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24400",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Senta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24406",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Breg",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24407",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kevi",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24408",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogaras",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24410",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Horgoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24411",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Horgoš Granični Prelaz",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24413",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Palić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24414",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Hajdukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24415",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Vinogradi",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24416",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Male Pijace",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24417",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Martonoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24420",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kanjiža",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24425",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Adorjan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24426",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tresnjevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24427",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Totovo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24430",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ada",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24435",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mol",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "24437",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Utrine",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sombor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Conoplja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svetozar Miletić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksa Santic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crvenka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kljajićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Telečka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sivac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nova Crvenka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krusčić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kula",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lipar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ruski Krstur",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lalić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stapar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Brestovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Doroslovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Srpski Miletić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogojevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Odzaci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Gracac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ratkovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Deronje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Karavukovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Apatin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kupušina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25263",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prigrevica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25264",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sonta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25265",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svilojevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25270",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bezdan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25272",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Monostor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25274",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kolut",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25275",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bački Breg",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25280",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ridjica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25282",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gakovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25283",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rastina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "25284",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stanišić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pančevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jabuka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Glogonj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sefkerin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Opovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Baranda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sakule",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Idvor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kovačica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kačarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crepaja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Padina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Uzdin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kovin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bavanište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gaj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dubovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Deliblato",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mramorak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dolovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Skorenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pločica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Omoljica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Starčevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ivanovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatski Brestovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vršac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Alibunar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatsko Novo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vladimirovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26316",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Devojački Bunar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatski Karlovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nikolinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crvena Crkva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26324",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatska Palanka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26327",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banatska Subotica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26328",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dupljaja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26329",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kajtasovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Uljma",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26331",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ritisevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26332",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vlajkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26333",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pavliš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26334",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Središte",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26335",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gudurica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26336",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kuštilj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26337",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vatin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26338",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vojvodinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26340",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bela Crkva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26343",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Izbište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26345",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Straža",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26346",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jasenovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26347",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grebenac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26348",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vračev Gaj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26349",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kusić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26350",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Samoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26351",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Seleuš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26352",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ilandža",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26353",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Kozjak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26354",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dobrica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26360",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Plandište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26361",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lokve",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26362",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Janošik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26363",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jermenovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26364",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Margita",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26365",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Gaj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26366",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Greda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26367",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Barice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26368",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kupinik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26370",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Hajdučica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26371",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stari Lec",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26373",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Miletićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "26380",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kruščica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Užice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lunovo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Karan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sevojno",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravni",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sirogojno",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rožanstvo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ljubiš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Požega",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ježevica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Dobrinja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jelen Do",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Arilje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kruščica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brekovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Divljaka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Roge",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bioska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kremna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mokra Gora",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šljivovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bajina Bašta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mitrovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zlodol",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kostojevići",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rogačica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Perućac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kaluđerske Bare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kosjerić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Seča Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31263",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Varda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31265",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ražana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prijepolje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brodarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jabuka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aljinovici",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čajetina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bela Zemlja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mačkat",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gostilje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jablanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zlatibor",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31317",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Draglica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kokin Brod",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31319",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jasenovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Nova Varoš",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bozetici",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bistrica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31330",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Priboj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31335",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sastavci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "31337",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banja Kod Priboja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čačak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trbušani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kamenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mrčajevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mojsinje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Preljina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bresnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Trepca",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trnava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ježevica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zablaće",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Slatina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Goričani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Guča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Goračići",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kaona",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kotraža",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lučani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ovčar Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Markovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ivanjica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bukovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prilicki Kiseljak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezova",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vionica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medjurečje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bratljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kovilje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kušići",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32259",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bele Vode",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Milanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32303",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brđani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Takovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bersici",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Banjani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pranjani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šilopaj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Boljkovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rudnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ugrinovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "32315",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vračevšnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kragujevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grosnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ilićevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Divostin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornja Sabanta",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Erdec",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Marsic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rača Kragujevačka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jovanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Malo Krcmare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Krčmare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Đurdjevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Male Pčelice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bukurovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lapovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lapovo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Korman",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Resnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Badnjevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Batočina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brzan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zirovnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gruza",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dragobraca",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Guberevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Knić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bumbarevo Brdo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Toponica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zabojnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Arandjelovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34301",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bukovik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34302",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ranilovic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34303",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Arandjelovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34304",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Darosava",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vencane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stojnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Orašac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jelovik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Topola",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belosavci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Natalinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34314",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Satornja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34318",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jarmenovci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Desimirovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34322",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čumić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34323",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stragari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "34325",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lužnice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jagodina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Siokovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bagrdan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Raševica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Potočac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vojska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Subotica Kod Svilajnca",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svilajnac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35211",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sedlare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Plažane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Despotovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stenjevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bobovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35219",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Končarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ribare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Glogovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Popović",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medvedja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kušiljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Krušar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Supska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ćuprija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Senje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Senjski Rudnik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ravna Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mijatovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Resavica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35238",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bigrenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35241",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jasenovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kolare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35247",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Plana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35248",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trešnjevica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35249",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Busilovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35250",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Paraćin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Popovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donja Mutnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sikirica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Drenovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donje Vidovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35259",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Svojnovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rekovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35261",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Glavinci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dragoševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35263",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Belusic",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35264",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prevešt",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35265",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dragovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35267",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Oparić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35268",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Miloševo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35269",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Strižilo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35270",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Majur",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35271",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novo Lanište",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35272",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dragocvet",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "35273",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bunar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kraljevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Mataruška Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Samaila",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Adrani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lađevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Roćevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vitanovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vitkovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sirča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrnjačka Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ratina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrba",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Podunavci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novo Selo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vrnjci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čukojevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rudno",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36300",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Novi Pazar",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36305",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dezeva",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36306",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lukare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36307",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Delimede",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36308",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sopoćani",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36309",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ribarice",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36310",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sjenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36311",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Štavalj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36312",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Duga Poljana",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36313",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ugao",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36320",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Tutin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36321",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Crkvine",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36340",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Konarevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36341",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bogutovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36342",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ušće",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36343",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Studenica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36344",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Baljevac Na Ibru",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36345",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jošanicka Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36346",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brvenik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36350",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Raška",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36353",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rudnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "36354",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kopaonik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37000",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kruševac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37201",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Parunovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37202",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Djunis",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37203",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zdravinje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37204",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliki Siljegovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ribarska Banja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37206",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dvorane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37207",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Veliko Golovode",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37208",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Čitluk",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37209",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Lomnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ćićevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37212",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stalać",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Vitosevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37214",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pojate",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37215",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ražanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brus",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37221",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Stepos",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37222",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kupci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37223",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Razbojna",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37224",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lepenac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37225",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brzeće",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37226",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Blazevo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Milentija",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zlatari",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37229",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Grasevci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37230",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Aleksandrovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37231",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pepeljevac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37232",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Laćisled",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37233",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Vrbnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37234",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gornji Stupanj",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37235",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trnavci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Rataje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37237",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ploča",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37238",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ples",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37239",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Šljivovo",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37240",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Trstenik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37242",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Stopanja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37243",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Počekovina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37244",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Medvedja",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37245",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Velika Drenova",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37246",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Milutovac",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37251",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Globoder",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37252",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Jasika",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37253",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bela Voda",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37254",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Konjuh",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37255",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kukljin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37256",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kaonik",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37257",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Padež",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37258",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Donji Krcin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37259",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ribare",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37260",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Varvarin",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37262",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bosnjane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37265",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Bačina",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37266",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Obrez",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37271",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Dasnica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37281",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Osreci",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "37282",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kriva Reka",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38157",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Brezovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38205",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Gracanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38210",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kosovo Polje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38213",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Prilužje",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38216",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Banjska",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38217",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Sočanica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38218",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Leposavić",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38219",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Lešak",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38220",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Kosovska Mitrovica",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38227",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zvecan",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38228",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Zubin Potok",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38236",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Štrpce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38239",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Drajkovce",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38266",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Pasjane",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  },
+  {
+    "code": "38267",
+    "country_id": 196,
+    "country_code": "RS",
+    "locality_name": "Ranilug",
+    "type": "full",
+    "source": "posta-srbije-via-nebjak"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 1,170 Serbia postcodes covering Pošta Srbije's catalogue, sourced
from the MIT-licensed ``nebjak/serbia-zip-codes-js`` package.

- **Coverage**: country-only by design.
- **Granularity**: city level — one record per ``(5-digit code, city)`` pair.

## Why country-only

Source carries only ``city`` + ``zip_code``. Mapping to the 32
okrugs / cities of national importance in ``states.json`` would
require an external okrug-by-locality table; matches the
SE/SI/ZA/GR/VN/LV/KE precedent.

## Source & licence

- Source URL: https://raw.githubusercontent.com/nebjak/serbia-zip-codes-js/master/data/serbia_zip_codes.json
- Licence: MIT (community redistribution of Pošta Srbije data).
- Each row: ``"source": "posta-srbije-via-nebjak"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 1,170 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)