### PR TITLE
feat(postcodes/VE): bulk-import 1,187 Venezuela postcodes via IPOSTEL (#1039)

### DIFF
--- a/bin/scripts/sync/import_venezuela_postcodes.py
+++ b/bin/scripts/sync/import_venezuela_postcodes.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Venezuela -> contributions/postcodes/VE.json importer for #1039.
+
+Source data
+-----------
+The community ``JhonnelN/codigos_postales_venezuela`` repository
+ships IPOSTEL's catalogue keyed by estado / zona / postcode / city:
+
+    estado, zona, codigo_postal, ciudad
+    Anzoategui, Anaco, 6003, Anaco
+
+Source URL: https://raw.githubusercontent.com/JhonnelN/codigos_postales_venezuela/master/codigos_postales.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Resolves ``state_id`` via ASCII-fold name match against
+   ``states.json`` with a 1-entry STATE_ALIASES bridge for the 2019
+   "Vargas" -> "La Guaira" rename.
+3. Pads codes to the 4-digit canonical form.
+4. Writes contributions/postcodes/VE.json idempotently.
+
+License & attribution
+---------------------
+- Source: JhonnelN/codigos_postales_venezuela (open redistribution
+  of IPOSTEL's publicly published index).
+- Each row: ``source: "ipostel-via-JhonnelN"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_venezuela_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/JhonnelN/codigos_postales_venezuela/"
+    "master/codigos_postales.csv"
+)
+
+# Source estado (ASCII-folded) -> CSC states.json "name"
+STATE_ALIASES: Dict[str, str] = {
+    "vargas": "La Guaira",  # 2019 rename
+}
+
+
+def _fold(value: str) -> str:
+    s = "".join(
+        c for c in unicodedata.normalize("NFKD", (value or "").lower())
+        if not unicodedata.combining(c)
+    )
+    return s.strip()
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    ve_country = next((c for c in countries if c.get("iso2") == "VE"), None)
+    if ve_country is None:
+        print("ERROR: VE not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(ve_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    ve_states = [s for s in states if s.get("country_id") == ve_country["id"]]
+    state_by_fold: Dict[str, dict] = {_fold(s["name"]): s for s in ve_states}
+    print(f"Country: Venezuela (id={ve_country['id']}); states indexed: {len(ve_states)}")
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for row in rows:
+        code = (row.get("codigo_postal") or "").strip().zfill(4)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        estado = (row.get("estado") or "").strip()
+        ciudad = (row.get("ciudad") or "").strip()
+        zona = (row.get("zona") or "").strip()
+        locality = ciudad or zona
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(ve_country["id"]),
+            "country_code": "VE",
+        }
+        target_estado = STATE_ALIASES.get(_fold(estado), estado)
+        state = state_by_fold.get(_fold(target_estado))
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        else:
+            skipped_no_state += 1
+
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "ipostel-via-JhonnelN"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/VE.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/VE.json
+++ b/contributions/postcodes/VE.json
@@ -1,0 +1,11872 @@
+[
+  {
+    "code": "0002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Bello Monte 1",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "0002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Bucares 1",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "0002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Mendoza 1",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1000",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Parate Bueno",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1000",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Unidos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1000",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio El Manguito San Agustin del Sur",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Los Cujicitos San Jose",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Puerta de Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Sabana Del Blanco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Sabana de Blanco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Buenos Aires El Paraiso",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio El Triángulo La Vega",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Los Cujicitos La Vega",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio San Miguel Cota 905",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio San Rafael o Sucre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio Unión",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Otras Poblaciones o Sectores",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio El Carmen Catia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Los Frailes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Los Higitos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio Niño Jesús",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Plan de Manzano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Ruperto Lugo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Simon Bolívar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Ciudad Tablita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Colonia Tovar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "El Junquito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Los Magallanes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Propatria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Vista Al Mar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio El Triángulo El Cementerio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Providencia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio San Andrés",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Zamora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Quebrada Honda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1053",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1060",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio La Cruz Chacao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1060",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Centro Comercial Plaza Las Americas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Plaza las Américas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Santa Paula",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Santa Rosa de Lima",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Sector Los Naranjos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1064",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1064",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Chuao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1071",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1071",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "El Marqués",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1071",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Los Chorros",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1071",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Sebucán",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Buenos Aires Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Caucagüita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio El Carmen Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio El Manguito Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio La Cruz Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio San Blas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio San Miguel Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio San Pascual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Barrio Valle Fresco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Petare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1073",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Blas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1080",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio El Carmen Minas de Baruta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1080",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1080",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Los Samanes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1080",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Prados del Este",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1080",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Santa Gertrudis",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1083",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1083",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "La Tahona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1083",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Lomas de la Lagunita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1086",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "U.S.B.",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1090",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1090",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "El Valle",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1160",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Anare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1160",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Camuri Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1160",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "La Guaira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Catia La Mar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Chichiriviche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Las Salinas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Marapa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Oricao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Puerto Carayaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Taguao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1162",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Villa Croacia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1165",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "La Guaira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1166",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Chuspa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1166",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "La Sabana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1166",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "Los Caracas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1168",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2055,
+    "state_code": "X",
+    "locality_name": "La Guaira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Llanos de Miquillen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Los Teques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1203",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Carrizal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Antonio de los Altos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Diego de los Altos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San José de los Altos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Pedro de los Altos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Colonia Mendoza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Corocito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "La Democracia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Ocumare del Tuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Quiripital",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1210",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Charallave",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1211",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Cúa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1211",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Tacata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1212",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Francisco de Yare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1214",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1215",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "San Antonio Landér",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1215",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Santa Teresa del Tuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1220",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Guarenas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1221",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Araira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1221",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Barrio El Rodeo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1221",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Guatire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1223",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Aragüita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1224",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Tapipa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1225",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Capaya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1225",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "El Café",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1226",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Panaquire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1228",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Las González",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1228",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Mamporal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1228",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Tacarigua Mamporal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1231",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Carenero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1231",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Chirimena",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1231",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Higuerote",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1232",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Birongo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1232",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Curiepe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1235",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Pueblo Nuevo Mamporal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1235",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San José de Barlovento",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1235",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San José de Río Chico",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1236",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Paparo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1236",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Río Chico",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1236",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Tacarigua de La Laguna",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1238",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Cupira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1241",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "El Clavo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1241",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Merecure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1243",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "El Guapo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1243",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "San Fernando del Guapo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1243",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4855,
+    "state_code": "A",
+    "locality_name": "Santa Barbara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1245",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Machurucuto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1246",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Caucagüa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "1246",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2037,
+    "state_code": "M",
+    "locality_name": "Chuspita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Naguanagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "3 de Mayo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Big Low Center",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Central Tacarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "El Roble",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Flor Amarilla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Flor Amarillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Industrial Carabobo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Industrial Castillito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Industrial La Quizanda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Industrial Municipal Norte",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Isabelita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "La Isabelica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Las Agüitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Cerritos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Guayos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Paraparal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Parque Valencia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Paso Real",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Piedras Negras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Vivienda Popular de los Guayos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Zona Industrial La Isabelica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Bárbula",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "La Entrada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Las Quintas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Las Trincheras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Naguanagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Santa Eduvigis",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "1º de Mayo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Bosque Serino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Campo Solo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "El Morro 1 y 2",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "La Esmeralda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Arales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Harales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Los Magallanes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Monte Serino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Pueblo de San Diego",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "San Diego",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Vivienda Rural los Arales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2006",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Yuma 1 y 2",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "El Trompillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Güigüe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Guacara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Vigirima",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Yagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2016",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Valencia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2017",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Pueblo de Maraira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2018",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "San Joaquín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2035",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Barrera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2035",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Campo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2035",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Carabobo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2035",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Tocuyito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2035",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Villa Jardín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2039",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Pueblo de Belén",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Bejuma",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2040",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Canoabo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2041",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Miranda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2041",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Valle de Aguirre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2042",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Montalban",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Chirgua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Base Naval",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "El Cambur",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "El Palito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Goaigoaza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "La Hoya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "La Sorpresa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Puerto Cabello",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Punto Nutria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Rancho Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Taborda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2051",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Morón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2051",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Urama",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2052",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Boca de Aroa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2053",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Boca de Tocuyo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2053",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Tocuyo de La Costa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Chichiriviche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San Juan de Los Cayos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2055",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2040,
+    "state_code": "G",
+    "locality_name": "Tucacas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Tapatapa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2103",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2104",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "12 de Febrero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2104",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2105",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "El Limón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2105",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "10 de Diciembre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "19 de Abril",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "19 de Abril Maracay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Choroní",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Cuyagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Ocumare de La Costa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2113",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Puerto Colombia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2114",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Ocumare de La Costa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2115",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Turmero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2116",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Turmero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2117",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Ezequiel Zamora Palo Negro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2117",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Palo Negro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "5 de Julio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "El Consejo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2119",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Tejerias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2119",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Tejerías",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2120",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "San Mateo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2120",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Zamora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2121",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "La Victoria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2122",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Cagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2122",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Ocumare de La Costa - Cagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2122",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Yarabi",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2122",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Yarabí",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2123",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2123",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Villa Zuica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2125",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "San Francisco de Asís",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2126",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Tucutunemo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2126",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Villa de Cura",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2127",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Zuata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2128",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Magdaleno",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Agua Linda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Apartaderos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Arismendi",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Cojeditos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Guadarrama",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2203",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "La Sierra",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2203",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Manrique",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Las Vegas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2206",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "La Aguadita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Macapo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Vallecito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Cojedes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Tinaquillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2213",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Arismendi",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2213",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "El Baúl",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2213",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Guadarrama",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2214",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "El Pao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2216",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "El Amparo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2216",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "Libertad de Cojedes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Aragua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Barbacoas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Cambural de Cataure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Cazorla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Corozopando",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Dos Caminos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Caro de La Negra",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Corozo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Palito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Punzón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Espino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Francisco de Tiznado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Guaripa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Ipare de Orituco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "La Arboleda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "La Esperanza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Las Minas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Lezama",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Libertad de Orituco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Los Pozotes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Mamonal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Parapara de Ortíz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Paso Real de Macaira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Pirital",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Roblecito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Sabana Grande de Orituco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Francisco de Cara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Francisco de Macaira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San José de Anare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San José de Guaribe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Juan de los Morros",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Rafael de Laya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Rafael de Orituco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Santa Rita de Manapire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Taguay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Tucupido",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2302",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Ortíz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2303",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Calvario",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2304",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Rastro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2305",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San José de Tiznados",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2311",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Carmen de Cura",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2312",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Calabozo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2312",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "La Unión",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2316",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Guardatinaja",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2319",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Sombrero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2320",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Altagracia de Orituco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2332",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Zaraza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2334",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Barbacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2335",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Camatagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2335",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Carmen de Cura",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2335",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "San Francisco de Cara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2335",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Taguay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2338",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Guiripa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2338",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "San Casimiro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2338",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "Valle Morin",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2340",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2047,
+    "state_code": "D",
+    "locality_name": "San Sebastian",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2340",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Sebastián",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Chaparro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Valle La Pascua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2351",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "San Jose Unare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2354",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Santa María de Ipire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2355",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "El Socorro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2356",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Las Mercedes del Llano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "2358",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Chaguaramas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Barquisimeto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Basarida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Casa de Agua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Las Casitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Moran",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Moroturo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3004",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Bobare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3004",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Matatere",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3009",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Río Claro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "La Miel",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Sarare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3016",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Quibor",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3023",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Cabudare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3023",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Los Rastrojos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3025",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Duaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3028",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Sanare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3031",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Aguada Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Siquisique",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "El Porvenir",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "La Vega",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Las Guabinas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Moyetones",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Urucure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3034",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Baragua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Agua Salada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Arenales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Atarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Barbacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Bocare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Burere",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Carora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Guadalupe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "La Pastora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Los Yabos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Puricaure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "San Pablo de Lara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3051",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Cariragua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3052",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Aregue",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Río Tocuyo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3055",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3056",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "San Pedro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3057",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Guárico",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3058",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Humocaro Alto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3058",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Humocaro Bajo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3059",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Villa Nueva",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3060",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "El Empedrado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3060",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Pie de Cuesta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3061",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Quibor",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3063",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Cubiro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Agua Santa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Agua Viva",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Arapuey",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Boscán",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "El Batatal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Batey",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "El Cenizo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "El Socorro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Cuchilla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Mulata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Plazuelita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Unión",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Las Mesitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Nueva Bolivia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Quebrada Arriba",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Sabana Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "San Cristobal De Torondoy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San José de Palmira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Juan de Betijoque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Miguel De Bocono",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Rafael de Carvajal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Santa Apolonia De Merida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santiago",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Torondoy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Tostos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Valera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Valera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3103",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Boconó",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3103",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Rafael de Boconó",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3104",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Betijoque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3105",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "El Alto Escuque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3105",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Escuque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Valera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Dividive",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3108",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Ceiba",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3109",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Isnotú",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Sabana de Mendoza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Chachopo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Timotes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3113",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santa Isabel",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3115",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Burbusay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3116",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Campo Elías",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Niquitao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3119",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3122",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Mendoza Fría",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3123",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Carache",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3124",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Chejende",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3125",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Cuicas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3127",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santa Apolonia de Trujillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3128",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Miton",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3129",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Torococo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3132",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Altos de Estanque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3133",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Cristóbal de Torondoy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3134",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Monte Carmelo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3135",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Sabana Libre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3136",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santa Apolonia de Mérida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3137",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Capazón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3137",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Caño Zancudo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3140",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Motatán",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3141",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Las Virtudes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3141",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Nueva Bolivia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3141",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Punto Palmarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Jajó",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3146",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Mesa de Esnujaque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3147",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Quebrada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3149",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Cejita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Casco Central",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Concepción De Carache",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Concepción De Pampanito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "La Plazuela",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Trujillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3151",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Pampan",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3152",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Pampanito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3153",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Monay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3154",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "San Lázaro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3156",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3157",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Bolivia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3158",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Bobures",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3158",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Nueva Bolivia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3164",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2043,
+    "state_code": "T",
+    "locality_name": "Mérida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Agua Negra",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Boraure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Corocote",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "El Caserío de Carabobo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "El Cedrito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "El Guayabo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Hato Viejo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Independencia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Las Rositas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "San Felipe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "San Pablo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Taria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Temerla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Urachiche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Yumare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3202",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Chivacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3203",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Yaritagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3205",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Nirgua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3206",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Marín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Guama",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Campo Elías",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3210",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Aroa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3211",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Sabana de Parra",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3214",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Salom",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3222",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2041,
+    "state_code": "U",
+    "locality_name": "Farriar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Acarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "La Misión",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3302",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Agua Blanca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3303",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Araure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3304",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Acarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3305",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Píritu",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3306",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "San Rafael de Onoto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3307",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Santa Rosalía de Turen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3309",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "El Poblado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3309",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Los Colorados",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3309",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Turen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3309",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Villa Bruzual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3317",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Colonia Tunén",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Aparición",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Guanare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "La Trinidad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Los Morrones",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Mesa de Caruaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3350",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Unellez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3351",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Biscucuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3352",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "La Estación",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3352",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Ospino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3353",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Papelón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3354",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Guanarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3354",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "La Concepción",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3355",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Boconoito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3357",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Chabasquén",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3357",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Córdoba",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "3357",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2036,
+    "state_code": "P",
+    "locality_name": "Paraiso De Chabasquen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barrio El Calvario",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barrio La Pomona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barrio Libertad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barrio de Estanques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Ceuta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Carmelo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Cinco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Consejo De Siruma",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Guanabano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El LLano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Moralito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Siete",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "La Cañada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Las Delicias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Los Teques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Maracaibo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Palmarejo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Maracaibo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4004",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Maracaibo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Maracaibo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Monte Claro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Residencia San Luis",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4011",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Universidad del Zulia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4012",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Aeropuerto La Chinita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4013",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Cabimas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4013",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Punta Gorda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4014",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Bachaquero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Machango",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Mene Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4016",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Lagunillas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4017",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Tía Juana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4018",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San Timoteo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4019",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Ciudad Ojeda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4019",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Las Morochas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4019",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Pica Pica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barranca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Mene",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Puerto Escondido",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Santa Rita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Calle Larga",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Machiques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Macoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San Jose De Perija",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San José",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Venado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4031",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Isla de Toas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Campos Petroleros",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Concepción",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Laberinto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Laberinto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Maracaibo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4036",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Tablazo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4036",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Los Puertos de Altagracia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4036",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Quisiro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Carretal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Cojoro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Cojua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Guarero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Paraguaipoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4041",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San Lorenzo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4043",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San Rafael de Machiques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Campo Mara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Carrasquero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Mojan",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Isla de San Carlos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "La Rosita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4044",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Las Cruces",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4045",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Santa Cruz de Mara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4046",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Sinamaica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4047",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Alturitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4047",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Barranquitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4047",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Los Haticos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4047",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "San Ignacio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4047",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Villa del Rosario",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Acurigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Agua Larga",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Agua Salada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Aguide",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Amuay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Aracua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Bariro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Boca de Mangle",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Boca de Tocuyo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Cabure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Capadare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Casigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Coro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Corralito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Curamichate",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Curarí",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Curimagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "El Charal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "El Menen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "El Vinculo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Guaibacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Jadacaquiva",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Chapa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Negrita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Pastora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Tabla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Taza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Lizardo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Mancillar de La Costa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Mataruca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Mitare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pecaya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pueblo Cumarebo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pueblo Nuevo de La Sierra",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pureche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San José de Bruzual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San José de Seque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San Lorenzo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San Miguel de Macoruca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Santa Cruz de Bucaral",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Tocopero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Tocumo de La Rosita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Tupure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Urumaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Zazarida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Adaure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Agua Clara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Baraived",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "El Duvisí",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Punto Fijo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4103",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Píritu",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4104",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Maparari",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4109",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Agua Linda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Jácura",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Mirimire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4114",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Cruz de Taratara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4117",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Mene Mauroa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Borojó",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Capatárida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4118",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Dabajuro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4132",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "La Vela de Coro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4136",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Piedra Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4137",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pedregal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Caja de Agua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Pueblo Nuevo de Paraguaná",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4152",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Churuguara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4154",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Punto Fijo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "4167",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2035,
+    "state_code": "I",
+    "locality_name": "Puerto Cumarebo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Batatal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Corozo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Jordan",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Helechales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Hernandez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Florida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Fundación",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Los Kioscos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Queniquea",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Cristobal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Cristóbal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Felix De Urraca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Joaquin De Navay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Josecito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Juan De Colon",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Abejales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Pedrera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Mérida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Colon",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Felix",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Pedro de Lirio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Pino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Antonio del Táchira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5009",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Independencia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5009",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Peribeca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Hato de La Virgen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Libertad del Táchira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5012",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Cordero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Palmira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5015",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Patiecito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5017",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Revancha",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5017",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Los Caneyes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5017",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Táriba",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Boca de Grita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Caño Macho",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Potosí",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Fría",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Orope",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5021",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Cobre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Grita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Llano Largo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Pueblo Encima",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Pueblo Hondo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Sabana Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5027",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Seboruco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Delicias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Las Dantas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Ramos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Rubio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Río Chiquito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5030",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Villa Páez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Pinal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Teteo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Los Naranjos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Rafael Del Piñal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5033",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Borota",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5036",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Lobatera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5037",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Michelena",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Aldea",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Coloncito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Tendida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Morotuto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Pueblo Las Hernández",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San Simón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5038",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Umuquena",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5048",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Aguas Calientes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5048",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "La Rinconada",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5048",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Nueva Arcadia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5048",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Ureña",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5051",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "San José de Bolívar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5058",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Pregonero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5062",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Amparo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5063",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Apure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5063",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Nula",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5063",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Guasdualito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5065",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "Palmarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5067",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2048,
+    "state_code": "S",
+    "locality_name": "El Cantón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5067",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Quebrada Seca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Acarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "El Guayabo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "El Morro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Encontrados",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Estanques",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2038,
+    "state_code": "K",
+    "locality_name": "Guayabones",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Humboldt",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Hechicera",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Pedregosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Vega",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Los Sauzales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Medio Cuarto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Merida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2042,
+    "state_code": "V",
+    "locality_name": "Moralito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mucujepe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mérida",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "San Jacinto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "San José",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Santa Elena de Arenales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Unión",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Azulita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5105",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mucuchachi",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mucutuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Jají",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5108",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Acequias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5111",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Ejido",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5111",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Los González",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Chocanta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Mesa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5112",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Mesa de Ejido",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5114",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Piñango",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5115",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Parroquia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5115",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Punta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5116",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Tabay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5124",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Pueblo Llano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5129",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mucuruba",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5130",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Apartaderos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5130",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mucuchies",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5130",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "San Rafael de Mucuchies",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5131",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Santo Domingo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5133",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Bailadores",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5134",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Guaraque",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5134",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mesa Quintero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5138",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Chiguara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5138",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Trampa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5138",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Lagunilla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5138",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5138",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "San Juan de Lagunilla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5141",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Mesa Bolívar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5141",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Tucani",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5142",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "El Peñón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5142",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Santa Cruz de Mora",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5143",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Playa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5143",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Tovar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5144",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Zea",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "El Vigia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Blanca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Gonzalez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Palmita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "La Playita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Libertad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5145",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Tucantocani",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5154",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2053,
+    "state_code": "L",
+    "locality_name": "Canagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Barinas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Barinitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Barrancas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Bruzual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Capitanejo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "El Cantón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "El Real",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "El Regalo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "La Luz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Maporal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Mijagual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Pedraza la Vieja",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Puerto Nutrias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Quebrada Seca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Quintero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "San Rafael de Canagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Santa Catalina",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Santa Inés",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Torunos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Veguitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5203",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Barinas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5206",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Barinitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Calderas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5208",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Altamira",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5210",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Santa Barbara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5213",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Obispos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5214",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Ciudad Bolivia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5216",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Chameta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5216",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Sacopó",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5217",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Dolores",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5219",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5220",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Libertad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5221",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Ciudad de Nutrias",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "5224",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2049,
+    "state_code": "E",
+    "locality_name": "Sabaneta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Anaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Atapirire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Barbacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Barcelona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Cachipo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Carito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Hatillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Pao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Pilar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Guaribe de Cajigal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Los Altos de Santa Fe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Mapire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Modulo de Boyacá",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Mundo Nuevo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Sabana de Uchire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San Diego de Cabrutica",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San Pablo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Santa Clara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Santa Cruz del Orinoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Santa Inés",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Uríca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Uverito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Aragua de Barcelona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "La Margarita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Anaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Los Pilones",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Boca de Uchire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Cantaura",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6008",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Clarines",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6009",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Modulo de Chuparin",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6012",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Guanape",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6014",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Guanta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6014",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Pertigalete",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6016",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Morro de Barcelona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6016",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Lecherías",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6020",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Onoto",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Puerto La Cruz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Puerto Píritu",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6022",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Píritu",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6023",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Puerto La Cruz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6027",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6032",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Valle Guanape",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6048",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San Mateo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "El Tigre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6052",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Pariaguán",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San José de Guanipa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6055",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "San Tomé",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6057",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Zuata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Caigüire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Campo Claro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Carupano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Chacopata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Cumana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "El Peñón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Las Piedras de Cocollar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Las Vegas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Los Altos De Santa fe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Muelle de Cariaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Quebrada Seca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6102",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Araya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Acarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Arenas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Cumanacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6106",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San Lorenzo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6107",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Mariguitar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6110",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San Antonio del Golfo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6123",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Altos de Sucre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6126",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Cariaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Agua Fria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Bohordal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Campearito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Carupano",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Catuaro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Cumaná",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "El Paujil",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "El Rincón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guanoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guarauna",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guaraunos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guariquen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guayana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Los Arroyos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Macuro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Nueva Colombia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Playa Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Rio Salado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Rio Seco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San Juan de Unare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San Juan de las Galdonas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Santa Cruz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Santa María de Cariaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Saucedo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Soro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Tunapuicito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Valle de San Bonifacio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6150",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Yoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6152",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "El Pilar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6154",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Tunapuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6154",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Tunapuycito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6155",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Yaguaraparo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6156",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Irapa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6156",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Maraval",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6160",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Güiria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6160",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Río Grande",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6161",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Güiria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6163",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "El Morro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6163",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Puerto Santo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6164",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Río Caribe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6167",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "San José de Aerocuar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6168",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Casanay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6168",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Guarapiche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6168",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2056,
+    "state_code": "R",
+    "locality_name": "Río Casanay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Aguasay",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Alto Guri",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Altos de los Godos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Andrés Eloy Blanco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Areo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Azagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Bajo Guarapiche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Brisas de Aribi",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Cachipo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Campo Alegre",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Carabobo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Caño Colorado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Chaguaramal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Cortijo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Furrial",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Junín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Merey",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Paraíso",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Pelón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Respiro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Zamuro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "El Zorro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Guarapiche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Guarito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Candelaria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Cruz de La Paloma",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Morrocoya",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Plantación",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Poderosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Las Alhuacas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Las Brisas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Las Palmeras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Las Pinas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Libertador",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Los Guaritos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Manreza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Maturin",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Maturín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Morichal Largo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Puerto Amador",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Punta Gorda",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Santa Elena",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Sarabria",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Tirado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Viento Colao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Vuelta Larga",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6201",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Zona Industrial",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6204",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Maturin",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6206",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Aragua de Maturín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6207",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Viento Fresco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6208",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Barrancas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6209",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Caicara de Maturín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6210",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Caripe",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6210",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Guanota",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6211",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Caripito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6213",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Punta de Mata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6214",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Guanaguana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6215",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "La Toscana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6216",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Miraflores",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6218",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Quiriquire",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6219",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Antonio de Maturín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6219",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Francisco de Maturín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6221",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Santa Bárbara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6223",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Temblador",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6224",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "Teresen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6225",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Antonio de Tabasca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6226",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2054,
+    "state_code": "N",
+    "locality_name": "San Felix de Monagas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Agua de Vaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Altagracia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Antolin del Campo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Boca del Pozo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Boquerón",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Chacachacare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Amparo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Bicha",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Espinal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Maco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Pilar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Valle de Pedro González",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "El Valle del Espíritu Santo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Guinima",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Isla de Coche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asunción",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Guardia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Isleta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Plaza de Paraguachí",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Vecindad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Las Cabreras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Las Hernández",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Las Maritas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Bagres",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Cerritos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Giles",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Gómez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Marvales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Los Millanes",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Macanao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Manzanillo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Marino",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Mariño",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Orinoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Pedregales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Pedro González",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Porlamar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Puerto Fermín",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Punta de Piedras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Robledal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Tacarigua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6301",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Villa Rosa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6304",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "Boca del Río",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6309",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6311",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6316",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6318",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6320",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "San Juan Bautista",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6321",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2052,
+    "state_code": "O",
+    "locality_name": "San Pedro de Coche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Coporito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Curiapo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "El Torito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "La Orquesta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Macareito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Piacoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Sacupana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2034,
+    "state_code": "H",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "San José de Mazareito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Santa Catalina",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Tabasca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Tucupita",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "6401",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2051,
+    "state_code": "Y",
+    "locality_name": "Uracoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Arichuna",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Camatagua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Cazorla",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Cunaviche",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "El Samán de Apure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "El Yagual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Guasimal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Guayabal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Guáchara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "La Trinidad de Orichuna",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Municipio Quintero",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Puerto Nova",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "San Fernando de Apure",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "San Juan de Payara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7002",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Achaguas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Apurito",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7004",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "San Juan de Payara",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7005",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Bruzual",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Biruaca",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Camaguán",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7010",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Mantecal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7011",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 4856,
+    "state_code": "C",
+    "locality_name": "Elorza",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "Maroa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "Puerto Ayacucho",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "Puerto Páez",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "San Carlos de Río Negro",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "San Fernando de Atabapo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "San Fernando de Guainia",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "San Juan de Manapiare",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "San Simón de Cocuy",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "7101",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2044,
+    "state_code": "Z",
+    "locality_name": "Santa Rosa de Amanadona",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Aripao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Ciudad Bolivar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Ciudad Bolívar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Cuchiberos",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Icabarú",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Kanavayen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "La Canoa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "La Paragua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "La Urbina",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Las Bonitas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Las Majadas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Las Trincheras",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Los Morichales",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Matanzas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Moitaco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Puruey",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "San Francisco de La Paragua",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "San Pedro de Las Bocas",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Santa Cruz de Orinoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Santa Rosalía",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8001",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Santa Teresa de Canavayen",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8003",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Ciudad Piar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2045,
+    "state_code": "J",
+    "locality_name": "Cabruta",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8007",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Caicara del Orinoco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8009",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Maripa",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8011",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Santa Elena de Uairén",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8013",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2050,
+    "state_code": "B",
+    "locality_name": "Soledad",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Ciudad Guayana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Dorado",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Manteco",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Miamo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Pao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Guasipati",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Jabillal",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Los Castillos de Guayana",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8050",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Puerto Ordáz",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8051",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "San Félix",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8052",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Upata",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8054",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Palmar",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8056",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "El Callao",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  },
+  {
+    "code": "8057",
+    "country_id": 239,
+    "country_code": "VE",
+    "state_id": 2039,
+    "state_code": "F",
+    "locality_name": "Tumeremo",
+    "type": "full",
+    "source": "ipostel-via-JhonnelN"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 1,187 Venezuela postcodes spanning all 24 estados, sourced from
the ``JhonnelN/codigos_postales_venezuela`` CSV mirror of IPOSTEL's
4-digit catalogue.

- **Coverage**: 100% estado resolution.
- **Granularity**: city level — one record per
  ``(4-digit code, city)`` pair, deduped from 2,447 source rows.

## How it works

ASCII-fold name match against ``states.json`` with a 1-entry
``STATE_ALIASES`` bridge for the 2019 ``Vargas`` -> ``La Guaira``
rename.

## Source & licence

- Source URL: https://raw.githubusercontent.com/JhonnelN/codigos_postales_venezuela/master/codigos_postales.csv
- Origin: IPOSTEL publicly published catalogue, redistributed by
  JhonnelN.
- Each row: ``"source": "ipostel-via-JhonnelN"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 1,187 codes match ``country.postal_code_regex`` (``^(\d{4})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 239``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)