### PR TITLE
feat(postcodes/SV): bulk-import 262 El Salvador postcodes via Correos de El Salvador (#1039)

### DIFF
--- a/bin/scripts/sync/import_el_salvador_postcodes.py
+++ b/bin/scripts/sync/import_el_salvador_postcodes.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""El Salvador -> contributions/postcodes/SV.json importer for #1039.
+
+Source data
+-----------
+The community ``micryptosv/SV-Postales-2025-API`` repository ships
+the 2025 Correos de El Salvador catalogue keyed by department,
+municipality, district and 5-digit code:
+
+    Departamento, Municipio, Distrito, CodigoPostal
+    Ahuachapán, Ahuachapán Norte, Atiquizaya, 02103
+
+Source URL: https://raw.githubusercontent.com/micryptosv/SV-Postales-2025-API/main/data/elsalvador.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Strips the always-present leading ``0`` to recover the canonical
+   4-digit form expected by the country regex ``^(?:CP)*(\\d{4})$``.
+3. Resolves ``state_id`` via case-insensitive name match against
+   ``states.json`` for all 14 departments.
+4. Emits one record per ``(4-digit code, distrito)`` pair.
+5. Writes contributions/postcodes/SV.json idempotently.
+
+License & attribution
+---------------------
+- Source: micryptosv/SV-Postales-2025-API; data is the publicly
+  published 2025 Correos de El Salvador catalogue.
+- Each row: ``source: "correos-el-salvador-via-micryptosv"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_el_salvador_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/micryptosv/SV-Postales-2025-API/"
+    "main/data/elsalvador.csv"
+)
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    sv_country = next((c for c in countries if c.get("iso2") == "SV"), None)
+    if sv_country is None:
+        print("ERROR: SV not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(sv_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    sv_states = [s for s in states if s.get("country_id") == sv_country["id"]]
+    state_by_name: Dict[str, dict] = {
+        s["name"].strip().lower(): s for s in sv_states
+    }
+    print(f"Country: El Salvador (id={sv_country['id']}); states indexed: {len(sv_states)}")
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        code = (row.get("CodigoPostal") or "").strip()
+        # Strip the always-present leading "0" to get the canonical 4-digit
+        if code.startswith("0") and len(code) == 5 and code.isdigit():
+            code = code[1:]
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        province = (row.get("Departamento") or "").strip()
+        distrito = (row.get("Distrito") or "").strip()
+        municipio = (row.get("Municipio") or "").strip()
+        locality = ", ".join(p for p in (distrito, municipio) if p)
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(sv_country["id"]),
+            "country_code": "SV",
+        }
+        state = state_by_name.get(province.lower())
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "correos-el-salvador-via-micryptosv"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/SV.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/SV.json
+++ b/contributions/postcodes/SV.json
@@ -1,0 +1,2622 @@
+[
+  {
+    "code": "1101",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "San Salvador, San Salvador Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1115",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "San Marcos, San Salvador Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1116",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Soyapango, San Salvador Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1117",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Ilopango, San Salvador Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1118",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Ciudad Delgado, San Salvador Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1119",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Cuscatancingo, San Salvador Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1120",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Mejicanos, San Salvador Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1121",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Ayutuxtepeque, San Salvador Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1122",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Aguilares, San Salvador Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1123",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Apopa, San Salvador Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1124",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "El Paisnal, San Salvador Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1125",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Guazapa, San Salvador Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1126",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Nejapa, San Salvador Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1127",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Panchimalco, San Salvador Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1128",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Rosario de Mora, San Salvador Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1129",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "San Martín, San Salvador Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1130",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Santiago Texacuangos, San Salvador Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1131",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Santo Tomás, San Salvador Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1132",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4133,
+    "state_code": "SS",
+    "locality_name": "Tonacatepeque, San Salvador Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1201",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Sensuntepeque, Cabañas Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1202",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Cinquera, Cabañas Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1203",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Guacotecti, Cabañas Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1204",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Ilobasco, Cabañas Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1206",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Jutiapa, Cabañas Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1207",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "San Isidro, Cabañas Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1208",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Tejutepeque, Cabañas Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1209",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Dolores, Cabañas Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1210",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4132,
+    "state_code": "CA",
+    "locality_name": "Victoria, Cabañas Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1301",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Chalatenango, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1302",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Agua Caliente, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1303",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Arcatao, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1304",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Azacualpa, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1305",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San José Cancasque, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1306",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Citalá, Chalatenango Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1307",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Comalapa, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1308",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Concepción Quezaltepeque, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1309",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Dulce Nombre de María, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1311",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "El Carrizal, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1312",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "El Paraíso, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1313",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "La Laguna, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1314",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "La Palma, Chalatenango Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1315",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "La Reina, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1316",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San José Las Flores, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1317",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Las Vueltas, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1318",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Nombre de Jesús, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1319",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Nueva Concepción, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1320",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Nueva Trinidad, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1321",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Ojos de Agua, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1322",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Potonico, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1324",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Antonio de La Cruz, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1325",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Antonio Los Ranchos, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1326",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Fernando, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1327",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Francisco Lempa, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1328",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Francisco Morazán, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1329",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Ignacio, Chalatenango Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1330",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Isidro Labrador, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1331",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Luis del Carmen, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1332",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Miguel de Mercedes, Chalatenango Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1333",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "San Rafael, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1334",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Santa Rita, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1335",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4131,
+    "state_code": "CH",
+    "locality_name": "Tejutla, Chalatenango Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1401",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Cojutepeque, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1402",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Candelaria, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1403",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "El Carmen, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1404",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "El Rosario, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1405",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Monte San Juan, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1406",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Oratorio de Concepción, Cuscatlán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1407",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San Bartolomé Perulapán, Cuscatlán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1408",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San Cristóbal, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1409",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San José Guayabal, Cuscatlán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1410",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San Pedro Perulapán, Cuscatlán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1411",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San Rafael Cedros, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1412",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "San Ramón, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1413",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Santa Cruz Analquito, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1414",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Santa Cruz Michapa, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1415",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Suchitoto, Cuscatlán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1416",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4137,
+    "state_code": "CU",
+    "locality_name": "Tenancingo, Cuscatlán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1501",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Santa Tecla, La Libertad Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1502",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Antiguo Cuscatlán, La Libertad Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1504",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Ciudad Arce, La Libertad Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1506",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Comasagua, La Libertad Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1507",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Chiltiupán, La Libertad Costa",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1508",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Huizúcar, La Libertad Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1509",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Jayaque, La Libertad Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1510",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Jicalapa, La Libertad Costa",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1511",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "La Libertad, La Libertad Costa",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1512",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Colón, La Libertad Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1513",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Nuevo Cuscatlán, La Libertad Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1514",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "San Juan Opico, La Libertad Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1515",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Quezaltepeque, La Libertad Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1516",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Sacacoyo, La Libertad Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1517",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "San José Villanueva, La Libertad Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1518",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "San Matías, La Libertad Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1519",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "San Pablo Tacachico, La Libertad Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1521",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Talnique, La Libertad Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1522",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Tamanique, La Libertad Costa",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1523",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Teotepeque, La Libertad Costa",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1524",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Tepecoyo, La Libertad Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1525",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4134,
+    "state_code": "LI",
+    "locality_name": "Zaragoza, La Libertad Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1601",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Zacatecoluca, La Paz Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1603",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Cuyultitán, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1604",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "El Rosario, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1605",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Jerusalén, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1606",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Luis La Herradura, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1607",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Mercedes La Ceiba, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1608",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Olocuilta, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1609",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Paraíso de Osorio, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1610",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Antonio Masahuat, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1611",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Emigdio, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1612",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Francisco Chinameca, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1613",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Juan Nonualco, La Paz Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1614",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Juan Talpa, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1615",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Juan Tepezontes, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1616",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Luis Talpa, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1617",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Miguel Tepezontes, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1618",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Pedro Masahuat, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1619",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Pedro Nonualco, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1620",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "San Rafael Obrajuelo, La Paz Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1621",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Santa María Ostuma, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1622",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Santiago Nonualco, La Paz Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1623",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4136,
+    "state_code": "PA",
+    "locality_name": "Tapalhuaca, La Paz Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1701",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Vicente, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1702",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Apastepeque, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1703",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Guadalupe, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1704",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Cayetano Istepeque, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1705",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Esteban Catarina, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1706",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Ildefonso, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1707",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Lorenzo, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1708",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "San Sebastián, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1709",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Santa Clara, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1710",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Santo Domingo, San Vicente Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1711",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Tecoluca, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1712",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Tepetitán, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "1713",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4127,
+    "state_code": "SV",
+    "locality_name": "Verapaz, San Vicente Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2101",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Ahuachapán, Ahuachapán Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2102",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Apaneca, Ahuachapán Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2103",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Atiquizaya, Ahuachapán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2106",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Concepción de Ataco, Ahuachapán Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2107",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "El Refugio, Ahuachapán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2108",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Guaymango, Ahuachapán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2109",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Jujutla, Ahuachapán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2113",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "San Francisco Menéndez, Ahuachapán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2115",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "San Lorenzo, Ahuachapán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2116",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "San Pedro Puxtla, Ahuachapán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2117",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Tacuba, Ahuachapán Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2118",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4139,
+    "state_code": "AH",
+    "locality_name": "Turín, Ahuachapán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2201",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Santa Ana, Santa Ana Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2203",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Candelaria de la Frontera, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2204",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Coatepeque, Santa Ana Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2205",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Chalchuapa, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2207",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "El Congo, Santa Ana Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2208",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "El Porvenir, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2210",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Masahuat, Santa Ana Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2211",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Metapán, Santa Ana Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2212",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "San Antonio Pajonal, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2215",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "San Sebastián Salitrillo, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2216",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Santa Rosa Guachipilín, Santa Ana Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2217",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Santiago de La Frontera, Santa Ana Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2218",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4128,
+    "state_code": "SA",
+    "locality_name": "Texistepeque, Santa Ana Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2301",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Sonsonate, Sonsonate Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2302",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Acajutla, Sonsonate Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2303",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Armenia, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2304",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Caluco, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2305",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Cuisnahuat, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2306",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Izalco, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2307",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Juayúa, Sonsonate Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2311",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Nahuizalco, Sonsonate Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2312",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Nahulingo, Sonsonate Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2313",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Salcoatitán, Sonsonate Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2314",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "San Antonio del Monte, Sonsonate Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2316",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "San Julián, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2317",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Santa Catarina Masahuat, Sonsonate Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2318",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Santa Isabel Ishuatán, Sonsonate Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2319",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Santo Domingo de Guzmán, Sonsonate Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "2320",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4140,
+    "state_code": "SO",
+    "locality_name": "Sonzacate, Sonsonate Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3101",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "La Unión, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3104",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Anamorós, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3105",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Bolívar, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3106",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Concepción de Oriente, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3107",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Conchagua, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3108",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "El Carmen, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3109",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "El Sauce, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3111",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Intipucá, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3112",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Lislique, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3113",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Meanguera del Golfo, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3114",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Nueva Esparta, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3116",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Pasaquina, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3117",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Polorós, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3119",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "San Alejo, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3120",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "San José La Fuente, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3121",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Santa Rosa de Lima, La Unión Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3122",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Yayantique, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3123",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4138,
+    "state_code": "UN",
+    "locality_name": "Yucuaiquín, La Unión Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3201",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "San Francisco Gotera, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3202",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Arambala, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3203",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Cacaopera, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3204",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Corinto, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3205",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Chilanga, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3206",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Delicias de Concepción, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3207",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "El Divisadero, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3208",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "El Rosario, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3209",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Gualococti, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3210",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Guatajiagua, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3211",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Joateca, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3212",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Jocoaitique, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3213",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Jocoro, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3214",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Lolotiquillo, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3215",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Meanguera, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3216",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Osicala, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3217",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Perquín, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3218",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "San Carlos, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3219",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "San Fernando, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3220",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "San Isidro, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3221",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "San Simón, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3222",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Sensembra, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3223",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Sociedad, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3224",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Torola, Morazán Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3225",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Yamabal, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3226",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4130,
+    "state_code": "MO",
+    "locality_name": "Yoloaiquín, Morazán Sur",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3301",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Miguel, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3302",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Carolina, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3303",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Ciudad Barrios, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3304",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Comacarán, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3305",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Chapeltique, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3306",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Chinameca, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3307",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Chirilagua, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3309",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "El Tránsito, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3311",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Lolotique, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3312",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Moncagua, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3313",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Nueva Guadalupe, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3314",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Nuevo Edén de San Juan, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3315",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Quelepa, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3316",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Antonio del Mosco, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3318",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Gerardo, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3319",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Jorge, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3320",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Luis de La Reina, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3322",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "San Rafael Oriente, San Miguel Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3323",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Sesori, San Miguel Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3324",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4135,
+    "state_code": "SM",
+    "locality_name": "Uluazapa, San Miguel Centro",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3401",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Usulután, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3403",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Berlín, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3404",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Alegría, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3404",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "California, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3405",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Concepción Batres, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3406",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "El Triunfo, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3407",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Ereguayquín, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3408",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Estanzuelas, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3409",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Jiquilisco, Usulután Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3410",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Jucuapa, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3411",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Jucuarán, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3412",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Mercedes Umaña, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3413",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Nueva Granada, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3415",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Ozatlán, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3417",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Puerto El Triunfo, Usulután Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3418",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "San Agustín, Usulután Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3419",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "San Buenaventura, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3420",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "San Dionisio, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3421",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "San Francisco Javier, Usulután Oeste",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3422",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Santa Elena, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3423",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Santa María, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3424",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Santiago de María, Usulután Norte",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  },
+  {
+    "code": "3426",
+    "country_id": 66,
+    "country_code": "SV",
+    "state_id": 4129,
+    "state_code": "US",
+    "locality_name": "Tecapán, Usulután Este",
+    "type": "full",
+    "source": "correos-el-salvador-via-micryptosv"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 262 El Salvador postcodes spanning all 14 departments, sourced
from the 2025 Correos de El Salvador catalogue redistributed via the
``micryptosv/SV-Postales-2025-API`` CSV.

- **Coverage**: 100% department resolution.
- **Granularity**: distrito level — one record per
  ``(4-digit code, distrito + municipio)`` pair.

## How it works

The source ships codes in a 5-digit form (e.g. ``02103``) where the
always-present leading ``0`` is a regional grouping prefix. The
importer strips it to obtain the canonical 4-digit form expected by
the country regex ``^(?:CP)*(\d{4})$``.

## Source & licence

- Source URL: https://raw.githubusercontent.com/micryptosv/SV-Postales-2025-API/main/data/elsalvador.csv
- Origin: 2025 Correos de El Salvador publicly published catalogue.
- Each row: ``"source": "correos-el-salvador-via-micryptosv"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 262 codes match ``country.postal_code_regex`` (``^(?:CP)*(\d{4})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 66``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)