### PR TITLE
feat(postcodes/MU): bulk-import 1,874 Mauritius postcodes via Mauritius Post (#1039)

### DIFF
--- a/bin/scripts/sync/import_mauritius_postcodes.py
+++ b/bin/scripts/sync/import_mauritius_postcodes.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Mauritius -> contributions/postcodes/MU.json importer for #1039.
+
+Source data
+-----------
+The community ``Samimveza/mauritius_postal_code`` repository ships
+the Mauritius Post catalogue keyed by city -> sublocality:
+
+    {"16eme Mille": [
+        {"name": "Cite Anoushka", "code": "52601", "street": ""},
+        ...
+    ]}
+
+Source URL: https://raw.githubusercontent.com/Samimveza/mauritius_postal_code/master/city-sublocality.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Walks city -> sublocality entries; emits one record per
+   ``(5-digit code, sublocality + city)`` pair.
+3. Ships country-only: source has no district mapping (``states.json``
+   does carry 12 districts but the source's 144 cities don't directly
+   align without a hand-curated crosswalk).
+4. Writes contributions/postcodes/MU.json idempotently.
+
+License & attribution
+---------------------
+- Source: Samimveza/mauritius_postal_code (open redistribution of
+  Mauritius Post's publicly published index).
+- Each row: ``source: "mauritius-post-via-Samimveza"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_mauritius_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/Samimveza/mauritius_postal_code/"
+    "master/city-sublocality.json"
+)
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    mu_country = next((c for c in countries if c.get("iso2") == "MU"), None)
+    if mu_country is None:
+        print("ERROR: MU not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(mu_country.get("postal_code_regex") or ".*")
+    print(f"Country: Mauritius (id={mu_country['id']})")
+    print(f"Source cities: {len(data):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for city, sublocs in data.items():
+        if not isinstance(sublocs, list):
+            continue
+        for entry in sublocs:
+            code = (entry.get("code") or "").strip()
+            if not code:
+                continue
+            if not regex.match(code):
+                skipped_bad_regex += 1
+                continue
+            sub_name = (entry.get("name") or "").strip()
+            locality = ", ".join(p for p in (sub_name, city.strip()) if p)
+            key = (code, locality.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+
+            record: Dict[str, object] = {
+                "code": code,
+                "country_id": int(mu_country["id"]),
+                "country_code": "MU",
+            }
+            if locality:
+                record["locality_name"] = locality
+            record["type"] = "full"
+            record["source"] = "mauritius-post-via-Samimveza"
+            records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/MU.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/MU.json
+++ b/contributions/postcodes/MU.json
@@ -1,0 +1,14994 @@
+[
+  {
+    "code": "11101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Firinga, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Firinga, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Blanc ( Padco ), Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Blanc /Sugar Planters, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite C.H.A/Cite Debarcadere, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Debarcadere / CHA, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Ilois Phase 1 and 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Ilois Phase I & phase II, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Lateka, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Lateka, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Lumiere, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Lumiere, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kensington, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kensington, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tour Koenig Phase 1 and 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tour Koenig Phase I & Phase 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tour Koenig Industrial Zone, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tour Koenig Industrial Zone, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Marguerite Phase 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Marguerite Phase 1, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement D'Hotman, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement D'Hotman, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11112",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Fon Sing, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11112",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Fon Sing, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11113",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Fortune, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11113",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Fortune, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11114",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Brunes Pailles, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11114",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ghurburrun Ph 1 Brunes Pailles Phase 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11115",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ibrahim Dawood, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11115",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ibrahim Dawood, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11116",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ilois Phase 1 & Phase 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11116",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ilois Phase 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11116",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ilois Phase 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11117",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Koenig/Verger Sur Mer, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11117",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Koenig/sur mer, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11118",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Le Prinmtemps, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11118",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Le Printemps, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11119",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Le Vieux, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11119",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Le Vieux, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11120",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Nazroo Phase 1 & Phase 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11120",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Nazroo Phase 1/2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11121",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Rey, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11121",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Rey, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11122",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ghurbhurrun, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11122",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Sagittaire, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11123",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement S.L.D.C, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11123",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Sagittaire/SLDC, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11124",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Sohun, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11124",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Sohun, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11125",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Soobra Phase 1 & Phase 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11125",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Soobra Phase 1/2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11126",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Verger Mangue, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11126",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Verger Mangue, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11127",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Verger Le Bain, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11127",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Verger Le Bain, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11128",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Verger Sur Mer, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11129",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe aux Sables, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11129",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe aux Sables, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11130",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Police Flat, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11130",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Police Flat-Pointe aux sables, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11131",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence Coquillage, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11131",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence Coquillage, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11132",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence La Tourelle 1 & 2, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11132",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence La Tourelle 1/2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11133",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terrason 1 (west), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11133",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terrasson 1, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11134",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "U.T.M, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11134",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "U.T.M, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11135",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Verger Mangue, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11135",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Verger Mangue, Pointe aux Sables",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Anse Courtois, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bell Village, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Borstal, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Chapelon East, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Chapelon West, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Borstal, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Canal Dayot (both sides), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mauvillac, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine Les Pailles, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GRNW, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Informatic Park, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11212",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tour Koenig East: Excell Avenue (East), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Guibies, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11214",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Rock, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11215",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11216",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montebello: Western Side of Trunk Road from Ring Road to Pailles Junction, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11217",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montebello Industrial Zone, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11218",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montee S: From P aux Sables Junction to B River Junction (Western Side), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11219",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pailles, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11220",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pailles East, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11221",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pailles West, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Lauzun Industrial Zone, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11223",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Police Flats (Bell Village), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11224",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont St Louis: Trunk Road from St Louis Stream 1 to St Louis Stream 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11225",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Soreze, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11226",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SVICC, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11227",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terrasson Lower, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bain des Dames, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Barracks Region, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cassis 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cassis 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cassis 3, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Caudan, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11307",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Caudan Waterfromt, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11308",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Central Market (Both wings), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11309",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Valijee, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Dr. A. G. Jeetoo Hospital, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "G.M. Tower, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11312",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "I.B.L. Complex, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Intermediate Court, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11314",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Butte Region, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11315",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Salines, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11316",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Line Barracks, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11317",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mauritius Bulk Sugar Terminal (Building), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11318",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Municipality of Port Louis, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11319",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Government Centre, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11320",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Port Louis Waterfront (Harbour up to Fish Port), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11321",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Emmanuel Anquetil Building, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11322",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Royal College, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11323",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ruisseau des Creoles, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11324",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Georges, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11325",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Supreme Court, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11326",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "The Peninsula (Tower), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11327",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Victoria Square, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11328",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "William Newton Region, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bangladesh, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Blvd Victoria 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Blvd Victoria 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Champ De Mars, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Citadelle Region, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Crowland Tory, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Harbour View 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Harbour View 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Manna, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tranquebar, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Denis, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Enniskillen, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Marie Reine de la Paix, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Martial, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Verte 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Verte 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vallee Pitot 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vallee Pitot 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vallee Pitot 3, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Yoloff, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "China Town, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Roche Bois, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Customs House, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Font George, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hospice Montfort, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mauritius Freeport Authority, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "M.C.F.I, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mer Rouge, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Moulin De La Concorde, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Verte 3, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Verte 4, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Renganaden Seeneevassen, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11614",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Roche Bois 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11615",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quay D, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Briquetterie, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Paul Toureau Region, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Roche Bois 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Croix 1, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Croix 2, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11706",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Croix 3, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11707",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Croix 4, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11708",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Croix 5, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Lalo, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Cure, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Croisee Vallee Des Pretes, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Crownland Robert Scott, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Cure :La Cure Bus Terminus, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Agnis /Ramlagun ( lower V.D Pretes), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ally /Sekdaur (lower V.D Pretes), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Almadina, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Ameermeeah, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mocellement Mohamedally, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Pitchen, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Cite La Cure, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC (La Cure ), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11815",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC (Les Cocotiers ), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11816",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC (Media ), PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11817",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lower Valle Des Pretes, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "11818",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Upper Vallee Des Pretes, PORT LOUIS",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Arsenal, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine Les Cascades, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Poonith, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Promo Holiday, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramjan, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Royal Park, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Sobrun, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Paul & Virginie, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Gamin, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere Citron, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Joseph, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Calebasses, Calebasses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Koyratty, Calebasses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Espoir, Calebasses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Old Flacq, Calebasses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Congomah, Congomah",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite E.D.C, Congomah",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Royal Rd, Congomah",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Creve Coeur, Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc.Creve, Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ripaille 1/2/3, Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson (Right side), Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Thomassin, Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Upper C. Coeur, Creve Coeur",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Creole, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite C.H.A, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Depinay Village, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine de Rosalie, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grande Rosalie, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ilot, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jouvence, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Plessis Mount, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Plaisir Mount, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc. Le Plessis, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc. Mount, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc. Juwaheer, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc V.R.S, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Gout, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mme Cayeux, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "The Mount, D'Epinay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Fond du Sac East, Fond du Sac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Fond du Sac West, Fond du Sac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dilchand, Fond du Sac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Baillache, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Boulingrin, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp la Boue/ Vallee du Paradis, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "C.H.A, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Social Welfare, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Descoins, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.D.C. A, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.D.C. B, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Mariannes, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Industrie, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Baillache, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Nouvelle, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson (Left Side), Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Valton, Long Mountain",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Cremation, Morc St Andre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc St Andre East, Morc St Andre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc St Andre West, Morc St Andre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "20904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Morc St Andre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Plan, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Rouge, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Botanical Garden, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Canton Nancy, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Canton Belle Eau, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Badamiers, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21007",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp d Embrevades, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21008",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite E.D.C, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21009",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Louisa, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21010",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Plaisir, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21011",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc. Ripaille, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21012",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Rocher, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21013",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc.Maison Blanche, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21014",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pamplemousses, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21015",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere Citron, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21016",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sixth Mile, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21017",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "S.S.R.N.Hospital, Pamplemousses",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Mangue, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Maraz, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite NHDC, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Beau Plan, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Blue Nile, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Chummun, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dauhoo, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Koonjoo, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramphul, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Seebundhun, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21212",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "P.Papayes East, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21214",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "P.Papayes West, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21215",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Theo Maigrot Sq, Plaine des Papayes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Lilas, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Sada, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Scipion, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grande Pointe aux Piments, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Brizmohun, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite Pointe aux Piments, Pointe aux Piments",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21307",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Baie aux Tortues, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21308",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Le Vieux Banian, Arsenal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Marchand, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Pignolet, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp La Boue, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "C.E.B Sq., Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Bois Marchand, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mamzelle Laure, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bussawon, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Cathan, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Green Park, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Peerun, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc.Poonith, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Ragoobar, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Soobratty, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Tara, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Joseph, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terre Rouge, Terre Rouge",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cinema Casse, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Huitieme Mile, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Neuvieme Mile, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC (Solitude), Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Septieme Mile, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solitude, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terminus, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trois Boutiques, Triolet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Sipaye, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Songe, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Monc V.R.S, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nicoliere, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite Julie, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ville Bague upper, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ville Bague lower, Ville Bague",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Praslin, Brisee Verdiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Auberge, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bay Village, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Florida, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Illois, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Chaux/State Land, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21706",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Docker's land, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21707",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Elizabethville, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21708",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Industrial Zone, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21709",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Goulet (Royal Rd), Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21710",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Beau Rivage, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21711",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Boucan, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21712",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Concorde, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21713",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Coprim, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21714",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dassagne, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21715",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Filature, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21716",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Fong Sing, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21717",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Illois, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21718",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc La Cocheyle, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21719",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Verger, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21720",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Madhoo, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21721",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mignot, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21722",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Rouillard, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21723",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ruhomatally, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21724",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Senestra, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21725",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Swan, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21726",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Zenith, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21727",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21728",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Paille en Queue, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21729",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Bruniquel, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21730",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence St Malo, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21731",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riche Terre, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21732",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Malo, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21733",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tombeau Bay (Royal Rd), Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21734",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tresor, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21735",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Village les cocotiers, Tombeau Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite C.H.A, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Roma, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jumbo, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Fontaine 23, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Hochet, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Foondun, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Goolamally 1, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Goolamally 2, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Manick, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Motee, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc.Raffray 1, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Raffray 2, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riche Terre, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riche Terre Ind Zone, Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "21815",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terre Rouge (village), Le Hochet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Church Square, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montee Jolie, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Kitchine, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc L'Amitie, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc.La Rochelle, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Teeluck, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22007",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22008",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Notre Dame, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22009",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C Baillache, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22010",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C.Church, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22011",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C.Valton, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22012",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Platform, Notre Dame",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC Pere Laval, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Asviva, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bassa, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Choisy, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Elaya, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Future, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22307",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Hossen, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22308",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Jhuboo, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22309",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mascareign, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Moosary, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Papin, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22312",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramdewar, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramdhany, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22314",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Residence, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22315",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Sagitaire, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22316",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Souvenir, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22317",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Tobago, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22318",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Trio, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22319",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS Choisy, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22320",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence Flebistier, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22321",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trou aux Biches I, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "22322",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trou aux Biches II, Trou aux Biches",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "B.V.Maurel (Amitie) part of, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Antoinette, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Barlow, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Vue Maurel, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Desjardins, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon. Allybocus, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Loisir, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Phoolia Nagar, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite C.H.A, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cottage North, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cottage South, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Beau Plateau, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Kestrel, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC, Cottage",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Esperance Trebuchet, L'Esperance Trebuchet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Arya Mandir, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Astoria, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Balkan, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Rouge, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CEB Sq, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Ste Claire, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine du Moulin, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Madame Azor, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mamzelle Jeanne (Wlk II) & (Wlk III), Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mapon Leclezio, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Petit Village, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc St Antoine, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Sq, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Morc Goodlands, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Village, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plateau, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway Sq, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Reservoir, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30419",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Soobany Sq, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30420",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Antoine Industrial Zone, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30421",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Triangle, Goodlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Aquamarine, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bazar, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bain Boeuf, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Manguier, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Harel, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Lumiere, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Huradon, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coastal Rd, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Lamour, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Carol, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chemin Vingt Pied, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Dodo Square, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Bougainvilliers, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Croisette, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Mare Ronde, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Flamants, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30520",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray (a), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30521",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray (b), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30522",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray (c), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30523",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray (d), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30524",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Corsaire, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30525",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Choisy (s.e), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30526",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Berth, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30527",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Choisy Shopping Mall, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30528",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Martin, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30529",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Boucan, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30530",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Honore, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30531",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Caleche, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30532",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Swan, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30533",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Foondun, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30534",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Unicorn, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30535",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Toorabally, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30536",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Moulin Casse, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30537",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Chetty, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30538",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Villa Pereybere, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30539",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Oreb, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30540",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Jaulim, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30541",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Comty, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30542",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Jitsing, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30543",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramdin, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30544",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Macumba, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30545",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Oasis 2 (res), Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30546",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pereybere, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30547",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe D'Azur, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30548",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Richmond Hill, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30549",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Racket, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30550",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sottise, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30551",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Super U, Grand Bay",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Arya Mandir, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Batie, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Butte a L'Herbe, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Calodyne, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Corail, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Madras, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Petrol, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Citerne, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Complex Paul et Virginie, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Complex Melville No 1, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Complex Melville No 2, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Complex Melville No 3, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30614",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Complex Melville No 4, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30615",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Couacaud, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30616",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Germain, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30617",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Gaube, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30618",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "John Kennedy, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30619",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Lucie Residence, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30620",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Agnis Phase 1, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30621",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nelson, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30622",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pere Glorieux, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30623",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quartier des Lauriers, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30624",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Jean Bosco, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30625",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sin Fat, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30626",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Joseph Roc en Roc, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30627",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Michel, Grand Gaube",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Mayeux, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Charmose, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare Seche, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Mascal, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bholah, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30706",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gowreesunkur 1, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30707",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gowreesunkur 2, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30708",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Harrangee, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30709",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Loderchand, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30710",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Moulin au vent, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30711",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Raffray Village 1, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30712",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Raffray Village 2, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30713",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Reunion Maurel, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30714",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Francois, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30715",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Union Daruty, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30716",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Union Delcourt, Petit Raffray",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Sejour, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Sejour SE, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bon Espoir, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Espe Piton, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Paix, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Piton, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Haut Champs, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC, Piton",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Doiseau, Poudre D'Or Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Poudre D'Or Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Poudre D'Or Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ile Dambre, Poudre D'Or Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "30905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Poudre D'Or Village, Poudre D'Or Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Forbach Branch, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS A, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS B, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS C, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS D, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Poudre D'Or Hamlet, Poudre D'Or Hamlet",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite C.H.A, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coquinbourg, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Haute Rive, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Clemence, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Maurel, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Lane, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Panchvati, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pave, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pte des Lascars, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway Lane, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31112",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway Line, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31113",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riverside, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31114",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere du Rempart, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31115",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Schoenfield, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31116",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Temple, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Azuri Complex, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coastal Side, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine du levant, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Haute Rive, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lambic, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Roches Noires Village, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Branch Rd, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sidine, Roches Noires",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lower Vale, The Vale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Upper Vale, The Vale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Amaury, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Jacquot, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Mourand, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Beauclimat, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Amitie (part of), Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Amitie, Amitie Gokhoola",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Amitie Gokhoola",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gokhoola, Amitie Gokhoola",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Amitie Gokhoola",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Anse La Raie, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bain Boeuf, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Calodyne, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Gervaise, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cape Garden, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31706",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cap Malheureux, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31707",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cayeux, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31708",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "C.H.A, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31709",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31710",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jardin du Cap, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31711",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Roue Charette, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31712",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mariamen Temple, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31713",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Agnis Ph 2, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31714",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Chetty 1, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31715",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Chetty 2, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31716",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Chetty 3, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31717",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Garrib, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31718",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Merven, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31719",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Rouillard, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31720",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Rd, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31721",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31722",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pavillon, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31723",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pazani Mallaye, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31724",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quartier La Ligne, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31725",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence du Nord, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31726",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Francois, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31727",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Villa Maria Sq, Cap Malheureux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite S.I.L.W.F, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ferret, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Labourdonnais, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mapou, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc B.Plateau, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc BelleVue, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Hiilside, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC, Mapou",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaines des Roches Aubin, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaines des Roches (Lower), Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaines des Roches (Upper), Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "31904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaines des Roches Seneck, Riviere du Rempart",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "32001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Calasse, Roche Terre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "32002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Roche Terre, Roche Terre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bel Air, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Caroline, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ernest Florent, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Laura, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Lucie Roy, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Lucie Building, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Central, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement La Cheminee, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Pont Lardier, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Bois, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Lardier, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40112",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Michel, Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mission Cross, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belvedere, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Bas Fond (northern part), Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bon Accueil, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Bois, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quatre Bords, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Latapie (eastern side), Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Balance John, Camp De Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp De Masque, Camp De Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Sonar, Camp De Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L' Unite, Camp De Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp De Masque Pave, Camp De Masque Pave",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare Goyaves, Camp De Masque Pave",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite Cabane, Camp De Masque Pave",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Ithier, Camp Ithier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Isidore Rose, Camp Ithier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Isidore Rose Pave, Camp Ithier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Vue Allendy, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Boulet Blanc, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Boulet Rouge, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Boutique Coco, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Garreau, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Central Flacq, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Argy, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Hibiscus, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Constance S.E, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine La Colombe, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hermitage, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Source, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Argy, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40614",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Hospital, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40615",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Robillard, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40616",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nehru Nagar, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40617",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine De Gersigny, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40618",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riche Mare, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40619",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Remy, Central Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Rose, Clemencia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clemencia, Clemencia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ecroignard, Ecroignard",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ANAHITA IRS+HOTEL, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Champ, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Champ S.E (ALTEO), G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Pecheurs, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FOUR SEASONS+HOTEL, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40906",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grande River South East, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40907",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "40908",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quartier, G.R.S.E",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Laventure, Laventure",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Creole, Mare La Chaux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare La Chaux, Mare La Chaux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bel Etang, Medine Camp de Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Medine, Medine Camp de Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Ida, Medine Camp de Masque",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Beau Bois, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Jakeeree, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CHA + (state land), Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Deep River S.E, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "EDC, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kewal Nagar (Belle Rive), Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "la Nourrice, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Louis Renaud, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Deep River, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Hamid, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Louis Renaud, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Trois Ilots****, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS Kewal Nagar, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Olivia, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaines Bananes, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rousset Rd (olivia), Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SILWF - Olivia, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trois Ilots, Olivia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bras d'Eau, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Accacia, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Poorun, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Raffia, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Perdu, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Choisy, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cremation, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jardin, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kashinath, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Pointe, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Porte, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Constance, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Janoo, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Monet, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Providence, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Blanc, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Poste de Flacq, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Poste Lafayette, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41520",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway, Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41521",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "One and only (st Geran Hotel), Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Mare, Quatre Cocos",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Long Beach Hotel(ex Coco), Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Marcelin, Quatre Cocos",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "The Resort(Belle Mare Plage), Poste de Flacq",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Rannoo, Quatre Cocos",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Palmar, Quatre Cocos",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quatre Cocos, Quatre Cocos",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Julien Village, Saint Julien Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rich Fund, Saint Julien Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "41903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Union Flacq, Saint Julien Village",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cent Gaulettes, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Sebastopol, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clavet, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Etoile, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lesur, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pellegrin, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sebastopol, Sebastopol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Rivage, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Nadal, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Nowbuth, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Toorab, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Desperoux, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Pelouse, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Maho, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montee Bastille, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Palmar Beach, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sept Croisees(inc Montaigu), Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42212",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Touessrock/Casuarina, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Victoria, Trou D'Eau Douce",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belvedere, Brisee Verdiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Latapie(western side), Brisee Verdiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Brisee Verdiere, Brisee Verdiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare D'Australia, Brisee Verdiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lalmatie, Lalmatie",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mission Cross, Lalmatie",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belvedere, Lalmatie",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Bas Fond(southern part), Lalmatie",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bonne Mere, Queen Victoria",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Bonne Mere, Queen Victoria",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC B Mere, Queen Victoria",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "42704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Queen Victoria, Queen Victoria",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "43201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bramsthan, Bramsthan",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "43301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grande Retraite, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "43302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois d'Oiseaux, Grande Retraite",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "43302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Off Beau Bois/Vrindavan, Bon Accueil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "43303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite retraite, Grande Retraite",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bambous Virieux, Bambous Virieux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Bambous Virieux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Mares, Bambous Virieux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe Bambous, Bambous Virieux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bananes, Bananes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Eau Bleue Reservoir, Bananes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Bel Air, Grand Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Des Amourettes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Des Amourettes, Bois Des Amourettes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine des Chasseur, Bois Des Amourettes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Providence, Bois Des Amourettes",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bemanique, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Bengali, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Ramdin, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cluny, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Eau Bleue Tostee, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway, Cluny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Balma, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Pierre, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Sable, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Sable, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Des Roches, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe Des Roches, Grand Sable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Gheude, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Blue Bay, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois D'oiseaux, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Manioc, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cent Gaulettes, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Chaux, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hospital, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ile aux deux cocos, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mahebourg, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Maurice st, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Lorette, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Museum, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe Canon, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50815",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe D'Esny, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50816",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pte des Regates, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50817",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pte Jerome, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50818",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quartier, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50819",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Remy Ollier, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50820",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tombeau, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50821",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ville Noire, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50822",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Villeneuve, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "50823",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Waterfront, Mahebourg",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Coco, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mare D'Albert, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gros Bois S.E, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Vergers de Gros Bois, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare D'Albert, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51007",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gokool, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51008",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Grove, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51009",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Piscine, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51010",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Samlaul, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51011",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Toolsee, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51012",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rampe Le Moirt, Mare D'Albert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Aspral, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Francois, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Greenwood, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gros Bois Rd, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Joli Bois, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jugoo Bhunjun, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare Tabac, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc SIT, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Mare Tabac, Mare Tabac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Astroea Rochecouste, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bamboo, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois D’oiseaux, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Business Park, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Rosa, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mont Fertile, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite NHDC, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Deux Bras, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Deux Bras S.E, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gros Billot, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gros Billot Branch, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51212",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kalimaye, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Rosa, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51214",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare Chicose, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51215",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Fertille, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51216",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Balance, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51217",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dreepaul, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51218",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ganga, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51219",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gaytree, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51220",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mauripark, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51221",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Grove, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51223",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Parasol, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51224",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Siding, New Grove",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bemanique, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bissoondoyalrd, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Commelonne, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Port Rd, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kanpur, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Peyre, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51307",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc B.Climat, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51308",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C N.France, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51309",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.France, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Colville, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence U.Park, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51312",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Savanne Rd, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Seegoolam Rd, Nouvelle France",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Vue /Kenya, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite NHDC, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Debarcadere, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ferney, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Vallon, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Old Grand Port, Old Grand Port",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Agricultural Extension Office, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Balance, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois D'Oiseau, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cemetry Rd, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chatgaon (ex Airport), Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Burrenchobay, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC Balance, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Cambuse, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Grotte, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Chaland, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Madame Dayla, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon desert Rd, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gobin, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ithier, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC les Palmiers, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine Magnien, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rishi dayanand Rd, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ruisseau Copeaux, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solitude, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51520",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SSR International Airport, Plaine Magnien",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Carol, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Longtill, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Ferney, VRS, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pte Brocus, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere des Creoles, Riviere des Creoles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Baramia, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Bouvet, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Capitol, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chakla, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chapel, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gebert, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Letord, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Vieux Moulin, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Madame Lolo, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Marie Jeannie, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51815",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mongelard, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51816",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Rose 1, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51817",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Rose 2, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51818",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bakory, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51819",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Boolaky, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51820",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Brito, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51821",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Domaine, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51822",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Jac, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51823",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Orchidee, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51824",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Rosiere, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51825",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc S.I.T, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51826",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Rd, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51827",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51828",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Res Marc Chicose, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51829",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rose Belle, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Site, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Filbert, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Florine, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Jardin, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Ramphul, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51906",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cent Gaulettes, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51907",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51908",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite St Hilaire, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51909",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hydro Power Station, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51910",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Val Nature Park, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51911",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dussoye, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51912",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Henry, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51913",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riche en Eau, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51914",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Hilaire, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51915",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Hubert, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51916",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ste Madeleine, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "51917",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ste Philomene, St Hubert",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Fonds, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Esnouf, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau La Paille, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Trois Boutiques, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Malakoff, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52007",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Aspirale, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52008",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Les Palmiers, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52009",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Pitchen, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52010",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plein Bois, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52011",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trois Boutiques, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52012",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Union Vale, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52013",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Virginia, Trois Boutiques",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Balisson, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cluny rd, Union Park",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Cheminee, Union Park",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Union Park",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Balisson (SILWF), Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "School Rd, Union Park",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "U.Park, Union Park",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Padco, Rose Belle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Vallon, Beau Vallon",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, Beau Vallon",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite NHDC, Beau Vallon",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Residential Area [Morc], Beau Vallon",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Verger, Beau Vallon",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Vinson, Petit Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cemetery, Petit Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Bel Air, Petit Bel Air",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Carol, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Acacia, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Cambuse, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Bouchon, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Desert Mon Tresor, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. V.R.S M. Desert, Camp Carol",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Midlands, Midlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ferret, Midlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramdanee, Midlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc St Therese, Midlands",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Anoushka, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mon Bois, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coriolis, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Bois(cnt+ubs+laiterie), 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Domah, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "morc Sookary, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement RAMPHUL 1, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement RAMPHUL 2, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Seizieme mile, 16eme Mille",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Deux Freres Mountain side, Quatre Soeurs",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Deux Freres Seaside, Quatre Soeurs",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Marie Jeanne, Quatre Soeurs",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mr Joly, Quatre Soeurs",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "52705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pointe aux Feuilles, Quatre Soeurs",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Baie Du Cap, Baie Du Cap",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Choisy, Baie Du Cap",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ahchin, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Akla Road, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Cheri, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Building, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cader Road, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC Bois Cheri, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cooperative, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Heerallal Rd, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60209",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mambahal, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Porida, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60212",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence Bois Cheri, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Seeruttun Rd, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60214",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tivoli, Bois Cheri",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "EDC CAMP DIABLE, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC SAVANNAH, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ILOT, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP DIABLE, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC CAMP DIABLE, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RICHE BOIS, Camp Diable",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Adventist RD, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Barbe, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Charlot, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fanny, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fanny Lorquet, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Galets, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Goolbar, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Jeannette, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Lilas, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Florentina, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jooloom, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jumbo, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lotus, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Carmel, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dunputh, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Rd, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Mosque, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plaine des Galets, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60419",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PlayGround, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60420",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60421",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere des Galets, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60422",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Felix, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Satanah, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60424",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Social Welfare Centre Rd, Chemin Grenier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Jacques, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Bananes, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "College Lane, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Fazerally Road, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grand Bois + boolaky road, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Forge Road, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Grand Road, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Media, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc SIT, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C Grand Bois, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C Legrand, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Old Savanne Rd, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sewsagur Rd, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Young Tow, Grand Bois",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SENNEVILLE, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC ROUNTREE(land), Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PRUD'HOMME, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC PRUD'HOMME, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MAISONNETTE, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RAILWAY, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BARRACKS, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP MARTIN, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA VANILLE NHDC, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEL AIR SAINT FELIX, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Rabaud, Riviere du Poste",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Siajee, Riviere du Poste",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riv du Poste, Riviere du Poste",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terrain Maurice, Riviere du Poste",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Boodhoo, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite E.D.C Chaline, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite E.D.C Pitot, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Gris Gris, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Texamon, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lady Barkly, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Brise de Mer, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc GRIS GRIS, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Brise De Mer, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Souillac, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terracine, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VRS 1 souillac, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VRS 2 souillac, Souillac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "African Town squatters, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Balance, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CEMETARY Squatters, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite de Dieu Squatters, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC 1 Surinam, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60906",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC 2 Surinam, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60907",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coastal/mandir, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60908",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Katamaraz, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60909",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Martiniere, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60910",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Dhunputh, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60911",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc DIDI, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60912",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gobin, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60913",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Filao, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60914",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pomponette, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60915",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riambel, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60916",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rochester/Mosque, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60917",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Louis, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60918",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sept Croisees, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "60919",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trois Bras, Surinam",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Champ, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bel Ombre, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC Bel Ombre, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Longtill Bel Ombre, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sainte Marie, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Martin, Bel Ombre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BATIMARAIS, Benares",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "COLMAR, Benares",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BENARES, Benares",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BRITANNIA, Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE RAMPUR, Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VRS BRITANNIA (land only), Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RIVIERE DRAGON, Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC VRS R.DRAGON, Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61206",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP BERTHAUD, Britannia",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chamouny, Chamouny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mare Anguilles, Chamouny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Blanc, Chamouny",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp La Hache, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Tagore, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Charles Rd, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chattorgoon, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Longtill, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Paul & Virginie, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Barraque S.E, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Chapelle, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Sourdine, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Escalier, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Barbe, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc La Sourdine, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Tagore, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Savannah, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Savannah S.E, L'Escalier",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "UNION DUCRAY S.E/Union St Aubin, Union Ducray / St Aubin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE SAINT AUBIN, Union Ducray / St Aubin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC St Aubin, Union Ducray / St Aubin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New morc St Aubin (land only), Union Ducray / St Aubin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bostom Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cooperative Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kanhye Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61704",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Flora, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Matoo Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61706",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pamplemousses Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61707",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rioux, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61708",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Seebaruth Rd, La Flora",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE TYACK, Tyack",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LOWER TYACK, Tyack",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RAILWAY SQUARE, Riviere des Anguilles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC BLUE PRINT, Tyack",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC TYACK, Tyack",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "61805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "UPPER TYACK, Tyack",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71126",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC AH FOUYE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71128",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC BERTHAUD, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71129",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC Bholah, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71132",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC NARAIN (terrain), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71135",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC SOOKIA, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71170",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "STANLEY 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71171",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "STANLEY 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71173",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TREFLES 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71174",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TREFLES 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71175",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TREFLES 3, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71176",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TEFLES HOUSING ESTATE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP LEVIEUX 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP LEVIEUX 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CORP DE GARDE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ESPACE CONCORDE (C.levieux), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71210",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT BHUNJUN (village de la montagne), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71216",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT ROCHES BRUNES, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71225",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC GAYA, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71230",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC CHADY, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71231",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC GOPAL, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71233",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC NOUVELLE VILLE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71234",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC SEEBURN, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71238",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT NARAIN, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71241",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX -GERANIUM), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71242",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX-BEGONIA ), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71243",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX-CHRYSANTEME ), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71244",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX-DALHIA ), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71245",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX-EGLANTINE ), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71246",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC C LEVIEUX-FLAMBOYANT ), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71255",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE LA CONCORDE (NHDC), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71258",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROCHE BRUNES/ PLAISANCE 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71259",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROCHE BRUNES/ PLAISANCE 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ARAB TOWN, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ARCADES REETOO, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71308",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT ABDOOLAH, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71309",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT BADAMIERS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT HOLLYWOOD, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71312",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT MONMARTRE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT PEM, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71314",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT POUPINEL DE VALENCE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71315",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT ROBINSON, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71317",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GALERIE ATCHIA, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71318",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GALERIE EVERSHINE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71319",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GALERIE ROYALE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71320",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GOVINDEN COURT, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71321",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "HEAVEN HEIGHTS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71322",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MANDARIN COURT, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71323",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MARKET ROSE HILL, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71324",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONT ROYAL, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71327",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC BALGOBIN, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71336",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC ST ANDREWS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71337",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT LARCHER, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71339",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT ROGERS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71340",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.P.F BUILDING, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71347",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PLACE MARGEOT, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71348",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PLAISANCE 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71349",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PLAISANCE 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71350",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PLAISANCE H.E, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71351",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUEEN ELIZABETH COLLEGE, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71352",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUEEN .COURTS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71353",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RENOWN BUILDING, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71354",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE CLOS VERGER, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71356",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE MALARTIC, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71360",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 1, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71361",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 2, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71362",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 3, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71363",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 4, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71364",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 5, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71365",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 6, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71366",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 7, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71367",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 8, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71368",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROSE HILL CENTRE 9, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BROWN SEQUARD HOSPITAL, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CENTRAL PRISON, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE BARKLY, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "GOVERNMENT BLOCK, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONT ROCHES, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC LA COMETE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC NEW TOWN, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE ST DANIEL, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROCHES BRUNES, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VERGER BISSAMBAR, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 1, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 2, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 3, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 4, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 5, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 6, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU BASSIN CENTRE 7, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CASCADELLA, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CASCADELLE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE DE ROSNAY, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE VUILLEMIN, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "HAREWOOD PARK, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "JULES KOENIG H.E, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MARE GRAVIER Ward 5, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MELDRUM TOWERS, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC AVRILLON, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N.H.D.C VUILLEMIN, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PALM PLAZA, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROCHES BRUNES, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VUILLEMIN, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ETOILE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELVEDERE/CINQUIEME MILE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP BERTHELOT, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CHEBEL, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CHEBEL H.E 1, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CHEBEL H.E 2, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CHEBEC, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "COROMANDEL, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MAINGARD, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MARE GRAVIER Ward 6, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC CLAIRMONT, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement Hart de Keating, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT HERMITAGE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71614",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC LA CONFIANCE 1, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71615",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC LA CONFIANCE 2, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71616",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morcellement LIM FAT, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71617",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONTREAL 1, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71618",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONTREAL 2, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71619",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONTREAL 3, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71620",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MONTREAL 4, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71621",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC VRS CHEBEL, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71622",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PANORAMA, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71623",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "POLICE FLATS 1, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "71624",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "POLICE FLATS 2, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU SEJOUR 3, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU SEJOUR 4, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU SEJOUR 1, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU SEJOUR 2, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 6 CORIOLIS (walk 5), Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 6 CORIOLIS, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 7, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 8, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 5, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 9, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ebene Cybercity, Ebene",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ebene S.E (Ebene Housing Estate), Ebene",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ebene, Ebene",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 9, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CHINESE EMBASY, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BELLE ROSE 4, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72211",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CANDOS, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72218",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE SAINT JEAN, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72219",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "DREAMTON PARK, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "EMERALD PARK (Residence), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72224",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA COLLINE COMMERCIAL CENTRE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72228",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LE MERIT (delivery by Phoenix P.O), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72231",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "EBENE VIEWS (after river inc baden powell house), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72238",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC SAINT JEAN, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72241",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N H D C VILLENEUVE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72242",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ORCHARD CENTRE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72243",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ORCHARD TOWER, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72247",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PELLEGRIN, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72248",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PIERREFONDS, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72249",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUATRE BORNES 1, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72253",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUATRE BORNES 5, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72254",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE D'EPINAY, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72256",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SODNAC, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72257",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TRIANON, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72258",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "TRIANON SHOPPING CENTRE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72259",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VICTORIA HOSPITAL, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72260",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE TRIANON (delivery by Phoenix P.O), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72262",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "EMERALD PARK CENTRE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72263",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LE MERIT 2 (near Pellegrin), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72264",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LES HALLES, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72265",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT RIVER ISLANDS, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BEAU SEJOUR 5, Rose- Hill",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BOUNDARY, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE BEAU SEJOUR/Residence, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72314",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CANDOS/Residence, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72317",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE PERE LAVAL, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72326",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA LOUISE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72350",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUATRE BORNES 2, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72351",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUATRE BORNES 3, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72352",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "QUATRE BORNES 4, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72425",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA FERME Ave, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72427",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA SOURCE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72435",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC PIERREFONDS, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72436",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC POONITH, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72440",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "N H D C PALM, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72444",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PALMA 1, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72445",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PALMA 2, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72455",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RENGANADEN SEENEEVASSSEN AVE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BASSIN/ PALMA, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "BASSIN S.E, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE BASSIN, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE KENNEDY/Residence, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72523",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "JACKSON AVE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72523",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "JACKSON, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72529",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC CERISIER, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72530",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC DOOKUN 1 ( Mun of Q.Bornes), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72533",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC MEDINE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72534",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC NUCKCHEDDY, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72537",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC RIVERSIDE, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72539",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NEHRU ROAD (from Kingstone Ave to Kalimaye Rd), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72546",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PALMA JUNCTION, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "72560",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC MIO, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beard, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Belin, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Mapou, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Roches, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Lalianne, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Henriette, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73114",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Diolle, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73116",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Glen Park, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73117",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Glen Park NHDC, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73120",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Henrietta, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73126",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Marie, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73132",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Medine, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73135",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Pousson, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73137",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Seetaram, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73215",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.Anquetil, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73221",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hollyrood No.1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hollyrood No.2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73227",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Vanille, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73233",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Munbodh, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73234",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Peerun, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73238",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quinze Cantons No.1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73239",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quinze Cantons No.2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73240",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Reunion, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73242",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sadally, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73250",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Thompson, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73252",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tres Bon No. 1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73253",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tres Bon No. 2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73254",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tres Bon No. 3, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73255",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tres Bon No. 4, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bonne Terre, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite La Caverne, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73324",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Caverne No.1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73325",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Caverne No.2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73328",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ligne Berthaud, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73329",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Modern, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73330",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Desir, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73344",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solferino No. 1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73345",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solferino No. 2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73346",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solferino No. 3, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73347",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solferino No. 4, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73348",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Solferino No. 5, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73356",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vingta No. 1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73357",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vingta No. 2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73358",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vingta No. 3, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73359",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Visitation, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73360",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PAILLOTTE (West), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73361",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC DOOKUN 2 (Mun of Vac/Phoenix, QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Brillant, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Angus, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds No.1, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds No.2, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds No.3, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Closel, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Grannum, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73419",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gymkhana, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Independence, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jackson, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73431",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Fleuriot, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73436",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Sauba, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73440",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ollier, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73441",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riverwalk, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73443",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SMF QTRS, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73449",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St Paul, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73451",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73452",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PAILLOTTE (East), QUATRE BORNES",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Brillant, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Jacques, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds 1, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds 3, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clairfonds 2, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat River Islands, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73524",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Jumbo, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73525",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LE Meritt, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73526",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Halles, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73529",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Boucan, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73532",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Lenoir, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73535",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Noel, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73536",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Trianon, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73538",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nalletamby, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73539",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nehru, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73541",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Palmerstone, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73542",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Camp, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73544",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Fer, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73546",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson 1, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73547",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson 3, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73548",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson2, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73549",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sawmill, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73551",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "St. Paul, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73553",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Valentina, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73556",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Royal Road, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bassin, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Belle Terre, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Boundary, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fouquereaux 1, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fouquereaux 2, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fouquereaux 3, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Fouquereaux Bch Rd, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Hosany, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Castel, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cinq Arpents, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite 50, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73619",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hassen Raffa, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73620",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hermitage, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73621",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Highlands, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73622",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Highlands Branch Rd, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73627",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mesnil, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73628",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Blue Print, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73630",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Koenig, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73631",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Lonrho, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73633",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc MTMD, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73634",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Nazroo, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73637",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mosque Rd, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73643",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pine wood Garden, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73645",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riverside, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73650",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sayed Hossen Highlands Bch, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "73652",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tout Court, Phoenix",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Brillant, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Berthaud, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Loiseau, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mangalkhan, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "De Burg Edwards, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "John Kennedy, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "King George V, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Castel, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc GIDC, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Queen Mary, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74111",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Riviere Seche, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74112",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Simonet, Vacoas / Floreal",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74124",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Engrais Martial 1, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Abbe Laval, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bougainville, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74207",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Pierrot, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Rouillard, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74208",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E. Laurent, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74213",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Garden, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74215",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "HENRI ROBERT-north (WARD 2), FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74216",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Casernes, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74217",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cpe Rd (Dove st-De sornay st), Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74218",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Daruty De Grand Pre 1, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74220",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.Coulee Royal Rd 1, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74220",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Faucon, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74221",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc.Senneville, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.Coulee(Hissandee-C.Cheron, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74222",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Souchon, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74224",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Noelville, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74225",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Engrais Martial 2, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74226",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Bahemia, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74229",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Henessy, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74231",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hissandee, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74232",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Mairee, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74233",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lapeyrouse, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74234",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Talipots, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74235",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Piat, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74245",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pope Henessy 1, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74248",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Remono, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74252",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sir William Newton, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Abbe de la caille, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Dhoby, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Levieux, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74309",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Lotus, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74310",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite du Pavillon, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Malherbes B, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74311",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat St. Antoine, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74312",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite MalherbesA, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74313",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Rivet, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74314",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Souchon, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74315",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clement Charoux, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74316",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Couvent De Lorette Road, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74319",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Malherbes, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74321",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "E.Coulee Royal Rd 2, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74323",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Engrais Cathan, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74327",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Baissac, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74328",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Bonomally, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74330",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Joomun, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74334",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Burtun 111, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74335",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Thomy D'Arifat, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74336",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Nasapen, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74337",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Adam, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74338",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Baptiste, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74339",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Camphriers, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74340",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Cantin, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74341",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Hossenbux, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74342",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Municipal House, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74343",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Complex, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74344",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Prevert, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74347",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quatre Carreaux, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74354",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tout Court, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74356",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Villa Chambly, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP BOMBAY, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP LAGESSE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CAMP LE JUGE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Charles Lees, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE ATLEE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Clos de la tour, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE CAMP LE JUGE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Commerson, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE LA BRASSERIE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE ST LUC, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flat Mesnil, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Galeries Y. Palach, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Higginson, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ian Palach, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ICERY, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Malartic, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74419",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA CROIX, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74420",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LES AUBINEAUX, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74421",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LOCAL GOVT SERVICE COMMISSION, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74422",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'OKANA, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LOUIS PASTERUR, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Municipality, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74424",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MAGNOLIAS FLATS, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74425",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MAURICE MARTIN, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74425",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Queen Elizabeth, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74426",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "R.Gujadhur, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74427",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC CARBONEL, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74428",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC DEVOYENNE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74429",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC LECLEZIO, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74430",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC PIAT, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74430",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Royal College, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74431",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Salaffa Region, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74432",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ste Therese, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74434",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "PUBLIC SERVICE COMMISSION, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74435",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE LA COLOMBE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74436",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE LES COLONIES, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74437",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RESIDENCE LES JASMINS, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74438",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "ROCHECOUSTE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74444",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CELICOURT ANTELME, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74445",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "lA BASSERIE (south), FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74446",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pope Henessy 2, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74447",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC ANTELME, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74448",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORC PILOT, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74449",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Remono, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74451",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Royal Rd Shell- Pope Henessy, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Arcades Currimjee, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Barracks, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "B. Sequard, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Caval, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Commerford, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "CITE JOACHIM, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT CEZANNE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FLAT RAMDENEE, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FORST- SIDE 1, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FORST- SIDE 2, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FORST- SIDE 3, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FORST- SIDE 4, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "FORST- SIDE 5, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L.Geoffroy, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Daruty DE Grand Pre 2, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74527",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson 1, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74528",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson 2, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74529",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson 3, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74532",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT DARUTY, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74533",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Stevenson, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74536",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "W. Churchill, Curepipe",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74537",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA BASSERIE (north), FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74550",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Robinson, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74553",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terre Coupe, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74555",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Trou Aux Cerfs, Eau Coulee",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "74556",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MORCELLEMENT RAMALINGUM, FOREST - SIDE",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Thorel, Saint Julien d'Hotman",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Saint Julien d'Hotman, Saint Julien d'Hotman",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Assurance, Dagotiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Lower Dagotiere, Dagotiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Dagotiere, Dagotiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Upper Dagotiere, Dagotiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Valetta, Dagotiere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Esperance, L'Esperance",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Bois, L'Avenir",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Avenir, L'Avenir",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Laura, La Laura / Malenga",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA LAURA/Riv Baptiste, La Laura / Malenga",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Malinga, La Laura / Malenga",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Melrose, Melrose",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC Melrose, Melrose",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Appartment Le Ravin, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Baboolall RD, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bocage, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bois Cheri, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bon Air(+ villa road), Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Samy, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chantenay, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Mahatma Gandhi, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80809",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Telfair, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80810",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gentilly, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80811",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gentilly Estate (new morc MDA), Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80812",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mauritius Broadcasting Corporation( M B C ), Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80813",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Moka Business Centre, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80814",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MOKA EYE HOSPITAL, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80815",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Moka Village, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80816",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bagatelle, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80817",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bega-Ebene, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80818",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bout Du Monde-Ebene, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80819",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Eureka, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80820",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Hein, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80821",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mon Desert, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80822",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mon Plaisir, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80823",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Noel, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80824",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Paratian, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80825",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mount ORY, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80826",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Pont Souillac, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80827",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Railway Square, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80828",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence Cybervillage, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80829",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Telfair, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80830",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Valory, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80831",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vinson, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80832",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bagatelle Mall, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80832",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bagatelle Mall, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80832",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bagatelle Office Park, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80833",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Martindale, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80833",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Martindale, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80834",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "MauritIus Examination Syndicate, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80834",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mauritius Examination Syndicate ( M. E. S ), Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80835",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Reduit, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80835",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Reduit, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80836",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "STATE HOUSE, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80836",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "State House, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80837",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "University Of Mauritius, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80837",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "University of Mauritius, Reduit",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80838",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Allees d'Helvetia 2, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80839",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Allees d'Helvetia 3, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80840",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Allees d'Helvetia 1, Moka",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Saint Joseph, Montagne Blanche",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Montagne Blanche, Montagne Blanche",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Sans Souci, Montagne Blanche",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Paquet, Montagne Blanche",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "80906",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sans Souci, Montagne Blanche",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Betuel, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bonne Veine, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Bonne Veine, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Padco (A.Ravaton), Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "New Road***, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Quartier Militaire, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vuillemin, Quartier Militaire",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nouvelle Decouverte, Nouvelle Decouverte",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Auguste, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chantenay, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Circonstance, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Cote D'Or, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cote d'Or VRS 1, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Helvetia, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Industrial Zone-Old Post Office, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Kendra, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "L'Agrement, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mont Fleuri, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81410",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Frangipanne Phase 2, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81411",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Frangipanne Phase 3, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81412",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc MDA circonstance, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81413",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Merrytown, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81414",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81415",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Traffic Centre, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81416",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc VRS 1, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81417",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petit Verger, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81418",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Roselyn Cottage, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81419",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Rte Bois Cheri, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81420",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SAINT PIERRE 114+162, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81421",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sites and Services, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81422",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Traffic Commercial centre, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81423",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "VIGNOL NHDC, Saint Pierre",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "DUBREUIL, Dubreuil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC DUBREUIL, Dubreuil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "RISHI DAYANAND, Dubreuil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SAMLO, Dubreuil",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Providence, Providence",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Providence, Providence",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Providencia 1, Providence",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Providencia 2, Providence",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Providencia 3, Providence",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Alma, Verdun",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC Verdun, Verdun",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "81803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Verdun, Verdun",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "82001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ripailles, Ripailles",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Tamarin, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Bambous, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Eaux Bonnes, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Geoffroy, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90105",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Ferme, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90106",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mangues Vert Doux, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90107",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mon Repos, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90108",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Eaux Bonnes, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90109",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Vaudagne, Bambous",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90110",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "LA CHAUMIERE, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Beau Songes, Cascavelle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Creoles, Cascavelle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cascavelle, Cascavelle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Xavier, Cascavelle",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carreau Eucalyptus, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Case Noyale, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite CHA, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ilot Fortier, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90305",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Multipliants, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90306",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite Riviere Noire, Case Noyale",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90401",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Madras, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90402",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Chamarel, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90403",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Vielle Cheminee, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90404",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Ville Leon, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90405",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Rouleaux, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90406",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Piton, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90407",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Societe St Denis, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90408",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ste Anne, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90409",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Terre 7 Couleurs, Chamarel",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90501",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Carriere, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90502",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Flic en Flac, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90503",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Hilton Hotel, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90504",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Pirogue, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90505",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Manguiers, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90506",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Anna 1, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90507",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Anna 2, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90508",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Bismic, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90509",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc de Chazal, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90510",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Mouettes, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90511",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Safeland 1, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90512",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Safeland 2, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90513",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Safeland 3, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90514",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Palmyre, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90515",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Residence St Jacques, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90516",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sand Hotel, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90517",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Sofitel Hotel, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90518",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Souffleurs, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90519",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Taj and Mahadhiva Hotel, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90520",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tourtereaux, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90521",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Wolmar, Flic en Flac",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90601",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Black River, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90602",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Carre D'As, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90603",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90604",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Tamarinier, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90605",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Balise, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90606",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Balise Marina, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90607",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Mivoie, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90608",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Preneuse, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90609",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tourelle View, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90610",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Les Salines/Morc. Plateau, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90611",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "London Complex, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90612",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Martello Complex, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90613",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Matala Villa, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90614",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Carlos, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90615",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Filature, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90616",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Majo, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90617",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Mont Calme, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90618",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Paul Hein, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90619",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Ramdenee, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90620",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Diocese, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90621",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Villaze, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90622",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Nautica Complex, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90623",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Plantation Marguery, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90624",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "River view Com Centre, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90625",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Ruisseau Creole Complex, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90626",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "West Island Villa, Black River",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90701",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Croisee Chebel, Gros Cailloux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90702",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Gros Cailloux, Gros Cailloux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90703",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Domah, Gros Cailloux",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90705",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "SAINT MARTIN, Beau Bassin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90801",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp des Embrevades, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90802",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Racket (Benoit), Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90803",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Canon Casse, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90804",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Betel, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90805",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Flamboyant (NHDC), Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90806",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Goldsmith, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90807",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gros Cailloux, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90808",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Petite Riviere, Petite Riviere",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90901",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Barachois, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90902",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cap Dal, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90903",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite EDC, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90904",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Padco, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90905",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Domaine Mont Calme, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90906",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Mivoie, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90907",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Tourelle, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90908",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Black Rock, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90909",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Mont Calme, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90910",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Carlos, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90911",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Corail, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90912",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Investors, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90913",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Le Domain, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90914",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Les Alizees, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90915",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Les Salines, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90916",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Salt Pan, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90917",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. La Falaise, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90918",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. St. Benoit, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90919",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc. Verojan, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90920",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "NHDC, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90921",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tamarin, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "90922",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Tamarin Golf, Tamarin",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91001",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Albion, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91002",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Camp Creoles, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91003",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Croisette, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91004",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Beerjeeraz, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91005",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc de Chazal, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91006",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Raffray, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91007",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Terre Albion, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91008",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Splendid View, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91009",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Splendid Village, Albion",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91101",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Coteau Raffin, La Gaulette",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91102",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Gaulette, La Gaulette",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91103",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Desveaux, La Gaulette",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91104",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc La Fleche, La Gaulette",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91201",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Dilo Pourie, Le Morne",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91202",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Morne Brabant, Le Morne",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91203",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Le Morne Village, Le Morne",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91204",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "La Prairie, Le Morne",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91205",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Morc Gambien, Le Morne",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91301",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Allee Tamarin, Richelieu",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91302",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Cite Richelieu, Richelieu",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91303",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Platform, Richelieu",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  },
+  {
+    "code": "91304",
+    "country_id": 140,
+    "country_code": "MU",
+    "locality_name": "Richelieu, Richelieu",
+    "type": "full",
+    "source": "mauritius-post-via-Samimveza"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 1,874 Mauritius postcodes from Mauritius Post's city/sublocality
catalogue, sourced from the ``Samimveza/mauritius_postal_code`` mirror.

- **Coverage**: country-only by design.
- **Granularity**: sublocality level — one record per
  ``(5-digit code, sublocality + city)`` pair.

## Why country-only

The source's hierarchy is keyed by 144 cities; CSC's ``states.json``
carries 12 districts/dependencies. Mapping the cities to districts
would need a hand-curated 144-entry crosswalk and is left for a
follow-up.

## Source & licence

- Source URL: https://raw.githubusercontent.com/Samimveza/mauritius_postal_code/master/city-sublocality.json
- Origin: Mauritius Post publicly published index, redistributed by
  Samimveza.
- Each row: ``"source": "mauritius-post-via-Samimveza"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 1,874 codes match ``country.postal_code_regex`` (``^(\d{5})$``).
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + country FK).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)