### PR TITLE
feat(postcodes/MZ): bulk-import 161 Mozambique postcodes via Correios de Moçambique (#1039)

### DIFF
--- a/bin/scripts/sync/import_mozambique_postcodes.py
+++ b/bin/scripts/sync/import_mozambique_postcodes.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Mozambique -> contributions/postcodes/MZ.json importer for #1039.
+
+Source data
+-----------
+The community ``PauloPhagula/cep`` repository ships Correios de
+Moçambique's CEP catalogue keyed by province / district /
+"posto administrativo":
+
+    Província, Código de Província, Distrito, Código de Distrito,
+    Posto administrativo, Código de Posto Administrativo, CEP
+    Cidade de Maputo, 01, Distrito KaMpfumo, 01, Alto Maé A, 01, 0101-01
+
+Source URL: https://raw.githubusercontent.com/PauloPhagula/cep/master/cep.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Strips the administrative ``-NN`` suffix to obtain the canonical
+   4-digit CEP form (province+district) expected by the country
+   regex ``^(\\d{4})$``.
+3. Resolves ``state_id`` via case-insensitive name match against
+   ``states.json`` with a 2-entry STATE_ALIASES bridge for the
+   "Cidade de Maputo" -> Maputo city (``MPM``) and "Maputo Província"
+   -> Maputo province (``L``) split.
+4. Dedupes at (canonical CEP, district) so 555 source rows collapse
+   to ~161 distinct 4-digit codes.
+5. Writes contributions/postcodes/MZ.json idempotently.
+
+License & attribution
+---------------------
+- Source: PauloPhagula/cep (open redistribution of Correios de
+  Moçambique's publicly published CEP catalogue).
+- Each row: ``source: "correios-mocambique-via-PauloPhagula"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_mozambique_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/PauloPhagula/cep/master/cep.csv"
+)
+
+# Source province (lowercased) -> CSC states.json "name"
+STATE_ALIASES: Dict[str, str] = {
+    "cidade de maputo": "Maputo",       # CSC carries two "Maputo" entries (MPM city, L province)
+    "maputo provincia": "Maputo",       # ASCII-folded form
+    "maputo província": "Maputo",       # raw source form
+    "zambezia": "Zambezia",
+}
+
+# When two CSC entries share the same name, prefer this iso2 by source label.
+SOURCE_TO_ISO2: Dict[str, str] = {
+    "cidade de maputo": "MPM",
+    "maputo provincia": "L",
+    "maputo província": "L",
+}
+
+
+def _fold(value: str) -> str:
+    s = "".join(
+        c for c in unicodedata.normalize("NFKD", (value or "").lower())
+        if not unicodedata.combining(c)
+    )
+    return s.strip()
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    mz_country = next((c for c in countries if c.get("iso2") == "MZ"), None)
+    if mz_country is None:
+        print("ERROR: MZ not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(mz_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    mz_states = [s for s in states if s.get("country_id") == mz_country["id"]]
+    state_by_iso2: Dict[str, dict] = {(s.get("iso2") or "").upper(): s for s in mz_states if s.get("iso2")}
+    state_by_fold: Dict[str, dict] = {_fold(s["name"]): s for s in mz_states}
+    print(f"Country: Mozambique (id={mz_country['id']}); states indexed: {len(mz_states)}")
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        raw = (row.get("CEP") or "").strip()
+        if not raw:
+            continue
+        # Canonical 4-digit form is the part before the "-".
+        code = raw.split("-")[0].strip()
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        province_raw = (row.get("Província") or row.get("Provincia") or "").strip()
+        district = (row.get("Distrito") or "").strip()
+        key = (code, district.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(mz_country["id"]),
+            "country_code": "MZ",
+        }
+        prov_fold = _fold(province_raw)
+        # Disambiguate the duplicate "Maputo" CSC names via SOURCE_TO_ISO2
+        forced_iso2 = SOURCE_TO_ISO2.get(prov_fold)
+        state = None
+        if forced_iso2:
+            state = state_by_iso2.get(forced_iso2)
+        if state is None:
+            target_name = STATE_ALIASES.get(prov_fold, province_raw)
+            state = state_by_fold.get(_fold(target_name))
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if district:
+            record["locality_name"] = district
+        record["type"] = "full"
+        record["source"] = "correios-mocambique-via-PauloPhagula"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/MZ.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/MZ.json
+++ b/contributions/postcodes/MZ.json
@@ -5,7 +5,7 @@
     "country_code": "MZ",
     "state_id": 3335,
     "state_code": "MPM",
-    "locality_name": "Distrito KaMpfumo",
+    "locality_name": "KaMpfumo",
     "type": "full",
     "source": "correios-mocambique-via-PauloPhagula"
   },

--- a/contributions/postcodes/MZ.json
+++ b/contributions/postcodes/MZ.json
@@ -1,0 +1,1612 @@
+[
+  {
+    "code": "0101",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "Distrito KaMpfumo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0102",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "Nhlamankulu",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0103",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "KaMaxakeni",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0104",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "KaMavota",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0105",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "KaMubukwana",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0106",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "KaTembe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0107",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3335,
+    "state_code": "MPM",
+    "locality_name": "KaNyaka",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0201",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Matutuíne",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0202",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Namaacha",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0203",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Boane",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0204",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Matola",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0205",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Marracuene",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0206",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Moamba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0207",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Manhiça",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0208",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3332,
+    "state_code": "L",
+    "locality_name": "Magude",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0301",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Chongoene",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0302",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Xai-Xai",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0303",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Limpopo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0304",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Bilene",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0305",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Mandlakazi",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0306",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Chibuto",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0307",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Chókwè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0308",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Guijá",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0309",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Chigubo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0310",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Mabalane",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0311",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Massingir",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0312",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Mapai",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0313",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Chicualacuala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0314",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3329,
+    "state_code": "G",
+    "locality_name": "Massangena",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0401",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Zavala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0402",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Inharrime",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0403",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Jangamo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0404",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Inhambane",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0405",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Maxixe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0406",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Homoíne",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0407",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Panda",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0408",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Morrumbene",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0409",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Massinga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0410",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Funhalouro",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0411",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Vilankulo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0412",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Mabote",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0413",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Inhassoro",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0414",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3330,
+    "state_code": "I",
+    "locality_name": "Govuro",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0501",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Machanga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0502",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Búzi",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0503",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Chibabava",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0504",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Beira",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0505",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Dondo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0506",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Nhamatanda",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0507",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Muanza",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0508",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Gorongosa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0509",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Marromeu",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0510",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Cheringoma",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0511",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Caia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0512",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Marínguè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0513",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3331,
+    "state_code": "S",
+    "locality_name": "Chemba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0601",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Machaze",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0602",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Mossurize",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0603",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Sussundenga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0604",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Macate",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0605",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Gondola",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0606",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Chimoio",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0607",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Vanduzi",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0608",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Manica",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0609",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Macossa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0610",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Báruè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0611",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Tambara",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0612",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3337,
+    "state_code": "B",
+    "locality_name": "Guro",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0701",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Mutarara",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0702",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Dôa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0703",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Changara",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0704",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Moatize",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0705",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Tete",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0706",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Marara",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0707",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Cahora-Bassa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0708",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Mágoè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0709",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Tsangano",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0710",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Chiúta",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0711",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Marávia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0712",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Zumbu",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0713",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Angónia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0714",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Macanga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0715",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3334,
+    "state_code": "T",
+    "locality_name": "Chifunde",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0801",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Chinde",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0802",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Luabo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0803",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Inhassunge",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0804",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Quelimane",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0805",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Mopeia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0806",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Namacurra",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0807",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Nicoadala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0808",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Maganja da Costa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0809",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Mocubela",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0810",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Mocuba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0811",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Derre",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0812",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Morrumbala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0813",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Pebane",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0814",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Mulevala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0815",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Lugela",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0816",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Milange",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0817",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Gilé",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0818",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Alto Mulócuè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0819",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Ile",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0820",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Namarrói",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0821",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Molumbo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0822",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3328,
+    "state_code": "Q",
+    "locality_name": "Guruè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0901",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Moma",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0902",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Larde",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0903",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Angoche",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0904",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Mogovolas",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0905",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Murrupula",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0906",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Liúpo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0907",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Mogincual",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0908",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Meconta",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0909",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Nampula",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0910",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Rapele",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0911",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Ribáuè",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0912",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Malema",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0913",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Ilha de Moçambique",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0914",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Mossuril",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0915",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Monapo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0916",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Muecate",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0917",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Mecubúri",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0918",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Lalaua",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0919",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Nacala",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0920",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Nacava-a-Velha",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0921",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Nacarôa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0922",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Memba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "0923",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3336,
+    "state_code": "N",
+    "locality_name": "Eráti",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1001",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Mecufi",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1002",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Chiúre",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1003",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Namuno",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1004",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Balama",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1005",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Pemba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1006",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Metuge",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1007",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Ancuabe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1008",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Quissanga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1009",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Ibo",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1010",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Meluco",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1011",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Montepuez",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1012",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Macomoia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1013",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Mauidumbe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1014",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Mocímboa da Praia",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1015",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Mueda",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1016",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Palma",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1017",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3327,
+    "state_code": "P",
+    "locality_name": "Nangade",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1101",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Cuamba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1102",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Mecanhelas",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1103",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Metarica",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1104",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Mandimba",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1105",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Nipepe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1106",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Maúa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1107",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Marrupa",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1108",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Majune",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1109",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Ngaúma",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1110",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Chimbunila",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1111",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Lichinga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1112",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Mecula",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1113",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Mavago",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1114",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Muembe",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1115",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Sanga",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  },
+  {
+    "code": "1116",
+    "country_id": 150,
+    "country_code": "MZ",
+    "state_id": 3333,
+    "state_code": "A",
+    "locality_name": "Lago",
+    "type": "full",
+    "source": "correios-mocambique-via-PauloPhagula"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 161 Mozambique postcodes spanning all 11 provinces, sourced from
the ``PauloPhagula/cep`` CSV mirror of Correios de Moçambique's CEP
catalogue.

- **Coverage**: 100% province resolution.
- **Granularity**: district level — one record per
  ``(4-digit CEP, district)`` pair, deduped from 555 source
  ``posto administrativo`` rows.

## How it works

- Source ships codes as ``NNNN-NN`` where the trailing ``-NN`` is an
  administrative suffix; the importer strips it to recover the
  canonical 4-digit CEP expected by the country regex ``^(\d{4})$``.
- A 2-entry ``SOURCE_TO_ISO2`` disambiguator handles the two CSC
  states that share the name "Maputo": ``Cidade de Maputo`` -> MPM
  (city), ``Maputo Província`` -> L (province).

## Source & licence

- Source URL: https://raw.githubusercontent.com/PauloPhagula/cep/master/cep.csv
- Origin: Correios de Moçambique publicly published catalogue,
  redistributed by PauloPhagula.
- Each row: ``"source": "correios-mocambique-via-PauloPhagula"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 161 codes match ``country.postal_code_regex`` (``^(\d{4})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 150``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)