### PR TITLE
feat(postcodes/CY): bulk-import 825 Cyprus postcodes via Cyprus Post (#1039)

### DIFF
--- a/bin/scripts/sync/import_cyprus_postcodes.py
+++ b/bin/scripts/sync/import_cyprus_postcodes.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Cyprus -> contributions/postcodes/CY.json importer for #1039.
+
+Source data
+-----------
+The community ``georgioupanayiotis/zip-postal-codes-cyprus``
+repository ships Cyprus Post's catalogue keyed by street with
+Postcode + Municipality + District:
+
+    {"Street": "1 Apriliou", "Postcode": 2006,
+     "Municipality": "Strovolos", "District": "Lefkosia"}
+
+Source URL: https://raw.githubusercontent.com/georgioupanayiotis/zip-postal-codes-cyprus/master/postcodes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Resolves ``state_id`` via case-insensitive name match against
+   ``states.json`` with a 5-entry STATE_ALIASES bridge for the
+   Greek-form district names ("Lefkosia" -> "Nicosia (Lefkoşa)" etc.).
+3. Dedupes at (postcode, municipality) granularity (multiple streets
+   share the same postcode within a municipality).
+4. Writes contributions/postcodes/CY.json idempotently.
+
+License & attribution
+---------------------
+- Source: georgioupanayiotis/zip-postal-codes-cyprus (open
+  redistribution of Cyprus Post's publicly published index).
+- Each row: ``source: "cyprus-post-via-georgioupanayiotis"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_cyprus_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/georgioupanayiotis/zip-postal-codes-cyprus/"
+    "master/postcodes.json"
+)
+
+# Source District (lowercased) -> CSC states.json district lookup helper.
+# CSC names embed both Greek and Turkish forms in parentheses
+# ("Nicosia (Lefkoşa)"); the Greek form here is the source's own.
+DISTRICT_ALIASES: Dict[str, str] = {
+    "lefkosia":   "Nicosia (Lefkoşa)",
+    "lemesos":    "Limassol (Leymasun)",
+    "larnaka":    "Larnaca (Larnaka)",
+    "ammochostos": "Famagusta (Mağusa)",
+    "pafos":      "Paphos (Pafos)",
+}
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    rows = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    cy_country = next((c for c in countries if c.get("iso2") == "CY"), None)
+    if cy_country is None:
+        print("ERROR: CY not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(cy_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    cy_states = [s for s in states if s.get("country_id") == cy_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in cy_states}
+    print(f"Country: Cyprus (id={cy_country['id']}); states indexed: {len(cy_states)}")
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        raw = row.get("Postcode")
+        if raw is None:
+            continue
+        code = str(raw).strip().zfill(4)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        municipality = (row.get("Municipality") or "").strip()
+        district = (row.get("District") or "").strip()
+        key = (code, municipality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(cy_country["id"]),
+            "country_code": "CY",
+        }
+        target = DISTRICT_ALIASES.get(district.lower(), district)
+        state = state_by_name.get(target.lower())
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if municipality:
+            record["locality_name"] = municipality
+        record["type"] = "full"
+        record["source"] = "cyprus-post-via-georgioupanayiotis"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/CY.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/CY.json
+++ b/contributions/postcodes/CY.json
@@ -1,0 +1,8249 @@
+[
+  {
+    "code": "1010",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1011",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1015",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1016",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1017",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1021",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1022",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1025",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Omorfita)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1026",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1027",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1028",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1035",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1037",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Kaimakli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1048",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1049",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Pallouriotissa)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1055",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Lykavittos)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1056",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Lykavittos)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1057",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia (Lykavittos)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1060",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1061",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1065",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1066",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1070",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1071",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1075",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1076",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1077",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1080",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1081",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1082",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1085",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1086",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1087",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1090",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1095",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1096",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1097",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1100",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1101",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1102",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1105",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1106",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "1107",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lefkosia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2000",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2001",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2002",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2003",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2006",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2007",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2008",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2011",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2012",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2013",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2014",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2015",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2018",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2019",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2021",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2023",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2024",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2025",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2027",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2028",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2029",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2030",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2031",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2032",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2033",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2034",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2035",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2037",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2038",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2039",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2043",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2044",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2048",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2049",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2050",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2051",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2052",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2054",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2055",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2057",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2058",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2059",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2060",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2062",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2063",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2064",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2066",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Strovolos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2100",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2101",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2102",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2103",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2107",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2108",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2109",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2112",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2113",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2114",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2115",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2116",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2120",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2121",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2122",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2123",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Aglantzia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2200",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Geri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2201",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Geri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2202",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Geri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2220",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2221",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2222",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2223",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2224",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2230",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2231",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2232",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2233",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2234",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2235",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2236",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2237",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2238",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Latsia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2300",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2301",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2302",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2303",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2304",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2305",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2306",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2310",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2311",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2312",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2313",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2314",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2320",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2321",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2322",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2323",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2324",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2325",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2326",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2328",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2330",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2331",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2332",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2333",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2334",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2335",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lakatameia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2350",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Synoikismos Anthoupolis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2360",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2361",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2362",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2363",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2364",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2365",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2368",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2369",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2370",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2373",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Dometios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2400",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2401",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2402",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2404",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2406",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2407",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2408",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2409",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2410",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2411",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2412",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2413",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2414",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2415",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2416",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2417",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Egkomi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2450",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kato Deftera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2460",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pano Deftera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2480",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Tseri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2540",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Dali",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2546",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Dali (Ilioupoli)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2547",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Dali (Konstantia)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2548",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Dali (Kallithea)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2549",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Dali (Nea Lidra)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2560",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agia Varvara Lefkosias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2563",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Alampra",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2564",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kotsiatis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2565",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lythrodontas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2566",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lympia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2568",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Mathiatis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2570",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Profiti Ilia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2571",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Nisou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2572",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pera Chorio",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2573",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Potamia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2574",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Sia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2600",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Klirou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2610",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Epifanios Oreinis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2611",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Ioannis Lefkosias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2612",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Malounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2613",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Apliki",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2614",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Arediou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2615",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Gourri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2616",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kalo Chorio Oreinis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2617",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agrokipia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2618",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lazanias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2619",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kampi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2620",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Farmakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2621",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Machaira",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2622",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Mitsero",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2623",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Fikardou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2624",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Agiou Panteleimonos Achera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2630",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Psimolofou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2640",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Anageia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2641",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Analiontas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2642",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Episkopeio",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2643",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Ergates",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2644",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kampia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2645",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kapedes",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2646",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kataliontas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2647",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Margi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2648",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Agiou Irakleidiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2649",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Archangelou Michail",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2650",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2651",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Politiko",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2652",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Filani",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2653",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Panagias Theotokou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2660",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kokkinotrimithia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2671",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agioi Trimithias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2675",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Deneia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2679",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Mammari",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2682",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Palaiometocho",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2720",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Akaki",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2722",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Astromeritis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2728",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Meniko",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2731",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Peristerona Lefkosias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2740",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Palaichori Morfou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2745",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Palaichori Oreinis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2750",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Alithinou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2751",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Alona",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2752",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Askas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2753",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Lagoudera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2754",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Livadia Lefkosias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2755",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Platanistasa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2756",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Polystypos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2757",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Saranti",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2758",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Fterikoudi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2770",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kato Koutrafas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2771",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pano Koutrafas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2772",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agia Marina Xyliatou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2773",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Georgios Kafkalou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2774",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Vyzakia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2776",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kato Moni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2777",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Nikitari",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2779",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Orounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2780",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Potami",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2781",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Xyliatos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2800",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kakopetria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2820",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agia Eirini Lefkosias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2823",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Theodoros Soleas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2825",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Agios Nikolaos Stegis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2827",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Galata",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2831",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Evrychou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2832",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kaliana",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2834",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kannavia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2835",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Katydata",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2836",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Korakou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2839",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Sinaoros",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2840",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Skouriotissa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2841",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Spilia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2842",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Temvria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2843",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Flasou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2845",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Linou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2846",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kourdali",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2850",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pedoulas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2861",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Gerakies",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2862",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kalopanagiotis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2863",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kampos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2864",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Mylikouri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2865",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moni Kykkou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2866",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Moutoullas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2867",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Oikos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2869",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Tsakistra",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2940",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Kato Pyrgos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2950",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pano Pyrgos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2959",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Mosfileri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2961",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pachyammos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "2962",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 745,
+    "state_code": "01",
+    "locality_name": "Pigenia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3010",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3011",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3012",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3013",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3015",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3016",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3017",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3021",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3022",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3025",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3026",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3027",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3030",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3031",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3032",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3035",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3048",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3050",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3051",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3052",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3055",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3056",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3060",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3061",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3065",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3066",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3067",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3070",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3071",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3075",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3076",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3077",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3080",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3081",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3082",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3083",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3085",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3086",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3087",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3090",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3091",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3095",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3096",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3100",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3101",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3105",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3106",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3107",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3110",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3111",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3112",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3113",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3115",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3116",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3117",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3118",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3119",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3120",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "3150",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemesos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4000",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4001",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4002",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4003",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4004",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4005",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4006",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4007",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4008",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mesa Geitonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4043",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4044",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4048",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4049",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Germasogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4100",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4101",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4102",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4103",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4104",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4105",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4106",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4107",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4108",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Athanasios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4130",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pano Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4131",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pano Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4150",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4151",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4152",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4153",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4154",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4155",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4156",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4157",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4158",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4159",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4170",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Polemidia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4180",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4181",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4182",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4183",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4184",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4185",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4186",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4187",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4188",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4189",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4190",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4191",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4192",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4193",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4194",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Ypsonas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4500",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kellaki",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4501",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Akapnou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4502",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Asgata",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4504",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Vasa Kellakiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4505",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Prastio Kellakiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4506",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Eptagoneia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4507",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Klonari",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4508",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Zoodochou Pigis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4510",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Sanida",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4511",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Profitis Ilias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4520",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Parekklisia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4521",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Tychon",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4522",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Akrounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4523",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Armenochori",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4524",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Monagroulli",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4525",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4526",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Agiou Georgiou Alamanou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4527",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mouttagiaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4528",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pentakomo",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4529",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pyrgos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4530",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Foinikaria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4531",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mouttagiaka Touristiki Periochi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4532",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Tychon Touristiki Periochi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4533",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Parekklisia Touristiki Periochi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4534",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pyrgos Touristiki Periochi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4540",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Paramytha",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4541",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Apesia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4542",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Apsiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4543",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Gerasa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4544",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kapileio",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4545",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Korfi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4546",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Limnatis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4547",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mathikoloni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4548",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Evangelistrias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4549",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Palodeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4550",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Spitali",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4551",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Fasoula Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4560",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Louvaras",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4561",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Konstantinos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4562",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Pavlos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4563",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Arakapas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4564",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Dierona",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4565",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Zoopigi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4566",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kalo Chorio Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4569",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Sykopetra",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4600",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Avdimou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4601",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Prastio Avdimou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4602",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Alektora",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4603",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Anogyra",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4604",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Paramali",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4605",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Platanisteia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4606",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Thomas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4607",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pissouri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4620",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Episkopi Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4630",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Erimi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4631",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kantou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4632",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kolossi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4633",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Sotira Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4636",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kolossi (Synoikismos)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4640",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Akrotiri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4645",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Asomatos Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4650",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Agiou Nikolaou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4651",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Trachoni Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4652",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Tserkezoi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4700",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pachna",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4710",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Amvrosios Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4711",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Therapon",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4712",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Alassa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4713",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Zanakia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4715",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pano Kivides",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4716",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lofou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4717",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Souni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4730",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Trimiklini",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4740",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Georgios Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4741",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Mamas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4742",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Silikou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4743",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kouka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4744",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Laneia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4746",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Monagri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4747",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moniatis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4748",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Saittas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4749",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Stathmos Filagron",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4750",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Doros",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4760",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Omodos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4770",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Arsos Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4771",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Vasa Koilaniou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4772",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Vouni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4774",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Dora",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4775",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kissousa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4776",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Koilani",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4777",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Malia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4778",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Mandria Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4779",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pera Pedi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4780",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Potamiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4800",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Troodos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4810",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Amiantos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4811",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pano Amiantos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4812",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Trooditissis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4814",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Foini",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4815",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Platres",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4820",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pano Platres",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4840",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Prodromos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4842",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Dimitrios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4843",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kaminaria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4844",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Lemithou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4845",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Palaiomylos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4846",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Treis Elies",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4847",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Moni Panagias Trikoukkias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4860",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agros",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4870",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Theodoros Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4871",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agios Ioannis Lemesou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4872",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Agridia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4873",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Dymes",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4874",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kato Mylos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4875",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Chandria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4876",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Kyperounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4878",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Pelendri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "4879",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 748,
+    "state_code": "02",
+    "locality_name": "Potamitissa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5280",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5281",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5282",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5283",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5284",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5285",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5286",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5288",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5289",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5290",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5291",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5292",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5295",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5296",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5297",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Paralimni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5320",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Liopetri",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5330",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Agia Napa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5350",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Frenaros",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5380",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Deryneia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5390",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Sotira Ammochostou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5391",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Agia Thekla",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5510",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Avgorou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5521",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Acheritou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5522",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Vrysoules",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5523",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Dasaki Achnas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5524",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Moni Agiou Kendeou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5525",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Strovili",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "5620",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 749,
+    "state_code": "04",
+    "locality_name": "Agios Nikolaos Ammochostou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6010",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6011",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6012",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6013",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6015",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6016",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6017",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6018",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6019",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6021",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6022",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6023",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6025",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6026",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6027",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6028",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6030",
+    "country_id": 57,
+    "country_code": "CY",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6030",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6031",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6035",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6037",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6043",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6050",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6051",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6052",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6053",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6055",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6056",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6057",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6058",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6059",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "6060",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Larnaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7000",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Meneou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Dromolaxia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Voroklini",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Voroklini Tourist Area",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7060",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Livadia Larnakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7080",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Pyla",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7081",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Pyla Touristiki Periochi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7100",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7101",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7102",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7103",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7104",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7105",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Aradippou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7501",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Avdellero",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7502",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Dekeleia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7503",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kellia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7505",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Troulloi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7506",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Prosfygikos Synoikismos EAC",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7508",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Prosfygikos Synoikismos Vattaina",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7509",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Metamorfoseos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7510",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Xylotymvou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7520",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Xylofagou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7530",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Ormideia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7550",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kiti",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7560",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Perivolia Larnakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7561",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Softades",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7562",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Tersefanou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7570",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Alethriko",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7571",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Anglisides",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7572",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Alaminos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7573",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Anafotida",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7575",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kivisili",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7576",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Klavdia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7577",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Mazotos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7578",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Menogeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7600",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Athienou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7621",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kosi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7640",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kornos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7641",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Agia Anna",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7642",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Delikipos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7643",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kalo Chorio Larnakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7644",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Agias Theklis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7645",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Stavrovouniou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7646",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Panagias Galaktotrofousas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7647",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Mosfiloti",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7648",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Pyrga Larnakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7649",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Psevdas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7650",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Agias Varvaras",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7700",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Pano Lefkara",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7710",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kato Lefkara",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7711",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Agioi Vavatsinias",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7712",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Vavatsinia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7713",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Vavla",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7714",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kato Drys",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7715",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Lageia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7716",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Melini",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7717",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Moni Agiou Mina",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7718",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Odou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7719",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Ora",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7730",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Agios Theodoros Larnakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7731",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Skarinou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7733",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kalavasos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7735",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Kofinou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7736",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Mari",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7737",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Maroni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7738",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Vasiliko",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7739",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Zygi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7740",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Tochni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7741",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Choirokoitia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "7743",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 747,
+    "state_code": "03",
+    "locality_name": "Psematismenos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8010",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8011",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8015",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8016",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8020",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8021",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8025",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8026",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8027",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8028",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8035",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8036",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8040",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8041",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8042",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8045",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8046",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8047",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8048",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8049",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pafos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8200",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Geroskipou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8201",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Geroskipou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8220",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Chlorakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8221",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Chlorakas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8240",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agia Marinouda",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8250",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Empa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8260",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Lempa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8270",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Tremithousa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8280",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mesogi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8290",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mesa Chorio",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8300",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Konia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8310",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Geroskipou (Koloni)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8500",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kouklia Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8501",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agia Varvara Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8502",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Anarita",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8503",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Acheleia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8504",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mandria Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8505",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Nikokleia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8507",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Timi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8509",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kouklia Pafou (Lofoi Afroditis)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8510",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kouklia Pafou (Cha Potami)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8520",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Marathounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8521",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Axylou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8522",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Armou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8523",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Eledio",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8524",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Episkopi Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8525",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Nata",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8526",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Choletria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8540",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Tsada",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8541",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kallepeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8543",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Koili",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8544",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kourdaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8545",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Lemona",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8546",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Letymvou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8549",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Polemi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8550",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Stroumpi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8552",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Choulou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8560",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pegeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8570",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pegeia (Agios Georgios)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8572",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Akoursos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8573",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kathikas",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8574",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kissonerga",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8575",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pegeia (Kolpos Korallion)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8576",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Moni Agiou Neofytou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8577",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Tala",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8600",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mamonia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8601",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Stavrokonnou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8602",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kato Archimandrita",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8603",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pano Archimandrita",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8605",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mousere",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8606",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Prastio Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8607",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agios Georgios Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8608",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Trachypedoula",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8609",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Fasoula Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8620",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Salamiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8621",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agios Ioannis Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8623",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agios Nikolaos Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8625",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Arminou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8626",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kedares",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8627",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kidasi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8628",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kelokedara",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8629",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Fylousa Chrysochous",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8630",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Praitori",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8631",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mesana",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8640",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pano Panagia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8641",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agia Marina Kelokedaron",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8642",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Amargeti",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8643",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Asprogia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8645",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Galataria",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8646",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Koilineia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8647",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Lapithiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8648",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Mamountali",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8649",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Moni Chrysorrogiatisis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8650",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pentalia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8651",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Statos - Agios Fotios",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8700",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Drouseia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8701",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Androlikou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8702",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kato Arodes",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8703",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pano Arodes",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8704",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Ineia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8720",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Giolou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8721",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kato Akourdaleia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8722",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pano Akourdaleia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8723",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Theletra",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8724",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kritou Tera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8726",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Miliou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8727",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Moni Agion Anargyron",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8728",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Skoulli",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8729",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Tera",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8730",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Choli",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8740",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Lasa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8741",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agios Dimitrianos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8742",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Drymou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8743",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Thrinia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8744",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Milia Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8745",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Melamiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8746",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kannaviou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8747",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kritou Marottou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8748",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Fyti",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8749",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Psathi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8800",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Lysos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8802",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Anadiou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8805",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Evretou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8808",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Meladeia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8810",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Peristerona Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8811",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Fylousa Kelokedaron",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8812",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Simou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8820",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Polis",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8840",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Polis (Latsi)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8850",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Goudi",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8852",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Neo Chorio Pafou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8854",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Polis (Prodromi)",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8855",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Chrysochou",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8870",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pomos",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8873",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Argaka",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8875",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Gialia",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8876",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Kynousa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8877",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Limni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8879",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Makounta",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8880",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Nea Dimmata",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8881",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Agia Marina Chrysochous",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8882",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Pelathousa",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  },
+  {
+    "code": "8884",
+    "country_id": 57,
+    "country_code": "CY",
+    "state_id": 746,
+    "state_code": "05",
+    "locality_name": "Steni",
+    "type": "full",
+    "source": "cyprus-post-via-georgioupanayiotis"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 825 Cyprus postcodes spanning all 5 government-controlled
districts (Lefkosia, Lemesos, Larnaka, Ammochostos free area, Pafos),
sourced from the ``georgioupanayiotis/zip-postal-codes-cyprus``
mirror of Cyprus Post's catalogue.

- **Coverage**: 99% state FK (the lone unresolved row has
  ``District=null`` in source).
- **Granularity**: municipality level — one record per
  ``(4-digit code, municipality)`` pair, deduped from 29,591
  source street rows.

## How it works

Source uses Greek district forms ("Lefkosia"/"Lemesos"/etc.); CSC
embeds both Greek and Turkish forms in its names ("Nicosia
(Lefkoşa)"/"Limassol (Leymasun)"/etc.). A 5-entry ``DISTRICT_ALIASES``
bridge maps each Greek source name to the combined CSC name.

The 6th CSC district (Kyrenia (Keryneia)) is in northern Cyprus and
not represented in Cyprus Post's free-area-only feed; backfill would
require a separate KKTC Posta source.

## Source & licence

- Source URL: https://raw.githubusercontent.com/georgioupanayiotis/zip-postal-codes-cyprus/master/postcodes.json
- Origin: Cyprus Post publicly published index, redistributed by
  georgioupanayiotis.
- Each row: ``"source": "cyprus-post-via-georgioupanayiotis"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 825 codes match ``country.postal_code_regex`` (``^(\d{4})$``).
- 99% of records resolve a valid ``state_id`` whose ``country_id == 57``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)