### PR TITLE
feat(postcodes/MN): bulk-import 2,605 Mongolia postcodes via Mongol Шуудан + fix MN regex (#1039)

### DIFF
--- a/bin/scripts/sync/import_mongolia_postcodes.py
+++ b/bin/scripts/sync/import_mongolia_postcodes.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Mongolia -> contributions/postcodes/MN.json importer for #1039.
+
+Source data
+-----------
+The community ``bekkaze/mnzipcode`` package ships Mongol Шуудан's
+catalogue as a nested JSON tree of aimags / capital districts ->
+sub-units, each carrying a 5-digit zipcode plus Mongolian + Latin
+names:
+
+    {"zipcode": [
+       {"stat": "capital", "mnname": "Улаанбаатар", "name":
+        "Ulaanbaatar", "zipcode": "11000", "sub_items": [...]},
+       ...
+    ]}
+
+Source URL: https://raw.githubusercontent.com/bekkaze/mnzipcode/main/data/data.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Recursively flattens the aimag tree into ``(zipcode, locality)``
+   tuples, carrying the top-level aimag/capital name forward for
+   FK resolution.
+3. Resolves ``state_id`` by ASCII-fold name match against
+   ``states.json`` (handles Latin variants such as Khövsgöl).
+4. Writes contributions/postcodes/MN.json idempotently.
+
+Also updates the Mongolia ``postal_code_regex``/``format`` in
+``countries.json`` from a 6-digit shape to the canonical 5-digit
+shape used by Mongol Шуудан (matches every code in this dataset
+and the UPU spec).
+
+License & attribution
+---------------------
+- Source: bekkaze/mnzipcode (open redistribution of Mongol Шуудан's
+  publicly published index).
+- Each row: ``source: "mongol-shuudan-via-bekkaze"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_mongolia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/bekkaze/mnzipcode/main/data/data.json"
+)
+
+# Source aimag-name (lowercased) -> CSC states.json "name"
+STATE_ALIASES: Dict[str, str] = {
+    "tuv": "Töv",        # source spells without diacritic; CSC uses Cyrillic-derived "ö"
+    "dundgobi": "Dundgovi",  # source uses 'b'; CSC and UPU use 'v'
+}
+
+
+def _fold(value: str) -> str:
+    s = "".join(
+        c for c in unicodedata.normalize("NFKD", (value or "").lower())
+        if not unicodedata.combining(c)
+    )
+    return s.strip()
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def walk(node: dict, aimag_name: Optional[str], rows: List[tuple]) -> None:
+    """Recursively flatten the bekkaze tree into (zipcode, name, aimag) tuples."""
+    code = (node.get("zipcode") or "").strip()
+    name = (node.get("name") or node.get("mnname") or "").strip()
+    if code:
+        rows.append((code, name, aimag_name or name))
+    next_aimag = aimag_name or name
+    for child in node.get("sub_items", []) or []:
+        if isinstance(child, dict):
+            walk(child, next_aimag, rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    mn_country = next((c for c in countries if c.get("iso2") == "MN"), None)
+    if mn_country is None:
+        print("ERROR: MN not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(mn_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    mn_states = [s for s in states if s.get("country_id") == mn_country["id"]]
+    state_by_fold: Dict[str, dict] = {_fold(s["name"]): s for s in mn_states}
+    print(f"Country: Mongolia (id={mn_country['id']}); states indexed: {len(mn_states)}")
+
+    rows: List[tuple] = []
+    for top in (data.get("zipcode") or []):
+        if isinstance(top, dict):
+            walk(top, None, rows)
+    print(f"Flattened source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for code, locality, aimag in rows:
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        key = (code, (locality or "").lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(mn_country["id"]),
+            "country_code": "MN",
+        }
+        target_aimag = STATE_ALIASES.get(_fold(aimag), aimag)
+        state = state_by_fold.get(_fold(target_aimag))
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "mongol-shuudan-via-bekkaze"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/MN.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -9798,8 +9798,8 @@
     "subregion_id": 12,
     "nationality": "Mongolian",
     "area_sq_km": 1565000.0,
-    "postal_code_format": "######",
-    "postal_code_regex": "^(\\d{6})$",
+    "postal_code_format": "#####",
+    "postal_code_regex": "^(\\d{5})$",
     "timezones": [
       {
         "zoneName": "Asia/Choibalsan",

--- a/contributions/postcodes/MN.json
+++ b/contributions/postcodes/MN.json
@@ -1,0 +1,26052 @@
+[
+  {
+    "code": "11000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ulaanbaatar",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Baganuur",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12001",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хэрлэн голын хөвөө-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12002",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12003",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нарийн нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12004",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нугийн тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12005",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тариан булаг-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12006",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тариан булаг-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12007",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хэрлэн голын хөвөө-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12008",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хүрмэнтийн хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12009",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дунд байдлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Талын толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тогос уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их гүн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хэрлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага гүн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Байдлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нарийн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Залуус хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хилчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сургалтын задгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хуцаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн хэсэг-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн хэсэг-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Замчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн хэсэг-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нүүрэнтэйн хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаан ухаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нуур хороолол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12212",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Булагтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12300",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Bagakhangai",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12301",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хангайн хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12302",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12305",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12310",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Єртєєний хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12311",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бор үзүүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12312",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12313",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цайдам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12314",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Замчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12320",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Аеродромын хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12330",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Єндєртолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12340",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12350",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Алтгана",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12360",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үнэгтэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12591",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өндөр улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12592",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баян давааны энгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12593",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цонжин болдог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12594",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тулгат гацаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12595",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Агуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12596",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "100 мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12597",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цагаан овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12598",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ёлын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12599",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Элстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12600",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Nalaikh",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12601",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тэрэлжийн бага ёл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12602",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гандан ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12603",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гялаан мөс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12604",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Онгоцотын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12605",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дугуй бургастай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12606",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Элст тохой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12607",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цагаан овооны хєндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12608",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нисэх хотхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12609",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баян-уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12610",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бүс нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12611",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12612",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гандан уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12613",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Уурхай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12614",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12615",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дархан ноёны хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12616",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Налайхын тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12617",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их бага модны ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12618",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Буурлын даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12619",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хар чулуутын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12620",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12621",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хөндлөнгийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12622",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хайрханы ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12623",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шохойтын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12630",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12640",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нисэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12650",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Єлгий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12660",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Алтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12670",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12680",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Замчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12690",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Туул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12700",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12710",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тэрэлж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12712",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шилжрээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12720",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Энгэр шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12724",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өгөөмөрийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12728",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Онгоцотын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12735",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12739",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Антын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12740",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цэргийн анги",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12750",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Уурхайчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12760",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Залуучууд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12770",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Горхи эрээний ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12771",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Горхийн баруун салаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12780",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цайзын хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12790",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалант-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12791",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалант-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12800",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12810",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өвөр шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "12820",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нарлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Bayanzurkh",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13009",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дэндийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13012",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Арцат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага хуандай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шар хоолойн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Могойн дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хонхор нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13086",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шажин хурах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхан уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13088",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нам даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хөлийн гол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хонхор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Туулын хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Төвийн хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баян дөхөмийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Эмийн ургамал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баян төхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гүнжийн хоолой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ногоон зоорь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сүүл даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13182",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ногоон зоорь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хөлийн гол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13184",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Туулын зөрлөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Туулын зөрлөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Төрхурах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хужирбулан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их булгийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13212",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баатархайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13214",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улиастайн гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цардуулт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13216",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хадат, Хожуултын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13218",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улиастай гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хүрхрээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Залаатын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улиастай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Амгалан-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Амгалан-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Амгалан-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13280",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шар хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13281",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шар хад-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13290",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цайз-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цайз-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13292",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цайз-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13300",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаанхуаран-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13301",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаанхуаран-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13302",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаанхуаран-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13311",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шинэ суурьшил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13312",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шинэ суурьшил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13313",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13314",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага тэнгэрийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13315",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их тэнгэрийн ам-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13320",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "16-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13321",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "16-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13330",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13331",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13332",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13333",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13334",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13335",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13336",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "14-р хороолол-7",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13340",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13341",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13342",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13343",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13344",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13345",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "15--р хороолол-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13350",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дарь-Эх -1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13351",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дарь-Эх -2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13352",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дунд дарь-Эх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13353",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жамсран уулын өвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13354",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага дарь-Эх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13355",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ганц худгийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13360",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хоршооллын хотхон-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13361",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хоршооллын хотхон -2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13370",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 2-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13371",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 2-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13372",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 2-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13373",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 2-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13374",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 2-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13380",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "12-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "13381",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "12-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Sukhbaatar",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх хадат 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх хадат 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14012",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх Цуурайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлбэ 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлбэ 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цээнийн хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цолмонгийн ам 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цолмонгийн ам 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14052",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх Мааньтын даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бэлх Даваатын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дамбадаржаа-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дамбадаржаа-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дамбадаржаа-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлх 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлх 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14072",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлх 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сэлх 4-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 1- хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 2-хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 3-хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 4-хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14084",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 5-хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шарга морьт 6-хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хандгайт 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хандгайт 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14092",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хандгайт 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хандгайтын богино 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14094",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хандгайтын богино 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар хустай 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар хустай 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зуун мод_СБ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянбулаг 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянбулаг 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14112",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянбулаг 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хуурай мухар 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хуурай мухар 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14122",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хуурай мухар 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гоодойн ам 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гоодойн ам 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14132",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гоодойн ам 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Санзай 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Санзай 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14142",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Санзай 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Санзай 4-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхан толгой_СБ 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхан толгой_СБ 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "5 буудал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "100 айл-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "100 айл-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "7-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "7-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14182",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "7-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "11-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "11-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14192",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "11-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "11-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага тойруу-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага тойруу-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 1-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 1-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "13-р хороолол 1-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Соёл амралтын хүрээлэн -1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Соёл амралтын хүрээлэн - 2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "5-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "5-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14252",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "5-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "14253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "5-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Chingeltei",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар согоот 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар согоот 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шадивлан 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шадивлан 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15022",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шадивлан 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шадивлан 4-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15024",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шадивлан 5-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Чингэлтэй 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Чингэлтэй 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15032",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Чингэлтэй 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зуун мод_ЧИН 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зуун мод_ЧИН  2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яргайт 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яргайт 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15052",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яргайтын богино 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яргайтын богино 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15054",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яргайтын богино 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Салхит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ойнбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхан толгой_Чин 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Майхан толгой_Чин 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гүнт 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гүнт 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жигжид 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жигжид 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жигжид 3-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жигжид 4-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15104",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жигжид 5-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хайлааст-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хайлааст-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дэнжийн мянга 1-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дэнжийн мянга 2-р хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Телевиз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "6-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "6-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тасганы овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бага тойруу-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "40, 50 мянгат-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "40, 50 мянгат-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "15172",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "40, 50 мянгат-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Bayangol",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн төвийн бүс-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн төвийн бүс-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн төвийн бүс-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гандан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "2-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "2-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16052",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "2-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16064",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16066",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-7",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "4-р хороолол-8",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "10-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "10-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16092",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16094",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "3-р хороолол-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 1-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 1-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 1-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "16103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 1-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Khan-Uul",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17009",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Стадион Оргил-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Стадион Оргил-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17012",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Стадион Оргил-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Стадион Оргил-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17022",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17024",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17026",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-7",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-8",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17028",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-9",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зайсан-10",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "19-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "19-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17032",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "19-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "19-р хороолол-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 2-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 2-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17042",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 2-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 2-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Богины ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Чандманы ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 1-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 1-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэр 1-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 2-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Үйлдвэрийн баруун бүс 2-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хүүшийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нүхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалантын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яармагийн урд дэнж-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яармагийн урд дэнж -1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дарга толгойн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яармаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Яармаг-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Буянт Ухаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Буянт Ухаа  хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17122",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Буянт Ухаа хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Морин-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Морин-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17132",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тайны ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Морин-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Био комбинат /Сонгино/ -1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Био комбинат /Сонгино/ -2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17142",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Эрдэнэтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Био комбинат 2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17144",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонгины амралтын хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй б",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17152",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бугын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар хөндлөнгийн хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Гавжийн шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шувуун фабрик /Туул тосгон/",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шувуун фабрик  /Туул тосгон/",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17172",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шувуун фабрик-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Уушийн ар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17174",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Аж үйлдвэрийн парк хэсэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "17175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Улаан овоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Songinokhairkhan",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянхошуу-1-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянхошуу-1-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "1-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "1-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18032",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "1-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өнөр хороолол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойтын зүүн салаа-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойтын зүүн салаа-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18052",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ханын материал-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ханын материал-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ханын материал-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Москва хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Москва хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18072",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Москва хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "21-р хороолол-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "21-р хороолол-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "21-р хороолол-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянхошуу-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18104",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойт-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Богдын ар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ар гүнт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18132",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18134",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сонсголон-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Наран-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойтын баруун салаа-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Толгойтын баруун салаа-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18152",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Орбит-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Орбит-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18172",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Орбит-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Орбит-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18182",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18192",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-7",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баянголын ам-8",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Цагаан бургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "335-ын гарам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18212",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бороочийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Өвөр уулын овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18214",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Халзангийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18216",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хүйн хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "335-ын гарам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18218",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18222",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 3",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 4",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18224",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 5",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Найрамдал 6",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Овоот тосгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18242",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тахилтын хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шижиртийн даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хустайн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хотын шинэ төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Авто худалдааны цогцолбор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18280",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бурхант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18290",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Ханан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18300",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шижир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18310",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шар цэцэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18311",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Соёондын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18312",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Таширын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18320",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Зүүн туруун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18330",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалант тос",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18340",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Баруун туруун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18341",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18350",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Тахир соёот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18360",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "347-ийн гарам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18361",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Жаргалант тосгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18370",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Саалийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18380",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Аюушийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18390",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Рашаант тосго",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18400",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Эмээлт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18401",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Эмээлт -2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18402",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18403",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Долоон худгийн хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18404",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Шинэ товчоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18410",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "361-ийн гарам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18411",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18412",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18420",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хурганы сангийн аж ахуй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18430",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Нарийн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18440",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "369-ын гарам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18450",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хужиртын даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18460",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хүй 7 худаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18470",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дунд дүүрэн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18471",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18472",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Эмээлт уулын баруун хоолой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18480",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хөх асар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18490",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Дааган толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18500",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Их булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18501",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18510",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Замтын булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18520",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Сүүж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18530",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Хөндлөнгийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18540",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Бүрдийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "18550",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 5453,
+    "state_code": "001",
+    "locality_name": "Суурьшилгүй бүс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Dornod",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Халхгол сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Цогтсүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Ялалт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Ташгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Матад сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Түмэнхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21022",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Мэнэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Буян Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баянхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Эрдэнэбадрах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Чулуунхороот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Цагаанчулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Галуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Чойбалсан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Энгэр шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хулстай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хөх нуурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баянтүмэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21054",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хотонт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Цагаан дэрс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хэрлэн сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "11-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "7-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "2-р сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "3-р сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "10-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "9-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "8-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Гурванзагал сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Сүмийн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Цагаан хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Булган сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хулсан шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Өндөр хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Дашбалбар сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Чух номинт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Номинт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Улз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Сэвсүүл Жараахай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Харзат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Сэргэлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Очирхүрээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Галын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Барчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хурган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баяндун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Яргай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Түргэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Зүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хүрээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Гүн цэнгэлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Элст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хөлөнбуйр сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21152",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Батхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Битүүгийн адаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Хар чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Өвөр эрээн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Жаварт хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Бэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "21171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1963,
+    "state_code": "061",
+    "locality_name": "Уртын адаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Sukhbaatar",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Эрдэнэцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хөндлөн хайлааст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хадын булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Билүүт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Бадрах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Алтан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Сүхбаатар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хулгар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хайлааст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Шинэбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Сайншанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дарьганга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Бадрах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Өрнө дэрс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Овоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Аман-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дөхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Их-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Наранбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Тосонгийн гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Гүнхудаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баруун-Урт сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "9-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "8-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "7-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Онгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Ихбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Шарбүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Цөнгөрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хавирга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Нүдэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Халзан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Сайншанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Сахиул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хатавч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Халзан шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баяндэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дөхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Ширээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян-уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Бүрэнцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Уулбаян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Жавхлант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Тэгш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Мөнххаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баянтэрэм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22144",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баясгалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян цагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Бүрэнцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Түмэнцогт сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Хошмиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Лхүмбэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Баянцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Түвшинширээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Сэргэлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "22169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1977,
+    "state_code": "051",
+    "locality_name": "Үнэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Khentii",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Норовлин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Онон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Ангирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дадал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Агац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Онон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Балж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Батноров",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Эхэн бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Эрдэнэчандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Төвийн баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Идэрмэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Идэрмэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дундбүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-хутаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Улаан Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Цантын хоолой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-Адарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Адарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дуурлиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Галшир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Буянтбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Арвин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянбадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Оч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Арвин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянбадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Биндэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Онон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Мандалхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэрлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Ишгэн толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "ӨндӨр хаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "БаянмӨнх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Сариг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Цогт Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэрлэн баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Мөрөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бүрээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Цагаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Чандган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Зөөлөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Өмнөдэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Талын булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Гурван баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Чандган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэнтий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Чандаган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэнтий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Батширээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Барх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хурх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Норволин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Онон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянмөнх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дулаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэрлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Улаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дархан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Шажин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Мэргэн хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бор-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хараат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23189",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дотуур булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Жаргалтхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Гичгэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баян-Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэрлэн тооно",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Аварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Долоод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хэрлэнбаян улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23209",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Цэнхэрмандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хужхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянмод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Согоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Нугаар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бор-Өндөр сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бор-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Холбоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Уурхайчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Хүйх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Өлгий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "23709",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1974,
+    "state_code": "039",
+    "locality_name": "Баянхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Tuv",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Мөнгөнморьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Байдлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянжаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Улаан ухаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баяндэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Байдлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Галуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Тамган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өвөр Жанчивлан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хушинга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянтуул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цавчир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Архуст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Нарст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Ноён шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цавчир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Гурван түрүү",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баян айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Зогсоол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Алтат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сэргэлэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэ уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянбүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хөшиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Адвар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Зуунмод сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Зүүндэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянхошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баруун зуунмод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Ланс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Нацагдорж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Номт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Батсүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цогт Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Үдлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Алтанбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сүмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Аргал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Алтан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Замт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баян-Өнжүүл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Бараат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Борнуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Нарт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Бичигт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянчандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Замт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Гуна",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сарлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Даргиат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Аргалын уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Жавхлант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Буурал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Загдал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Найрамдал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Угтаалцайдам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хар чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Талын-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хүүлээхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сүүл буга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Оргил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Талын хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41239",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Майхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Лүн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Авдрант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Цагаан уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Төвийн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Өндөрширээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянтуул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Сант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41257",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Уянга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Бүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Булангаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41263",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Монгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41265",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41267",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Төхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41269",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баянцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Заамар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41273",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Тосон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41275",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Хайлааст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41277",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Төмстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41280",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41281",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Тарган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41283",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41285",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Давст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41287",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Дуут-Хуримт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41290",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Эрдэнэсант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Улаанхудаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41293",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Угалзат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41295",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41297",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "41299",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1968,
+    "state_code": "047",
+    "locality_name": "Баргиалт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "Govisümber",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "Шивээговь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "Баянтал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "42043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1978,
+    "state_code": "064",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Selenge",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ерөө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бугант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Буургачин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Тавин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хүдэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Тарвагатай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Мандал сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Түнхэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43032",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ширхэнцэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43034",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Минжхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Замчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43036",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Тарина",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43038",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баян арцат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянсуудал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Алтанбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Цөх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Суварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бүргэдтэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Жавхлант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Моностой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Гонир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хараа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Шаамар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Дулаанхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Охиндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Сүхбаатар сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Цагаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хонгор морьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43084",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ганзам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Салхит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43086",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Буур хээр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бор гүвээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Зүүнбүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Мангирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бэлчир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Түшиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ар нуга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Жаргалмандах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Цагааннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Тийрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хуурч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Оргих",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хушаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Мөнхтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ишгэнт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Сайхан сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хөтөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Гавшгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Дөмбөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бэлэн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Сант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хушаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ивэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Орхонтуул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баянцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Шар-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Хонгор-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Баруунбүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Ивэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Бургалтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "43175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1980,
+    "state_code": "049",
+    "locality_name": "Цагаан-овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Dornogovi",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Замын-Үүд сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44012",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44014",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Дөрвөлж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Еншөөв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Улаан уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Цагаан хөтөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Бүрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Өргөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Баянмөнх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сүмийн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Дэлгэрэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Аманшанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Цагаанхад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Улаанбадрах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Баянбогд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Нүдэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Хөвсгөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Жавхлант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Хөвсгөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Элст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Алтанширээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Зараа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Тойг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Чулуун гишгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Хаяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Хатанбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Халив",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Замын шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сулинхээр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Аман ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Эргэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Агаруут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Иххэт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Зүлэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Бүрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сайншанд сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44102",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44104",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "7-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сайхандулаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Улаан шороот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Цохио",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сайн ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Нүдэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Цагаан дөрвөлж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Нард",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Даланжаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Өнгөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Цомог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44134",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Олон-Овоод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Элдэв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Бичигт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Мандах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Сэрвэн баян хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Алхан тээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Өехий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Төхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "44149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1981,
+    "state_code": "063",
+    "locality_name": "Баянхошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Darkhan-Uul",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Шарын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Санжинт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Дархан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Салхит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Буурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Буурал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Энхтал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Баян-Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "Дархан сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "7-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "8-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "16-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "15-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "12-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "13-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "11-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "10-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "14-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "9-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45062",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "17-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45064",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "18-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "45071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1962,
+    "state_code": "037",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Ömnögovi",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Ханбогд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Жавхлант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Гавилууд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Манлай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Өехий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Могой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Харзаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Налих",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Цогтцэций",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Билгэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Сийрст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Цагаан Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Богт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Эмгэн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хармагтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Дэрсэнэ Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Төхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Цогт-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Бортээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Замын шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Найз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Ханхонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хондот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Мандах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Даланзадгад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Цагаан булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Их Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Далан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46084",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Зүүн сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46086",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Дунд сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Оюут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баруун сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Мандал-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баянхошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Өтгөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хүрмэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хүрмэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Тулга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Жанжин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Дал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хавцгайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Дэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баяндалай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Төхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Сэврэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Хоолт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Бүйлсэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Сайншанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Ноён",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Сайран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Ганзагад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Гурвантэс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Баясах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Гоёот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Тост",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "46159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1967,
+    "state_code": "053",
+    "locality_name": "Бага-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Dundgobi",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Өндөршил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Талын нар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Цог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Баянжаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Шилийн гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48022",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Аргатай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Энгэр ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Цагаандэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэлгэрэх зам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Замын улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Хараат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Буянт-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Буянт-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэрт-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Тагт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэрт-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Гурвансайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Суугаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэрсэнэ-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Гурвансайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Элгэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Гурвансайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Суугаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэрсэнэ ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Говьугтаал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Морьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Ажирхай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Долоод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Алаг-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Саруул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сайнцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Боржигон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Арвижих",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Нарлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Үйзэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Тэвш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэлгэрцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэлгэр-Эмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Цахиурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Луус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48122",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Зүлэгтий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Суварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Хулд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Шувуутай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Олдох",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Бүлээн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Адаацаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Өвөр урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Тавин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Ар урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сүм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Хашаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Эрдэнэдалай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Цагаан овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сангийн-далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сумын төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Тэнгэлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Цавчир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Өнгөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Дэлгэрхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Толь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сумын төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Ар шавагтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Тарагт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Сайхан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Төгрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Найз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Онги",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "48187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "58191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1970,
+    "state_code": "059",
+    "locality_name": "Боршоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Orkhon",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Дулаан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Улаантолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Баян-Өндөр сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Говил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Оюут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Хүрэнбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Зэст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Бүрэнбүст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Уртбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Согоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61038",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Цагаанчулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61044",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Их-залуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Малчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Уурхайчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Даваат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Яргуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "61057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1966,
+    "state_code": "035",
+    "locality_name": "Уртын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Övörkhangai",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баян-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өвөр зүлэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Батхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хар тойром",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бөмбий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ар-жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Донгит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Онгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ар-хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Их-Боригдой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Есөнзүйл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Тахилга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Мөнхбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эрээн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Сант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цахиурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Улаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Залаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Майхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цариг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бор-хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Аргуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Гуулин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Яргайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хаяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан-булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ширээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цавын-ихэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эргэн-дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өнц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Төгрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Сайн-төгрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хоолт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Их-ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Мазар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хархорин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Жалбаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Онгоцон-Ухаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Нарийн-хүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эрдэнэ-толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ганган-Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Вангийн овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шанх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хужирт сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өвөр-модот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62112",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дулаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шунхлай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шивээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Уужим",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Зүүнбаян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дөлгөөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэвшил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цахиурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62129",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эмгэд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэвшил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цахиурт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эмгэд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Тарагт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Их булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Алтан тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Туяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Арвайн тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хүрэмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Алтан-тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Туяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Арвайн-тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Арвайхээр сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ягаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62162",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ноён",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62164",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Зүлэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Согоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62166",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Онги",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэлгэрэхийн дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Арвайхээр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бурхи",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэлгэрэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хүйс толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Гучин-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Гучин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Аргуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Богд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Гүн-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баянтөхөм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Далан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ховд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ялаатай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бат-Өлзий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бүрэгтий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Зөрүүлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өвт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Улаан-Ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хүйтэн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Уянга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өлт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бөөрөлжүүт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Таац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шивээ-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Онги",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шуранга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэрсэн хонхор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62239",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бурхант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хайрхандулаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Эмээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Нарт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Марзат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Дэрсэн хонхор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62249",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Бурхант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Ар агуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Гучин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Аргуйт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62257",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шар дов",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Нарийнтээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баянтээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62263",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өндөр хөмөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62265",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62267",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баруунбаян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өлзийт хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62273",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хүүхдийн-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62275",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62277",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62281",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Баянтээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62283",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өндөр-хөмөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62285",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62287",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Шарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Өлзийт хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62293",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хүүхэдийн-Ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62295",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "62297",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1965,
+    "state_code": "055",
+    "locality_name": "Цагаан-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Bulgan",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Шар тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сэлэнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сангалтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сэлэнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Ингэт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тарайхтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Таримал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хангал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сөрт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сумын төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хялганат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хангал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Халиун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сумын төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Ар булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бүхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бүрэгхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Дэрст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Цахт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Дархан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Дашинчилэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хараат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Доргонт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Лах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Рашаант сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Улаан Шивээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63072",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Аргалхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хар чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хөгнө Хан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Банзар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63082",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хүрэмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63086",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бумбат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баянтөгөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Ханжаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тэшиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Эрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Харгал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Далан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хишиг-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Банзар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хүрэмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тээг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Гурванбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хөгнө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Агьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хулст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Авзага",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63129",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Бэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тогоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Ачуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хутаг-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хантай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сумын төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Уньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Могод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Эрхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баясгалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Ундрах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хүрэмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Угалз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Мануулт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Сайхан Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хульж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баян-Агт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Дулаанхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Халтар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хүрэмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63189",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Шарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "63212",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1961,
+    "state_code": "067",
+    "locality_name": "Хөгнө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Bayankhongor",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянлиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бага-баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Халбагант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян-Аараг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хатан-суудал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Их-баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Эрдэнэцогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Жанжин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64022",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Эрхэт хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өвгөнжаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цагаан-дэнж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Ямаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Сэнжит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Ёлын ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Худаг урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бийр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Байн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Улаан уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бурхант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Дуурсах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Гэгээн шавь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Богд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Луугар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хориулт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Алтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Жинст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цагаан ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бодь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хүйс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөнөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Уу-булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Асгамба",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Мандал хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөх бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Уран хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянхонгор сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цагаан-ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Шаргалжуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цагаанчулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цахир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64098",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Есөн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Угалз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Дуурсах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Гэгээн шавь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Галуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Үнэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Улаансайр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Задгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хотын-булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянговь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хэлтгий булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өргөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өрхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цоохор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Залаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баацагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Буйлсан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Оройн бууц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Зүүн хаяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянсайр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Могой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Товгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өргөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өрхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цоохор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бөмбөгөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөх толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Улаан сайр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Задгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хотын булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Нам толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөндлөн булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Эмээлтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өлзийт өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Шинэжинст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Эрдэнэшанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Зараа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Уртын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Эхэн хавцгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Заг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Чандмань Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Залаа Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цэцэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Дэлгэрэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Гичгэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бууцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянбүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Тэмээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64226",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Гурванбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Давааны ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Буга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөвийн ам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64239",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Пионер толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хүрээмарал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хөх бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Цорж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Дэлгэр мөрөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Норовлин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64249",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Сонор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баян-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Элгэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64252",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Идрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Улаан үзүүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Хангал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64263",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64265",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Бүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "64267",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1976,
+    "state_code": "069",
+    "locality_name": "Сангийн-далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Arkhangai",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хашаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Номгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цагаан хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цайдам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өлгийнуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өгий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Зэгстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Дойт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65029",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тоглох",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Ямаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бодонт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Байшир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хотонт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бургалтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Улаан-Чулуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хотонт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хөөвөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өндөр сант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Могой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Жарантай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Төвшрүүлэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баян-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Жаарай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Сөрт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цэнхэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Буйлан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тамир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Алтан Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цэнхэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Орхон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Батцэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хөнөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Улаан чулуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Дайр бор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Дэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баян Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Улаан-Чулуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Дайр-бор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Дэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тамир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Зуунмод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тусгалт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэбулган сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цагаан дэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бор толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Наранбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цагдуулт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Арслан цохио",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цагаан даваа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тамир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэмандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Идэр-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Алаг Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хан Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэ Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Их тамир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тайхар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Борт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хан-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хөхнуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хонгорж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Их-Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Туулант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Зуслан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Эрдэнэ уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Асайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65209",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хоолт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өндөр-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хануй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Донгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Азарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бэлхи",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Чулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хүрэм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Халуун ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Зуунмод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өлзийт гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тариат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Мөрөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Алтайд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Бөөрөлжүүт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хорго",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65239",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цагааннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Суман",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Халуун-ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Зуун-Мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65249",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Өлзийт-гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Гичгэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Ноён хангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65257",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Ар баясгалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65259",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Тэрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цахир сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Цахир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65273",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Хан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65275",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "65277",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1973,
+    "state_code": "073",
+    "locality_name": "Жинст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Khövsgöl",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тариалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ар тархи",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Таван толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Давааны ар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сэлэнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баянхошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Эрдэнэбулган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Удган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Булган тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Дуурга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бөөрөлж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цагаан-Үүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Уйлган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Үүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Дархит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Их-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Их-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сэлэнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шивээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Их-ац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Энх тал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тээл 1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Талын ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ханх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тураг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Турт /төвийн баг/",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хороо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Чадмань-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шивэрт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хөхөө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Улаан асга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ёлгос",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67088",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хайрхан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Түнэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зуны гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Навчилтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бийж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баян Эрхэт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Алтгана",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тосонцэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мухар хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сэлэнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сүүл  Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мөрөн сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Үерт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67122",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Уран дөш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67124",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Элст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67129",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Уст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Дулаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67132",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Эрхэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сүх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Нисэх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67138",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Эрчим",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Жилчиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Алаг-Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цагаан бургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хатгал тосгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Яргис",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Манхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шувуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ужиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Төмөрбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тариат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Нарийн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бүгдгээн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Рэнчинлхүмбэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Далайн зах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ёлт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Ходон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зөөлөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хоолойн зах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хөндий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Галт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Галт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Нүхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Арбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хавтага",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сүмбэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Уртбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тарганнуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67209",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бор гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бэл булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бүрэнтогтох",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Эрчим",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Туяа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баянхошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Их уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бүрэнхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шинэ-Идэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баян Зүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Нүхт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Сангийн Далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цагаан бургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Харгана",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Оргил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67257",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Той",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67259",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цэцүүх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цагааннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67263",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зүүн тайга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Улаан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шивлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67273",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тоом",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67275",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Төгөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67277",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Соёо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67279",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Мунгараг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67290",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тоом",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67293",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Эмт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67295",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бэлтэс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67297",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хайс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67299",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Агар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67300",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цагаан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67301",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67303",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Тосон баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67305",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Өвгөд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67307",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Шарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67309",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67311",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Агар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67320",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67321",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67322",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Бүрхээр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67323",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Согоот",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67325",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Уранхайрхан буюу Ренчинжугнай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67327",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Халбан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67329",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Зуун мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67331",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Дэлгэрхаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67340",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Хатгал сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "67341",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Алагцар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "68271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цахир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "68291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цахир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "74071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Улаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "74073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Цэцэг гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "74077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1975,
+    "state_code": "041",
+    "locality_name": "Давст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Zavkhan",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Их-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хуягт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цэцүүх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Ухаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Үржил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Зарт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Тосонцэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Улаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Оргих",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Идэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дархан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Тэлмэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянтэгш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян Айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81058",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Өвөгдий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Шургах",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Идэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Мануустай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дархан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Загастай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Отгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Соёл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Онц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Бадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Улиастай сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Богдын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жинст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Товцог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Чигэстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нөмрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дархан Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хөдрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цагаанхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Онц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Агьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Яруу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Өргөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хэц-улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Зүйл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Шилүүстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хөгжил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цагаанчулуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Арц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жавцаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянтэс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Зайгал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хачиг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жавхлан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Бужир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Асгат сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Суварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Төөнт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Минж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Алдархаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Богдын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Чигэстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Алдар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Мандаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Түдэвтэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Ойгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цорго",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Шар нуруу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цэцэн-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Шотой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Оройн товгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81227",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81229",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Батсуурь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Сонгино",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Шар нуруу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Бор Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян Айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81239",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Тариат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81240",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Эрдэнэхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81241",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Мөсөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81243",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Багануур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81245",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Алтан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81247",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81249",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81250",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Тэс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81251",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Зүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81253",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81255",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нисэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81257",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дооно",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81260",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Сантмаргац",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81261",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81263",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Холбоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81265",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81267",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баяндавс",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81270",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Завханмандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81271",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нуга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81273",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Олонтүрүү",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81275",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Мандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81277",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Олонбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81280",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Дөрвөлжин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81281",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Цогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81283",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Буга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81285",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Буурал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81287",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Таван толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81289",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Онц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81290",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Ургамал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81291",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Нуур зөөхий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81293",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Хульж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81295",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81297",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Төв",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "81299",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1979,
+    "state_code": "057",
+    "locality_name": "Тосгуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Govi-Altai",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баян-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянхонгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Гуулин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянсан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянбуурал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Чандмань-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Эрдэнэ-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Өлзийбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сэрх-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цагаан-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Өлзийт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цэцэг нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бигэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хүрэнт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Мянгай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Уртын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Олон булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Буудай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цогт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Гэгээт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Далан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянтоорой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баян-Өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Төгрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баян-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Тайшир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хуримт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Галуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Далан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Есөнбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баяншанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Харзат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Галуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Түмэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Оргил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Халиун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Чацран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Гүүбариач",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сүүж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Олонбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Завхан гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Тээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цээл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Жаргалт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Дэрстэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Алтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянцагаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Урт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бадрал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Шарга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Улаан туг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сондуулт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хамтын хүч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баян-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Чандманьхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянбогд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Алтангадас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хүйсийн-говь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянговь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Завхан-гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сайн-уст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хүйсийн-говь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цоохор-нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Төгрөг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хүрэнгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Тунгалаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Төгрөгийн эх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цагаанхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Мааньт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хөхморьт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сангийн далай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Завхан гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сайн-Уст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хүйсийн говь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82189",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Цоохор нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Дарви",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Жавхлан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Үйлдвэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Ихэс нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Гаханч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Сүж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Биж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82209",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Ферм",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Тонхил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Бүс-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Тамч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Алтайн-Оргил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Зүйл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "82219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1972,
+    "state_code": "065",
+    "locality_name": "Алтансоёмбо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Bayan-Ölgii",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаан хус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Сөнхөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаагчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Сайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Шар цэхээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цэцэгт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагаан Арал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цул-Улаан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Алтанцөгц",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагаантүнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаанхаргана",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хаш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бугат сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хатуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бугат /төв/",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаантолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бугын гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Их булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Дэлүүн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Төвийн баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бүргэд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөхтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83066",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Шинэ айл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хүйтэн нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хар-Уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ганц мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ангирлаг буюу Саралахаз",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Чихэртэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83078",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хүйтэн буйр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Тал нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Толбо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бураат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Дөрөө нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хош",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх толгой /төв/",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83089",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Толбо нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хонгор өлөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ногооннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ховд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Чихтэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хосхаргай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ямаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бахлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Асгат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83112",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаанчулуун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагааннуур тосгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хызылхайын",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Өлгий сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хуст арал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бөхөн-уул",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Их Булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83129",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ховд гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ах хуст тау",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83134",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Харасай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хотгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83136",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бүркит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83138",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Жасыл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Жана ауыл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөлцөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Өмнөгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Шар тохойт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Алтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаан хад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83152",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Борбургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Бардам",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Чихэртэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хар нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Сагсай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хол Агаш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Ямаат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83164",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Өмнө гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Аххорим",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Уужим",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83168",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Даян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаанхус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Билүү-1",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Согоог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83174",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Казыл жар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх хөтөл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83178",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Монгол гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хулжаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Билүү-2",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83182",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Улаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Даян",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83184",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөх адыр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Их - Ойгор",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цэнгэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Харганат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагаантүнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Борбургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Загаст нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Цагаан гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Шар говь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Долоон гаталга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "83207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1969,
+    "state_code": "071",
+    "locality_name": "Партизан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Khovd",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Дарви",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Мөнгөн-аяга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84019",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Мөрөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Дөргөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Аргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Сээр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Агваш",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Чандмань",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Талын булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Урд гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Сүлжээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Талын булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Урд гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цэцэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хажинга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хөшөөт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цэцэг нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84059",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Зэрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Эхэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бураа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хөндлөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бургасан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Гүвээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84070",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Мөст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Улаантолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цэцэг гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Давст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Алтай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Барлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бодонч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Алтангадас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Нарийн гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаан бургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Норжинхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Наранхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84099",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаан эрэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Мянгад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84101",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаан булан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баян хошуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Чацаргант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Гахайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Манхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Зэрэг гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Төгрөг гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Ботгон",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84119",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Улаан хүрээ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хөх-үзүүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84127",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Улиаст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84129",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаантүнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Үенч",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Нарийн гол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хөх үзүүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Улиаст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаантүнгэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84140",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалант сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цамбагарав",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84143",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84145",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84147",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84149",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цамбагарав",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Тахилт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84159",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Наран",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Магсаржав",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Жаргалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Буянт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бичигт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84170",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Ховд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баруун салаа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Улаанбураа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Дунд ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаанбургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84180",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Эрдэнэбүрэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хар ус",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84185",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Шураг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84187",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хонгио",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84189",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Намарзан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Мөнххайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Алаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Сэнхэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Борт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Дуут",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Цагаан бургас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Босго",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Хөх бэлчир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84207",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Шивэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Булган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Бүрэнхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Далт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянсудал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Байтаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Алагтолгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "84281",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1964,
+    "state_code": "043",
+    "locality_name": "Барлаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85000",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Uvs",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85010",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Зүүнхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85011",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Даланбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85013",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85015",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85017",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85020",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баруунтуруун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85021",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Зүүнтуруун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85023",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Шанд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85025",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баян айраг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85027",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Туруун",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85030",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өндөрхангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85031",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цалуу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85033",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Батсайхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85035",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цэцэрлэг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85037",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цагаан нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85039",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Жаргалант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85040",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Зүүнговь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85041",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Тохой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85043",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баяннуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85045",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Зэл",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85047",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өгөөмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85049",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Суварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85050",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цагаанхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85051",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Даланхуруу",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85053",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ар булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85055",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хунт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85057",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хулж",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85060",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Тэс сум",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85061",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Нуур эхэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85063",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Булгийн өндөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85065",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цагаан толгой",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85067",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Нурагт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85069",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Тооромт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85071",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ендөрт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85073",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ханжид",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85075",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Суварга",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85077",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баян-Овоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85079",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85080",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хяргас",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85081",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хангай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85083",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Бугат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85085",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Дэлгэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85087",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85090",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Малчин",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85091",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баян-Эрдэнэ",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85093",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Цалгар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85095",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянмандал",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85097",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85100",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Завхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85103",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Айрагнуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85105",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хармагт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85107",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Шар булаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85109",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хяргас нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85110",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Наранбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85111",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хужирт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85113",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Гүнбүрд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85115",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Алдар",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85117",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Улаан үзүүр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85120",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Давст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85121",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Торхилог",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85123",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Зүүн хөвөө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85125",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хандгайт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85130",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Тариалан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85131",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хархираа",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85133",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Тарвагатай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85135",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Бургастай",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85137",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хөхөө",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85139",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Толь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85141",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Мянган",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85150",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өлгий",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85151",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хулст нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85153",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хөдөлмөр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85155",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Чаргат",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85157",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өлгий нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85160",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Улаангом",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85161",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "1-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85163",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "2-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85165",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "3-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85167",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "4-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85169",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "5-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85171",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "6-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85173",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "7-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85175",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "8-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85177",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "9-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85179",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "10-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85181",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "11-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85183",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "12-р баг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85190",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Сагил",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85191",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Боршоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85193",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өндөр мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85195",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хар мод",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85197",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянзүрх",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85199",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Үүрэг нуур",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85200",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Түргэн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85201",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85203",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Эрдэнэхайрхан",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85205",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Рашаант",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85210",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Өмнөговь",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85211",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Холбоо",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85213",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Намир",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85215",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Баянгол",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85217",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Орлого",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85219",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Улиаст",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85220",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Бөхмөрөн",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85221",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Хар алтад",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85223",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Байшинт",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85225",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "3 жигэртэй",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85230",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ховд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85231",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Шивэр",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85233",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ховд",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85235",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Халиунбулаг",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  },
+  {
+    "code": "85237",
+    "country_id": 146,
+    "country_code": "MN",
+    "state_id": 1971,
+    "state_code": "046",
+    "locality_name": "Ачит",
+    "type": "full",
+    "source": "mongol-shuudan-via-bekkaze"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 2,605 Mongolia postcodes spanning all 22 aimags + Ulaanbaatar's
9 capital districts, sourced from the ``bekkaze/mnzipcode`` package
of Mongol Шуудан's catalogue.

- **Coverage**: 100% aimag resolution.
- **Granularity**: bag/khoroolol level — one record per
  ``(5-digit code, locality)`` pair after recursively flattening the
  aimag → district → sub-unit tree.

## Also fixes Mongolia regex bug

The previous ``countries.json`` entry for Mongolia had:

```
"postal_code_format": "######"
"postal_code_regex":  "^(\\d{6})$"
```

That never matched Mongol Шуудан's actual 5-digit codes (e.g.
``11000`` for Ulaanbaatar centre) and would have rejected every
legitimate row in this PR. Updated to:

```
"postal_code_format": "#####"
"postal_code_regex":  "^(\\d{5})$"
```

Same kind of fix as the EC regex correction in #1463.

## How it works

- Recursively walks the source's aimag → district → sub_items tree,
  carrying the top-level aimag/capital name forward for FK
  resolution.
- ASCII-fold name match against ``states.json``.
- 2-entry ``STATE_ALIASES`` bridge for "Tuv" -> "Töv" and
  "Dundgobi" -> "Dundgovi" source spelling variants.

## Source & licence

- Source URL: https://raw.githubusercontent.com/bekkaze/mnzipcode/main/data/data.json
- Origin: Mongol Шуудан publicly published index, redistributed by
  bekkaze.
- Each row: ``"source": "mongol-shuudan-via-bekkaze"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 2,605 codes match the **fixed** ``country.postal_code_regex``
  (``^(\d{5})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 146``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)