### PR TITLE
feat(postcodes/NP): bulk-import 917 Nepal postcodes via Nepal Post (#1039)

### DIFF
--- a/bin/scripts/sync/import_nepal_postcodes.py
+++ b/bin/scripts/sync/import_nepal_postcodes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Nepal -> contributions/postcodes/NP.json importer for #1039.
+
+Source data
+-----------
+The community ``sprupak07/postal_code_nepal`` repository ships Nepal
+Post's catalogue keyed by district -> post-office:
+
+    {"District": "Achham", "Post Office": "Achham",
+     "Postal": {"Pin Code": 10700}, "Post Office Type": "D.P.O."}
+
+Source URL: https://raw.githubusercontent.com/sprupak07/postal_code_nepal/master/codenp.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Ships country-only: ``states.json`` carries the 7 post-2015
+   federal provinces while the source's hierarchy is keyed by 75
+   districts; mapping districts -> provinces would need an extra
+   crosswalk and is left for a follow-up.
+3. Emits one record per ``(pin code, post office)`` pair, with the
+   district as ``locality_name`` so users still recover sub-region
+   context.
+4. Writes contributions/postcodes/NP.json idempotently.
+
+License & attribution
+---------------------
+- Source: sprupak07/postal_code_nepal (open redistribution of Nepal
+  Post's publicly published index).
+- Each row: ``source: "nepal-post-via-sprupak07"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_nepal_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/sprupak07/postal_code_nepal/"
+    "master/codenp.json"
+)
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    rows = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    np_country = next((c for c in countries if c.get("iso2") == "NP"), None)
+    if np_country is None:
+        print("ERROR: NP not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(np_country.get("postal_code_regex") or ".*")
+    print(f"Country: Nepal (id={np_country['id']})")
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for row in rows:
+        postal = row.get("Postal") or {}
+        raw_code = postal.get("Pin Code")
+        if raw_code is None:
+            continue
+        code = str(raw_code).strip().zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        district = (row.get("District") or "").strip()
+        post_office = (row.get("Post Office") or "").strip()
+        locality = ", ".join(p for p in (post_office, district) if p and p != post_office or p == post_office and not district)
+        if not locality:
+            locality = post_office or district
+        elif post_office and district and post_office != district:
+            locality = f"{post_office}, {district}"
+        else:
+            locality = post_office or district
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(np_country["id"]),
+            "country_code": "NP",
+        }
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "nepal-post-via-sprupak07"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/NP.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/NP.json
+++ b/contributions/postcodes/NP.json
@@ -1,0 +1,7338 @@
+[
+  {
+    "code": "10100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10101",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rapla, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Duhuti, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Malikarjun, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Joljibi, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dandakot, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ritha Chaupata, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gokule, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10109",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sitola, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Marmalatinath, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sipti, Darchula",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10201",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kesharpur, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Patan, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khodpe, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mulkhatali, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gajari Changgad, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dehimandau, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sharmali, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Srikot, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dilasaini, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10212",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Swopana Taladehi, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10213",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Purchaudihat, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10214",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sitad, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10215",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhungad, Baitadi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10302",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ugratara, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dandaban, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ganeshpur, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaira Ganesh, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jogbudha, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamikande, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chipur, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ajayameru, Dadeldhura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Krishnapur, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalika, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Punarbas, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Beldadi, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipaladi, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandani, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Airport, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Suda, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhalari, Kanchanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10501",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Talkot, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jamatola, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jaya Prithivi Nagar, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhanna, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10507",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chaudhari, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rayal, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thalara, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bungal, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shayadi, Bajhang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dandakot, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jukot, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Faiti, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kolti, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manakot, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dogadi, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tate, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhatara, Bajura",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10701",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chaurpati, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Srikot, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thanti, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mellekh, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bayalpata, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10706",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhatakatiya, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jayagadh, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalagaun, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kuchikot, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kamal bazar, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhakari, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Turmakhad, Achham",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10801",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Silgadhi, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sanagaun, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10803",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Daund, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mauwa Nagardaha, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Banedungrasen, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10806",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jorayal, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10807",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gadhshera, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10808",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lanakedareswor, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Boktan, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10810",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Byal, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mudbhara, Doti",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10901",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tikapur, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Munuwa, Kailal",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dododhara, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamki, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Masuriya, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10906",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pahalmanpur, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hasuliya, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10908",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhajani, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Joshipur, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phulbari, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Atariya, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chaumala, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "10914",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phaltude, Kailali",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21003",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Muchu, Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lali, Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sarkegadh, Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Darma, Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Srinagar, Humla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rowa, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pulu, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sorubarma, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rara, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sukhadhik, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21109",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gumtha, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhainkot, Mugu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dillichaur, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tatopani, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Malikathata, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21206",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalikakhetu, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Narakot, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hatsinja, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chautha, Jumla",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sanniraskot, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mehalmudi, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kotbada, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Padamghat, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jubitha, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thirpu, Kalikot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Juphal, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tripurakot, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Liku, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sarmi, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kaigaun, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Foksundo, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Namdo, Dolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhime, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dalli, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ragda, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rokaya gaun (Limsa), Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dashera, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thalaraikar, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Garkhakot, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Karkigaun, Jajarkot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaidabaj, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Naumule, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Byastada, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhungeshwor, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Malika, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dullu, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jambu Kandha, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rakam Karnali, Dailekh",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21701",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhinchu, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramghat, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sahare, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gumi, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bheriganga, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21706",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Matela, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Garpan, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kunathari, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Babiyachaur, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gutu, Surkhet",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21801",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jamuni, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mainapokhar, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21803",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Motipur, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Magaragadi, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21808",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baganaha, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhurigaun, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rajapur, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21813",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pashupatinagar, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21814",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sanoshri, Bardiya",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21901",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Suiya, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhojbhagawanpur, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khaskusma, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kohalapur, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramjha, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Udayapur, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chisapani, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Godahana, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jayaspur, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khajura, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "21914",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandranagar, Banke",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22002",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rukumkot, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Riwangchaur, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kol, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Peugha, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chaurjahari, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Simli, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22010",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Radijyula, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22011",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baphikot, Rukum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khungri, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sirpa, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thawang, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Himtakura, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghartigaun, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nerpa, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dahaban, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22112",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shulichaur, Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22113",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhenam (Holeri), Rolpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22201",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalimati Kalche, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Luham, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhanbang, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahaneta, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Malneta, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maidu, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ragechour, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhalchaur, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tharmare, Salyan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22301",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dakhaquadi, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhingri, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Wangesal, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baraula, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Majuwa, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Machchhi, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thulabesi, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lungbahane, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bijuwar, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Naya Gaun, Pyuthan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hapur, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jumlepani, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhaluwang, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Koilabas, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jangrahawa, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rampur, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Urahari, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hekuli, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Panchakule, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shantinagar, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22412",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tulsipur, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22413",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manpur, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22414",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamahi, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "22415",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghoraha, Dang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32501",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sahalkot, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rampur, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hungi, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jalpa, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tahu, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhadewa, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32507",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aryabhanjyang, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madanpokhara, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khasyauli, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Argali, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhahara, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32512",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Palungmainadi, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32513",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baldengadi, Palpa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32601",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Purtighat, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bharse, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandrakot, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Majuwa, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ridi, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sringa, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Birabas, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Wami, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ismadohali, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32611",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhurkot, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32612",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Purkotadha, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32613",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arje, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32614",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manabhak, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32615",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipaldanda, Gulmi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32701",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Balkot, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arghatosh, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khana, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Wangla, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hamshapur, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32706",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thada, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32708",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khilji, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khidim, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pali, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhikura, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Argha, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Subarnakhal, Arghakhanchi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32801",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipara, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Patariya, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pakadi, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kopawa, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32808",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gotihawa, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gorusinge, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32810",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pattharkot, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thuniya, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32812",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maharajgunj, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32813",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ganeshpur, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32814",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chanauta, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32815",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Krishnanagar, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32816",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shiva Raj, Kapilbastu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32901",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Siktahan, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhakadhai, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manigram, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kotihawa, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thutipipal, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Butwal, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32908",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Parroha, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sauraha Pharsa, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Amuwa, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Saljhandi, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Suryapura, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tenuhawa, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32914",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lumbini, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32915",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Betkuiya, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "32916",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahadehiya, Rupandehi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33001",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rakuwa, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33002",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bulingtar, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33003",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaindakot, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dumkauli, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shergunj, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33006",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Naya Belhani, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tribeni, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Semari, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Guthi persauni, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33010",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhujahawa, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33011",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Makar, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33012",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tilakpur, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33013",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maheshpur, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33015",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sunawal, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33016",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pithauli, Nawalparasi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Marpha, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kagbeni, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Charang, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhoser, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Muktinath, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lete, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33109",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thak Tukuche, Mustang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Xyamarukot, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Galeswor, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rakhu Bhagawati, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sikha, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33206",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dana, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Babiyachaur, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Darbang, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pakhapani, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Takam, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lulang, Myagdi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33302",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pala, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bihukot, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Harichaur, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Balewa Payupata, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jaidi Belbagar, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bereng, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Galkot, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pandavkhani, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arnakot, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khrwang, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bongadovan, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33313",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhimpa, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33314",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kusmi Shera, Baglung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Salija, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khurkot, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Deurali, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thulipokhari, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Karkineta, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Devisthan, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bachchha, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lankhudeurali, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hubas, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khor Pokhara, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33412",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Setibeni, Parbat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pisang, Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhakra, Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mathillo Manang, Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33507",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nar, Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dharapani, Manang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maling, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sundar Bazar, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sotipasal, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kunchha, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gilung, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khudi, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phaliyasanghu, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bharate, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaunda, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33611",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tarkughat, Lamjung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33701",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rupakot, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gagan Gaunda, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Makaikhola, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Majhathana, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sildujure, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33706",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nirmalpokhari, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pardibandh, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33708",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhalam, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chapakot, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Birethanti, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Naudanda, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghachok, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Purunchaur, Kaski",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Syangja, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kolma, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33803",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kichnas, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jharkham, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arjunchaupari, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33806",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Panchamul, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33807",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rangethanti, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33808",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Fedikhola, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhumare, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33812",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kyakmi, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33813",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Waidha Bhanjhyang, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33814",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chapakot, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33815",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Galyang, Syanja",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tuhure Pasal, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manechauka, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bandipur, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aanbu Khaireni, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33906",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baidi, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kahunshivapur, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33908",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rising Ranipokhari, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghiring Sundhara, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhimad, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamagaun, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khairenitar, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shisha Ghat, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33914",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dumre, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "33915",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Devaghat, Tanahun",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34002",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bungkot, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34003",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manakamana, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Batase, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Luintel, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34006",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Anapipal, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jaubari, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhachchek, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Saurpani, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34010",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghyampesal, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34011",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aarughat, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34012",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gumda, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "34013",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sirdibash, Gorkha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44101",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phaparbari, Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ritha Chhatibwn, Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hatiya, Makabanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aambhanjyang, Makabanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manahari, Makabanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hetauda I.A., Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Basamadi, Makabanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Palung, Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhainse, Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44112",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhimphedi, Makawanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44113",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Markhu, Makabanpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chitwan, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhandara, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khairahani, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ratnanagar, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jutpani, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44206",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mugling, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Narayangadh, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phulbari, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rampur, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Meghauli, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Patihani, Chitwan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44212",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Soshi Bazar, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44213",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Harinagar, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44214",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madi, Chitawan",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44301",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aadarshanagar, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Parbanipur, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bindabasini, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bahuari Pidari, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shirsiya Khalwatola, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Biruwaguthi, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pakahamainpur, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phokhariya, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ranigunj, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Paterwa Sugauli, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Viswa, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44313",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Janakitol, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44314",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jeetpur, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44315",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thori, Parsa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nijgadh, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahendra Adarsha, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Simraungadh, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Umjan, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bariyarpur, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kabahigoth, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dumarwana, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipradhigoth, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Basantapur, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44412",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Simara, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44413",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Parsoni, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44416",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Amalekhgunj, Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44417",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jeetpur (Bhavanipur), Bara",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Saruatha, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipra bazar, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madhopur, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rajpurpharahadawa, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Patharabudhram, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sitalpur, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shivanagar, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Laxminiya, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44512",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Katahariya, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44513",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Samanpur, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44515",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandra Nigahapur, Rautahat",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44601",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sankhu, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chabahil, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sundarijal, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gauchar, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dillibazar, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bansbari, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tokha Saraswati, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sachibalaya, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manmaiju, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44611",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Balaju, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44613",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tribhuvan University, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44614",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalimati, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44615",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pharping, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44616",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baluwatar, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44617",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sarbochcha Adalat, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44618",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kirtipur, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44619",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thankot, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44620",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Swayambhu, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44621",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pashupati, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44622",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Budhanilkantha, Kathmandu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhapakhel, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Imadol, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Darabartole, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44708",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lubhu, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Godawari, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chapagaun, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gotikhel, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhattedanda, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pyutar, Lalitpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dubakot, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kharipati, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tathali, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44806",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jorpati, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gamcha, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44810",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dibyashwori, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thimi, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44812",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nagarkot, Bhaktapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thansingh, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ranipauwa, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Taruka, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44906",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Deurali, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kahule, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44908",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chokade, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kharanitar, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhadratar, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramabati, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rautbesi, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44914",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pokharichapadanda, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "44915",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Devighat, Nuwakot",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rasuwa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45003",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhaibung, Rasuwa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramkali, Rasuwa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rasuwa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Syaphru Besi, Rasuwa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45101",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lapa, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sertung, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phulkharka, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tripureshwor, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Katunje, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sunkhani, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sunaulabazar, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45109",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maidi, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khanikhola, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhumisthan, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45112",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gajuri, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45113",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Malekhu, Dhading",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45201",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghartichhap, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mangaltar, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pokharinarayanshthan, Kaverpalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gumati Bhanjyang, Kaverpalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dapcha, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Panauti, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Banepa, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45212",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Panchkhal, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45213",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahadevasthan, Kaverpalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45214",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phalante, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45215",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dolal Ghat, Kavrepalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45216",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khopasi, Kaverpalanchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45301",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kodari, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45302",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Barabise, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Atarpur, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamosanghu, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nawalpur, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pangtang, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jalbire, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhotsipa, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Melamchi Bahunepati, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gyalthum, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thangapaldhap, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45313",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dubachaur, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45314",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Balephi, Sindhupalchok",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Those, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Duragaun, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Betali, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khimti, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Saghutar, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kathjor, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Puranagaun, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Doramba, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hiledevi, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhirpani, Ramechhap",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45501",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khahare, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Namdu, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jiri, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Japhekalapani, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Melung, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45507",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhusapheda, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sunkhani, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khopachangu, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamabagar, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45512",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chitre, Dolakha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45601",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khajuri, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tinkoriya, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Yadukuha, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Duhabi, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chakkar, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Raghunathpur, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Godar Chisapani, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhanushadham, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bagachauda, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45611",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jatahi, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45612",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phulgama, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45616",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sankhuwa Mahendranagar, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45617",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhalkebar, Dhanusha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45701",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bardibash, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhangaha, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Loharpatti, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipara, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Matihani, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramgopalpur, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45708",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Balawa, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Laxminiya, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaushala, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shreepur, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Samsi, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45714",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manara, Mahottari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45801",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lalbandi, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bayalbas, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45803",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Haripurwa, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hariaun, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Haripur, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45806",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Brahmapuri, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kaudena, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45810",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Barahathawa, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sundarpur, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45813",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dumariya, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45814",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Karmaiya, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45815",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Harkathawa, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45816",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ramnagar(Bahuarwa), Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45817",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhatauna, Sarlahi",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45901",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Solpa, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bahun Tilpung, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dudhauli, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dakaha, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gwaltar, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45906",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khurkot, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Belghari, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhiman, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhanga Jholi, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Netrakali, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kapilakot, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "45913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pipalmadhiratanpur, Sindhuli",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56002",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Namche Bazar, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sotang, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jubu, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56006",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nele, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56007",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Necha, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shishakhola, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Himaganga, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56010",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lukla, Solukhumbu",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56101",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khani Bhanjyang, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rumjatar, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rampur, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bigutar, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khiji Phalate, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gamanangtar, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ghorakhori, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56109",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chyanam, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mane Bhanjyang, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Moli, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56112",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ragani, Okhaldhunga",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56201",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Wakshila, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aiselukharka, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jalpa, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lamidanda, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56206",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Halesi mahadevasthan, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Buipa, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manebhanjyang, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sapteshworichhitapokhari, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56212",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chisapani, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56214",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Simpani, Khotang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56301",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ratapani (Thoksila), Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56302",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Beltar, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hadiya, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pokhari, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baraha, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhutar, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rampur Jhilke, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Udayapur Gadhi, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Katari, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sorung Chhabise, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rauta Murkuchi, Udayapur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hanuman Nagar, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bairaba, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phattepur, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kanchanpur, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56405",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Praswani, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhagawatpur, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Koiladi, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhinnamasta, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bishnupur, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rupani, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56412",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pato, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56413",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arnaha, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56414",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalyanpur, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56415",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bodebarsain, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56416",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sisawa, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56417",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kadarwona, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56418",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhardaha, Saptari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56501",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bastipur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Lahan, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhagawanpur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhanagadhi, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Maheshpur patari, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bariyarpatti, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Golbazar (Asanpur), Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sukhipur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bishnupur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56512",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Belha, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56513",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madar, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56515",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mirchaiya, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56516",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bandipur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56517",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kalyanpur, Siraha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56600",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56601",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chunimari, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56602",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rangeli, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56603",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sanischare, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56604",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Urlabari, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56605",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madhumalla, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56606",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bayarban, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56607",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sorabhag, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56608",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dadarberiya, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56609",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Letang, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56610",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kerabari, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56611",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Haraincha, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56612",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhaudaha, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56613",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Biratnagar Bazar, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56614",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rani Sikiyahi, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56615",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhorahat, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56616",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Banigama, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56617",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bansbari, Morang",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56700",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56702",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mangalbare, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56703",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chatara, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56704",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bakalauri, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56705",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Itahari, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56706",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Simariya, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56707",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Duhabi, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56708",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chimadi, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56709",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhumka, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56710",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Inarauwa, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56711",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aurabari, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56712",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dewangunj, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56713",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madhuvan, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56714",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Laukahee, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56715",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhutaha, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56716",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mahendra Nagar, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56717",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chhitaha, Sunsari",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56800",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56801",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mudhebash, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56802",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rajarani, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56803",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dandabazar, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56804",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhedetar, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56805",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ankhisalla, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56806",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hile, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56807",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Muga, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56808",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Teliya, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56809",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pakhribash, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56810",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Leguwa, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56811",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mare Katahare, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56812",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Arknaule, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56813",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chungmang, Dhankuta",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56900",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56901",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hatiya, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56902",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hedangana, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56903",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tamku, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56904",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandanpur, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56905",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bahrabishe, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56906",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tumlingtar, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56907",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Wana, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56908",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shidhakali, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56909",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Madi, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56910",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ankhibhui, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56911",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mamling, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56912",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Manebhanjyang, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "56913",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chainpur, Sankhuwasabha",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57000",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57001",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kulung Agrakhe, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57002",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dingla, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57003",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Deurali, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57004",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pyauli, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57005",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Yaku, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57006",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bastim, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57008",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Timma, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57009",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dilpa Annapurna, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57010",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Bhulke, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57011",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baikunthe, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57012",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ranibas, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57013",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Walangkha, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57014",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tiwari Bhanjyang, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57015",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dobhane, Bhojpur",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57100",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57102",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jirikhimti, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57103",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Tinjure, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57104",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Basantapur, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57105",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sudap, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57106",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hamarjung, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57107",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Morahang, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57108",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pokalawang, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57110",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mulpani, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57111",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Iwa, Terhathum",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57200",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57201",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Baniyani, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57202",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Goldhap, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57203",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chandragadhi, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57204",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Birtamod, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57205",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sanishchare, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57206",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Budhabare, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57207",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dhulabari, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57208",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Kankarbhitta, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57209",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rajgadh, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57210",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Durgapur, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57211",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57212",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dudhe, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57213",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Shivagunj, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57214",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Topagachhi, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57215",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gaurigunj, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57216",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gauradaha, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57217",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Damak, Jhapa",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57300",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57302",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nayabazar, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57303",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pashupatinagar, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57304",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Aaitabare, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57305",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Harkatebazar, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57306",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gajurmukhi, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57307",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mangal Bare, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57308",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nepaltar, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57309",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Jamuna, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57310",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Gitpur, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57311",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Cheesa Pani Panchami, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57312",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Phikal, Ilam",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57400",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57401",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Chyangthapu, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57402",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Ambarpur, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57403",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Namluwa, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57404",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Yangnam, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57406",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Nawamidanda, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57407",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mehelbote, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57408",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Yasok, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57409",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Mauwa, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57410",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Rabi, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57411",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Limba, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57412",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Medibung, Panchthar",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57500",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57501",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khewang, Taplajung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57502",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sadeba, Taplajung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57503",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Sinam, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57504",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Pedang, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57505",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thechambu, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57506",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Siwang, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57507",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Khokling, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57508",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Olangchunggola, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57509",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Thokimba, Taplajung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57510",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Dobhan, Taplajung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57511",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Change, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  },
+  {
+    "code": "57512",
+    "country_id": 154,
+    "country_code": "NP",
+    "locality_name": "Hangpang, Taplejung",
+    "type": "full",
+    "source": "nepal-post-via-sprupak07"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 917 Nepal postcodes (the full Nepal Post district-post-office
catalogue) sourced from the ``sprupak07/postal_code_nepal`` mirror.

- **Coverage**: country-only by design.
- **Granularity**: post-office level — one record per
  ``(5-digit code, post office + district)`` pair.

## Why country-only

Source is keyed by the 75 historical districts; CSC's ``states.json``
carries the post-2015 7 federal provinces. Mapping districts to
provinces would need an extra crosswalk and is left for a follow-up.
Districts are surfaced via ``locality_name`` so users still recover
sub-region context.

## Source & licence

- Source URL: https://raw.githubusercontent.com/sprupak07/postal_code_nepal/master/codenp.json
- Origin: Nepal Post publicly published index, redistributed by
  sprupak07.
- Each row: ``"source": "nepal-post-via-sprupak07"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 917 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)