### PR TITLE
feat(postcodes/MG): bulk-import 111 Madagascar postcodes via Paositra Malagasy (#1039)

### DIFF
--- a/bin/scripts/sync/import_madagascar_postcodes.py
+++ b/bin/scripts/sync/import_madagascar_postcodes.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Madagascar -> contributions/postcodes/MG.json importer for #1039.
+
+Source data
+-----------
+The community ``rasolofonirina/zip-code-madagascar`` repository ships
+Paositra Malagasy's catalogue keyed by province / region / district:
+
+    [{"province": "Antananarivo", "region": "Analamanga",
+      "district": "Antananarivo-Renivohitra", "zip_code": 101}, ...]
+
+Source URL: https://raw.githubusercontent.com/rasolofonirina/zip-code-madagascar/master/zipcode.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Resolves ``state_id`` via case-insensitive name match against
+   ``states.json`` for the 6 historical provinces (CSC's iso2s
+   A/D/F/M/T/U).
+3. Pads codes to the 3-digit canonical form.
+4. Writes contributions/postcodes/MG.json idempotently.
+
+License & attribution
+---------------------
+- Source: rasolofonirina/zip-code-madagascar (open redistribution of
+  Paositra Malagasy's publicly published index).
+- Each row: ``source: "paositra-malagasy-via-rasolofonirina"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_madagascar_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/rasolofonirina/zip-code-madagascar/"
+    "master/zipcode.json"
+)
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    rows = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    mg_country = next((c for c in countries if c.get("iso2") == "MG"), None)
+    if mg_country is None:
+        print("ERROR: MG not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(mg_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    mg_states = [s for s in states if s.get("country_id") == mg_country["id"]]
+    state_by_name: Dict[str, dict] = {s["name"].lower(): s for s in mg_states}
+    print(f"Country: Madagascar (id={mg_country['id']}); states indexed: {len(mg_states)}")
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        raw = row.get("zip_code")
+        if raw is None:
+            continue
+        code = str(raw).strip().zfill(3)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        province = (row.get("province") or "").strip()
+        district = (row.get("district") or "").strip()
+        region = (row.get("region") or "").strip()
+        locality = ", ".join(p for p in (district, region) if p)
+        key = (code, district.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(mg_country["id"]),
+            "country_code": "MG",
+        }
+        state = state_by_name.get(province.lower())
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "paositra-malagasy-via-rasolofonirina"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/MG.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/MG.json
+++ b/contributions/postcodes/MG.json
@@ -1,0 +1,1112 @@
+[
+  {
+    "code": "101",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antananarivo-Renivohitra, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "102",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antananarivo-Atsimondrano, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "103",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antananarivo-Avaradrano, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "104",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Ambatolampy, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "105",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Ambohidratrimo, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "106",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Andramasina, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "107",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Anjozorobe, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "108",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Ankazobe, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "109",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antanifotsy, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "110",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antsirabe-I, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "111",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Antsirabe-II, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "112",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Arivonimamo, Itasy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "113",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Betafo, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "114",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Faratsiho, Vakinankaratra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "115",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Fenoarivo, Bongolava",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "116",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Manjakandriana, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "117",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Miarinarivo, Itasy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "118",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Soavinandriana, Itasy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "119",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2951,
+    "state_code": "T",
+    "locality_name": "Tsiroanomandidy, Analamanga",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "201",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Antsiranana-I, Diana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "202",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Antsiranana-II, Diana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "203",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Ambanja, Diana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "204",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Ambilobe, Diana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "205",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Andapa, Sava",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "206",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Antalaha, Sava",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "207",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Nosy-Be, Diana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "208",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Sambava, Sava",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "209",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2950,
+    "state_code": "D",
+    "locality_name": "Vohimarina, Sava",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "301",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Fianarantsoa-I, Haute-Matsiatra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "302",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Fianarantsoa-II, Haute-Matsiatra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "303",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ambalavao, Haute-Matsiatra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "304",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ambatofinandrahana, Amoron'i Mania",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "305",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ambohimahasoa, Haute-Matsiatra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "306",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ambositra, Amoron'i Mania",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "307",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Befotaka, Atsimo-Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "308",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Fandriana, Amoron'i Mania",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "309",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Farafangana, Atsimo-Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "310",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ikongo, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "311",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Iakora, Ihorombe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "312",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ifanadiana, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "313",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ihosy, Ihorombe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "314",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ikalamavony, Haute-Matsiatra",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "315",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Ivohibe, Ihorombe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "316",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Manakara, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "317",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Mananjary, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "318",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Midongy-Atsimo, Atsimo-Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "319",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Nosy-Varika, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "320",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Vangaindrano, Atsimo-Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "321",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Vohipeno, Vatovavy-Fitovinany",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "322",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Vondrozo, Atsimo-Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "323",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2948,
+    "state_code": "F",
+    "locality_name": "Manandriana, Amoron'i Mania",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "401",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Mahajanga-I, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "402",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Mahajanga-II, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "403",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Ambato-Boeny, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "404",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Ambatomainty, Melaky",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "405",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Analalava, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "406",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Antsalova, Melaky",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "407",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Antsihihy, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "408",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Bealanana, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "409",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Befandriana-Avaratra, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "410",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Besalampy, Melaky",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "411",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Kandreho, Betsiboka",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "412",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Maevatanana, Betsiboka",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "413",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Maintirano, Melaky",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "414",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Mampikony, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "415",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Mandritsara, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "416",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Marovoay, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "417",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Mitsinjo, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "418",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Morafanobe, Melaky",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "419",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Port-Bergé, Sofia",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "420",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Soalala, Boeny",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "421",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2953,
+    "state_code": "M",
+    "locality_name": "Tsaratanana, Betsiboka",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "501",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Toamasina-I, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "502",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Toamasina-II, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "503",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Ambatondrazaka, Alaotra-Mangoro",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "504",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Amparafaravola, Alaotra-Mangoro",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "505",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Andilamena, Alaotra-Mangoro",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "506",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Anosibe, Alaotra-Mangoro",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "507",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Antanambao-Manampotsy, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "508",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Ampasimanolotra, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "509",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Fenoarivo-Atsinanana, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "510",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Mahanoro, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "511",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Mananara, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "512",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Maroansetra, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "513",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Marolambo, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "514",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Moramanga, Alaotra-Mangoro",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "515",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Sainte-Marie, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "516",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Soanierana-Ivongo, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "517",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Vatomandry, Atsinanana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "518",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2952,
+    "state_code": "A",
+    "locality_name": "Vavatenina, Analanjirofo",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "601",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Toliara-I, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "602",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Toliara-II, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "603",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Amboasary-Atsimo, Anosy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "604",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Ambovombe-Androy, Androy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "605",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Ampanihy, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "606",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Ankazoabo-Atsimo, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "607",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Bekily, Androy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "608",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Belo-sur-Tsiribihina, Menabe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "609",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Beloha, Androy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "610",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Benenitra, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "611",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Beroroha, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "612",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Betioky-Atsimo, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "613",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Betroka, Anosy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "614",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Taolanaro, Anosy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "615",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Mahabo, Menabe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "616",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Manja, Menabe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "617",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Miandrivazo, Menabe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "618",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Morombe, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "619",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Morondava, Menabe",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "620",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Sakaraha, Atsimo-Andrefana",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  },
+  {
+    "code": "621",
+    "country_id": 130,
+    "country_code": "MG",
+    "state_id": 2949,
+    "state_code": "U",
+    "locality_name": "Tsiombe, Androy",
+    "type": "full",
+    "source": "paositra-malagasy-via-rasolofonirina"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 111 Madagascar postcodes spanning all 6 historical provinces,
sourced from the ``rasolofonirina/zip-code-madagascar`` mirror of
Paositra Malagasy's 3-digit catalogue.

- **Coverage**: 100% province resolution (6/6 in states.json).
- **Granularity**: district level — one record per
  ``(3-digit code, district + region)`` pair.

## Source & licence

- Source URL: https://raw.githubusercontent.com/rasolofonirina/zip-code-madagascar/master/zipcode.json
- Origin: Paositra Malagasy publicly published catalogue,
  redistributed by rasolofonirina.
- Each row: ``"source": "paositra-malagasy-via-rasolofonirina"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 111 codes match ``country.postal_code_regex`` (``^(\d{3})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 130``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)