### PR TITLE
feat(postcodes/KH): bulk-import 1,640 Cambodia postcodes via Cambodia Post + fix KH regex (#1039)

### DIFF
--- a/bin/scripts/sync/import_cambodia_postcodes.py
+++ b/bin/scripts/sync/import_cambodia_postcodes.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Cambodia -> contributions/postcodes/KH.json importer for #1039.
+
+Source data
+-----------
+The community ``seanghay/cambodia-postal-codes`` repository ships
+Cambodia Post's 2017-reform 6-digit catalogue keyed by province ->
+district -> sangkat:
+
+    [{"id": 12, "name": "រាជធានីភ្នំពេញ", "districts": [
+        {"location_en": "Khan Chamkar Mon", "codes": [
+            {"en": "Sangkat Tonle Basak", "code": "120101"}, ...]}, ...
+    ]}, ...]
+
+Source URL: https://raw.githubusercontent.com/seanghay/cambodia-postal-codes/main/cambodia-postal-codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Walks provinces -> districts -> codes; emits one record per
+   ``(6-digit code, sangkat + district)`` pair.
+3. Resolves ``state_id`` directly from the source's ``id`` field —
+   CSC's ``states.json`` already uses the same 1-25 numeric ``iso2``
+   for Cambodia provinces (12=Phnom Penh, 17=Siem Reap, etc.).
+4. Writes contributions/postcodes/KH.json idempotently.
+
+Also updates the Cambodia ``postal_code_regex``/``format`` in
+``countries.json`` from a 5-digit shape to the post-2017 6-digit
+shape used by Cambodia Post.
+
+License & attribution
+---------------------
+- Source: seanghay/cambodia-postal-codes (open redistribution of
+  Cambodia Post's publicly published 2017 reform index).
+- Each row: ``source: "cambodia-post-via-seanghay"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_cambodia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/seanghay/cambodia-postal-codes/"
+    "main/cambodia-postal-codes.json"
+)
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    data = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    kh_country = next((c for c in countries if c.get("iso2") == "KH"), None)
+    if kh_country is None:
+        print("ERROR: KH not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(kh_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    kh_states = [s for s in states if s.get("country_id") == kh_country["id"]]
+    state_by_iso2: Dict[str, dict] = {(s.get("iso2") or "").upper(): s for s in kh_states if s.get("iso2")}
+    print(f"Country: Cambodia (id={kh_country['id']}); states indexed: {len(kh_states)}")
+    print(f"Source provinces: {len(data)}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+
+    for prov in data:
+        prov_id = str(prov.get("id") or "").strip()
+        state = state_by_iso2.get(prov_id)
+        for district in prov.get("districts", []) or []:
+            district_name = (
+                district.get("location_en") or district.get("location_kh") or ""
+            ).strip()
+            for code_entry in district.get("codes", []) or []:
+                code = (code_entry.get("code") or "").strip()
+                if not code:
+                    continue
+                if not regex.match(code):
+                    skipped_bad_regex += 1
+                    continue
+                sangkat_en = (code_entry.get("en") or "").strip()
+                sangkat_km = (code_entry.get("km") or "").strip()
+                sangkat = sangkat_en or sangkat_km
+                locality = ", ".join(p for p in (sangkat, district_name) if p)
+                key = (code, locality.lower())
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                record: Dict[str, object] = {
+                    "code": code,
+                    "country_id": int(kh_country["id"]),
+                    "country_code": "KH",
+                }
+                if state is not None:
+                    record["state_id"] = int(state["id"])
+                    record["state_code"] = state.get("iso2")
+                    matched_state += 1
+                else:
+                    skipped_no_state += 1
+
+                if locality:
+                    record["locality_name"] = locality
+                record["type"] = "full"
+                record["source"] = "cambodia-post-via-seanghay"
+                records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    print(f"  no state FK:         {skipped_no_state:,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/KH.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -2581,8 +2581,8 @@
     "subregion_id": 13,
     "nationality": "Cambodian",
     "area_sq_km": 181040.0,
-    "postal_code_format": "#####",
-    "postal_code_regex": "^(\\d{5})$",
+    "postal_code_format": "######",
+    "postal_code_regex": "^(\\d{6})$",
     "timezones": [
       {
         "zoneName": "Asia/Phnom_Penh",

--- a/contributions/postcodes/KH.json
+++ b/contributions/postcodes/KH.json
@@ -1,0 +1,16402 @@
+[
+  {
+    "code": "010100",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Mongkol Borei District Post Office, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Banteay Neang Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Bat Trang Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Chamnaom Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Kouk Ballangk Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Koy Maeng Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ou Prasat Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Phnum Touch Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Rohat Tuek Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ruessei Kraok Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sambuor Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Soea Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Srah Reang Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ta Lam Commune, Mongkol Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Nam Tau Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Poy Char Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ponley Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Spean Sraeng Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Srah Chik Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Phnum Dei Commune, Phnom Srok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Chhnuor Mean Chey Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Chob Vari Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Phnum Lieb Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Prasat Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Preah Netr Prea Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Rohal Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Tean Kam Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Tuek Chour Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Bos Sbov Commune, Prea Netr Preah District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Changha Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Koub Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Kuttasat Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Samraong Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Souphi Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Soengh Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ou Beichoan Commune, Ou Chrov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Banteay Chhmar Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Kouk Romiet Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Phum Thmei Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Thma Puok Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Kouk Kakthen Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Kumru Commune, Thma Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Phkoam Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sarongk Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sla Kram Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Svay Check Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ta Baen Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ta Phou Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Treas Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Roluos Commune, Svay Check District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Boeng Beng Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Malai Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ou Sralau Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ou Sampoar Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Tuol Pongro Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Ta Kongg Commune, Malai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Kampong Svay, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Kaoh Pong Satv, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Mkak, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Ou Ambel, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Phniet, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Prea Ponlea, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Tuek Thla, Serei Saophoan Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Paoy Paet, Paoy Paet Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Nimitt, Paoy Paet Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "010903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3984,
+    "state_code": "1",
+    "locality_name": "Sangkat Phsar Kandal, Paoy Paet Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020100",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Banan District Post Office, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kantueu I Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kantueu II Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Bay Damram Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chheu Teal Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chaeng Mean Chey Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Phnum Sampov Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Snoeng Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Kream Commune, Banan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Pung Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Meun Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Ta Ki Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chrey Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Anlong Run Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chrouy Sdau Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Boeng Pring Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kouk Khmum Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Bansay Traeng Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Rung Chrey Commune, Thma Koul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Bavel Commun, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Khnach Romeas Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Lvea Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Prey Khpos Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ampil Pram Daeum Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kdol Ta Haen Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Khlaeng Meas Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Boeung Pram Commune, Bavel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Preak Norint Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Samraong Knong Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Preak Khpob Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Preak Luong Commung, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Peam Aek Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Prey Chas Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kaoh Chiveang Commune, Aek Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Moung Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kear Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Prey Svay Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chrey Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Loas Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Prey Touch Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Robas Mongkol Commune, Moung Ruessei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Preaek Chik Commune, Rukh Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Prey Tralach Commune, Rukh Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Mukh Reah Commune, Rukh Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sdok Pravoek Commune, Rukh Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Basak Commune, Rukh Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sdau Commune, Rotanak Mondol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Andaeuk Haeb Commune, Rotanak Mondol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Phlov Meas Commune, Rotanak Mondol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Traeng Commune, Rotanak Mondol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Reaksmei Songha Commune, Rotanak Mondol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Anglong Vil Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Norea Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Pon Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Roka Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kampong Preah Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kampong Prieng Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Reang Kesei Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Dambang I Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Dambang II Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Vaot Ta Muem Commune, Sangkae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Taok Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kampong Lpov Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Samril Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sung Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Samlout Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Mean Chey Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "020907",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Sanh Commune, Samlout District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sampov Lun Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Angkor Ban Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Sda Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Santepheap Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021005",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Serei Mean Chey Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021006",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chrey Seima Commune, Sampov Lun District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kamrieng Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Boeng Reang Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Da Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Trang Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Saen Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ta Krei Commune, Kamrieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chipakdei Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Kaos Krala Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Hab Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Preah Phos Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Doun Ba Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Chhnal Moan Commune, Koas Krala District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Phnum Proek Commune, Phnum Proek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Pech Chenda Commune, Phnum Proek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Bour Commune, Phnum Proek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Barang Thleak Commune, Phnum Proek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Ou Rumduol Commune, Phnum Proek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Toul Ta EK, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Preaek Preah Sdach, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Rottanak, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Chamkar Somraong, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Sla Ket, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Kdol Doun Teav, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Omal, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Wat Kor, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Ou Char, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "021410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3976,
+    "state_code": "2",
+    "locality_name": "Sangkat Svay Por, Battambang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Batheay Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Chbar Ampov Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Chealea Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Cheung Prey Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Me Pring Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ph'av Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sambour Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sandaek Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tang Krang Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tang krasang Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Trab Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tumnob Commune, Batheay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Bos Khnor  Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Chamkar Andoung Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Cheyyou Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Lvea Leu Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Spueu Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Svay Teab Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ta Ong Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ta Prok Commune, Chamkar Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Baray Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Khnor Dambang  Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kouk Rovieng  Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Pdau Chum Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Prey Char Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Pring Chrum Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sampong chey Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sdaeung Chey Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Soutib Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sramar Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Trapeang Kor Commune, Cheung Prey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sangkat Boeng Kok, Kampong Cham Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sangkat Kampong Cham, Kampong Cham Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sangkat Sambuor Meas, Kampong Cham Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sangkat veal vong, Kampong Cham Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ampil Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Hanchey  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kien Chrey Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kokor  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kaoh Mitt  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kaoh Roka  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kaoh Samraong  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Krala Tontuem  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Krala  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ou Svay  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030511",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ro'ang Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030512",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Rumchek  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030513",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Srak  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030514",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Trean  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030515",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Vihear Thum  Commune, Kampong Siem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Angkor Ban  Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kang Ta Noeng Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Khchau Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Peam Chi Kang Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek Koy Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek krabau Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Reay Pay Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Roka Ar Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Roka Koy Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sdau Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sour Kong Commune, Kang Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kampong Reab Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kaoh Soutin Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Lve Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Moha Leaph Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Moha Khnhoung Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Peam Prathnuoh Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Pongro Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030708",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek Ta Nong Commune, Kaoh Soutin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Baray Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Boeng Nay Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Chrey Vien Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Khvet Thum Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kor Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Krouch Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Lvea Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Mien Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Prey chhor Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sour Saen Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030811",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Samraong Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030812",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Sragnae Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030813",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Thma Pun Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030814",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tong Rong Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "030815",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Trapeang Preah Commune, Prey Chhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Areaks Tnot Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Dang Kdar Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Khpob Ta Nguon Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Me Sar chrey Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031005",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ou Mlu Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031006",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Peam Kaoh Snar Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031007",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preah Andoung Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031008",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preah Bak Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031009",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preah Kak Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031010",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Soupheas Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031011",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tuol Preah Khleang Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "031012",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tuol Sambuor Commune, Stueng Trang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "032514",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Tong Tralach   Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "033113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Svay Khsach Phnum   Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "033712",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Svay Pou   Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "034311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Ruessei Srok   Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "034910",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek Rumdeng   Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "035509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek Pou  Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "036108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Preaek Dambouk Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "036707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Pram Yam Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "037306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Phteah Kandal Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "037905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Mean Chey Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "038504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Kaoh Andaet Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "039103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "Khnar Sa Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "039702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3991,
+    "state_code": "3",
+    "locality_name": "chi Bal Commune, Srei  Santhor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Akphivoadth Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chieb Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chaong Maong Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kbal Teuk Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Khlong Popok Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Krang Skear Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Tang Krosang Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Toul Khpos Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kdol Saen Chey Commune, Teuk phos District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Ampil Teuk Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chhuk Sa Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chres Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kampong Tralach Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Longveak Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Ou Ruessei Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "peani Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Saeb Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Ta Ches Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Thma Edth Commune, Kompong Tralach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chol Sar  Commune, Chol Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kaoh Thkov  Commune, Chol Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kampong Ous  Commune, Chol Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Peam Chhkaok  Commune, Chol Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Prey Kri Commune, Chol Kiri District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Anhchanh Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chhnok Tru Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chak Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Khon Rang Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kampong Pres Kokir Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Melum Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Psar Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Pech Changvar Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "PoPel Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Ponley Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Trapeang Chan Commune, Baribour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chhean Laeung Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Khnar Chhmar Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Krang Lvea Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Peam Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Sedthei Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Svay Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Svay Chuk Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Tbaeng Khpos Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Thlok Vien Commune, Sameaki Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chranouk Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Dar Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kampong Hau Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Phlov Tuk Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Pou Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Pralay Meas Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Samraong Saen Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Svay Rumpean Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Trangel Commune, Kampong Leang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Andoung Snay Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Banteay Preal Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Cheung Kreav Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Chrey Bak Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Kouk Banteay Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Krang Leav Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Pongro Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040708",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Prasnoeb Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040709",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Prey Mul Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040710",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Rolea B'ier Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040711",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Srae Thmei Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040712",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Svay Chrum Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040713",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Tuek Hout Commune, Rolea B'ier District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Sangkat psar Chhnang, Kampong chhnang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Sangkat Kampong Chhnang, Kampong chhnang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Sangkat B'er, Kampong chhnang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "040804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3979,
+    "state_code": "4",
+    "locality_name": "Sangkat Khsam, Kampong chhnang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Roleang Chak Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Kahaeng cambodia, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "khtum Krang Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Krang Amoil Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pneay Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Roleeang Kreul Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Samraong Tong Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sambour Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Saen Dei Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Skuh Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tang Krouch Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Thummoda Ar Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Trapeang kong Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050114",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tumpoar Meas Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050115",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Voa Sar Commune, Samraong tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Basedth Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Kat Phluk Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Nitean Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pheakdei Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pheari Mean Chey Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Phong Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pou Angkrang Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pou Chamraeun Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Pou Mreal Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Svay Chacheb Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tuol Ampil Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tuol Sala Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050213",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Kak Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050214",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "svay Rumpear Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050215",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Preah Khae Commune, Basedth District: 15 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Angk Popel Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Chongruk Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Moha Ruessei Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "pechr Muni Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Preah Nipean Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prey Nheat Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prey Vihear Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Roka Kaoh Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sdok Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Snam Krapeu Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Srang Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050312",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tuek L'ak Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050313",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Veal Commune, Kong Pisei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Chan Saen Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Cheung Roas Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Chumpu Proeks Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "khsem Khsant Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Krang Chek Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Mean Chey Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Preah Srae Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prey Krasang Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Trach Tong Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Veal pong Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Veang Chas Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050412",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Yutth Sameakki Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050413",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Damnak Reang Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050414",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Peang Lvea Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050415",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Phnom touch Commune, Odongk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Chambak Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Choam Sangkae Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Dambouk Rung Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Kiri Voan Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Krang Dei Vay Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Moha Sang Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Ou Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prey Rumduol Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prey Kmeng Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tang Samraong Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050511",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Tang Sya Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050512",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Traeng Trayueng Commune, Phnum Sruoch District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Amleang Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Monourom Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Prambei Mum Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Rung Roeang Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Toap Mean Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Veal Pong Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Yea Angk Commune, Thpong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Haong Samnam Commune, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Reaksmei Samekki Commune, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Trapeang Chour Commune, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sangkae Satob Commune, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Ta Sal Commune, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sangkat Chbar Mon, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "sangkat Kandol Dom, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sangkat Rokar Thum, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sangkat Sopoar Tap, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "050805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3988,
+    "state_code": "5",
+    "locality_name": "Sangkat Svay kravan, Aoral District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Bak Sna Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Ballangk Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Baray Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Boeng Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chaeung Daeung Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chraneang Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chhuk Khsach Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chong Doung Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chrolong  Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kokir Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Krava Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Andoung Pou Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Pongro Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060114",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sou Young  Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060115",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sralau Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060116",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Svay Phleung Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060117",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tnaot Chum Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060118",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Triel Commune, Baray District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chey Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Damrei Slab Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kampong Kou  Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kampong Svay Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Nipech Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Phat Sanday Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "San Kor Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tbaeng Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Trapeang Ruessei Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kdel Doung Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Prey Kuy Commune, Kampong Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Doung Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kraya Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Phan Nheum Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sakream Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sala Visai Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sameakki Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tuol Kreul Commune, Prasat Balang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chhouk commune, Prasat Sambour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kourl commune, Prasat Sambour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sambo commune, Prasat Sambour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sroeung commune, Prasat Sambour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Taing Krasav commune, Prasat Sambour District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chheu Teal commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Dang Kambet commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Khleng commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Meanrith commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Mean Chey commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Ngorn commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sandan commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sochet commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tumring commune, Sandan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Boeng Lvea commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chroap commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kampong Thmor commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kokoh commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kraya commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Phneou commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Prasat commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Taing Krasaing commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tipo commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Tbaung Krapeu commune, Santuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Banteay Stoung Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chamna Kraom Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Chamna Leu Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kampong Chen Cheung Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Kampong Chen Tboung Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Msa Krang Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Peam Bang Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060708",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Popok Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060709",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Pralay Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060710",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Preah Damrei Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060711",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Roung Roeang Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060712",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Samprouch Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060713",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Trea Commune, Stoung District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Damrei Choan Khla, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Kampong Thum, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Kampong  Rotech, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Ou Kanthor, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Kampong Kraoau, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Prey Ta Hu, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Achar Leak, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "060808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5070,
+    "state_code": "6",
+    "locality_name": "Sangkat Srayov, Stueng Saen Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Baniev Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Takaen Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Boeng Nimol Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Chhuk Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Doun Yay Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Krang Sbov Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Krang Snay Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Lbaeuk Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Phleang Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Mean Chey Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Neareay Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Satv Pong Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Bei Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070114",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Tramaeng Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070115",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Dechou Akphivoadth Commune, Chhuk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Boeng Tuk Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Chum Kriel Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kampong Kraeng Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kampong Samraong Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kandaol Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kaoh Touch Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Koun Ssatv Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Makprang Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Preaek Tnoat Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Prey Khmim Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Prey Thnang Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Stueng Kaev Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070213",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Thmei Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070214",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Pring Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070215",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Sangkae Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070216",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Thum Commune, Tuek Chhou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Banteay Meas Khang Kaeut Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Banteay Meas Khang Lech Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Prey Tonle Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Samraong Kraom Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Samraong Leu Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sdach kong Khang Cheung Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sdach kong khang Lech Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sdach kong Khang Tboung Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Tnoat Chong Srang Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Sala Khang Kaeut Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Sala Khang Lech Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070312",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Tuk Meas Khang Kaeut Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070313",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Tuk Meas Khang Lech Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070314",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Watt Angk Khang Cheung Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070315",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Watt Angk Khang Tboung Commune, Banteay Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Angk Phnum Touch Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Angkor Chey Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Champei Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Dambouk Khpos Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Damn Koum Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Daeum Doung Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Mroum Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Phnum Kong Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Praphnum Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Samlanh Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Tani Commune, Angkor Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Damnak Sokram Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Dang Tong Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Khcheay Khang Cheung Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Khcheay Khang Tboung Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Mean Ritth Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Srae Chea Khang Cheung Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Srea Chea Khang Tboung Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Totoung Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Angk Romeas Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "L'ang Commune, Dang Tong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Boeng Sala Khang Cheung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Boeng Sala Khang Tboung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Damnak Kantuot Khang Cheung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Damnak Kantuot Khang Tboung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kompong Trach Khang Kaeut Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Kompong Trach Khang Lech Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Prasat Phnom Khyang Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Phnom Prasat Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Angk Sophy Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Preak kroes Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Ruessei Srok Khang Kaeut Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070612",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Ruessei Srok Khang Lech Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070613",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Svay Tong Khang Cheung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070614",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Svay Tong Khang Tboung Commune, Kampong Trach District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Chres Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Chumpu Voan Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Snay Anhchit Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Srae Chaeng Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Srae Knong Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Srae Somraong Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Trapeang Reang Commune, Chum Kiri District: 7 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sangkat Kampong Kandal, Kampot Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sangkat Krang Ampil, Kampot Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sangkat Kampong Bay, Kampot Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sangkat Andoung khmer, Kampot Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "070805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3981,
+    "state_code": "7",
+    "locality_name": "Sangkat Traeuy Kaoh, Kampot Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Baek Chan Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chhak Chhe Neang Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Damnak Ampil Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Krang Mkak Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Lumhach Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Mkak Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Peuk Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Prey Puoch Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Samraong Lu Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tuol Prech Commune, Angk Snuol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Bak Dav Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chey Thum Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Chamlang Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Chouram Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Oknha Tei Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preah Prasab Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ampil Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Luong Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ta Kov Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ta Meak Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Pun Ruessei Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roka Chonlueng Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080213",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sanlung Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080214",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sithor Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080215",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Svay Chrum Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080216",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Svay Romiet Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080217",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Ta Aek Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080218",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Vihea Suork Commune, Khsach Kandal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Ampov Prey Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Anlong Romiet Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Barku Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Boeng Khyang Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Cheung Kaeub Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Daeum Rues Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kandaok Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Thmei Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kouk Trab Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preah utth Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Roka Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080312",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Slaeng Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080313",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roka Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080314",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roleang Kaen Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080315",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Siem Reab Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080316",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tbaeng Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080317",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Trapeang Veaeng Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080318",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Trea Commune, Kandal Stueng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chheu Kmau Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chrouy Ta Kaev Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Kong Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Thum Ka Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Thom Kha  Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Leuk Daek Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Pouthi Ban Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Chrey Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Sdei Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Thmei Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sampeou Poun Commune, Kaoh Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Phnum Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "K'amSamnar Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Khpob Ateav Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Peam Reang Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Dach Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Tonloab Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sandar Commune, Leuk Daek Distict",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Akreiy Ksatr Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Barong Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Boeng Krum Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Kaev Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Reah Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Lvea Sar Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Peam Oknha Ong Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Phum Thum Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Kmeng Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Rey Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ruessei Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080612",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sambuor Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080613",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sarikakaev Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080614",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tma Kor Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080615",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tuek Khleang Commune, Lvea Aem District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Anhchanh Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Dambang Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roka Kong I Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roka Kong II Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Ruessei Chrouy Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sambuor Meas Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Svay Ampear Commune, Mukh Kampul District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chhveang Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chrey Loas Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Luong Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Os Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Chen Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Phnum Bat Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Ponhea Lueu Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ta Teaen Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Phsar Daek Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tumnob Thum Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080811",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Vihear Luong Commune, Ponhea Lueu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Khpob Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Anlong Chen Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Khael Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kaoh Khsach Tonlea Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Krang Yov Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Prasat Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080907",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Ambel Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080908",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Preaek Koy Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080909",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Roka Khpos Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080910",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "S'ang Phnum Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080911",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Setbou Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080912",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Svay Prateal Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080913",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Svay Rolum Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080914",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Ta Lon Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080915",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Traeuy Sla Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "080916",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Tuek Vil Commune, S'ang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Banteay Daek Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Chheu Teal Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Dei Edth Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kampong Svay Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081005",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kokir Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081006",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Kokir Thum Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081007",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Phum Thum Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081008",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Samraong Thum Commune, Kien Svay District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Ta Kdol, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Prek Ruessey, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Doeu Mien, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Ta Khmao, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Prek Ho, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "081106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3983,
+    "state_code": "8",
+    "locality_name": "Sangkat Kompong Samnanh, Ta Khmau Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Andoung Tuek Commune, Botum Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Kandaol Commune, Botum Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Ta Noun Commune, Botum Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Thma Sa Commune, Botum Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Kaoh Sdach Commune, Kiri Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Phnhi Meas Commune, Kiri Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Preaek Khsach Commune, Kiri Sakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chrouy Pras Commune, Kaoh Kong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Kaoh Kapi Commune, Kaoh Kong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Ta Tai Kraom Commune, Kaoh Kong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Trapeang Rung Commune, Kaoh Kong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Pak Khlang Commune, Mondol Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Peam Krasaob Commune, Mondol Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Tuol Kokir Commune, Mondol Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Boeng Preav Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chi Kha Kraom Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chi Kha Leu Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chrouy Svay Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Dang Peaeng Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Srae Ambel Commune, Srae Ambel District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Ta Tey Leu Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Pralay Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chumnoab Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Ruessei Chrum Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Chi Phat Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Thma Doun Pov Commune, Thma Bang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Sangkat Smach Mean Chey, Khemara Phoumin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Sangkat Dang Tong, Khemara Phoumin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "090703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3982,
+    "state_code": "9",
+    "locality_name": "Sangkat Stueng Veaeng, Khemara Phoumin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Khsuem Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Pir Thnu Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Snuol Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Srae Char Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Svay Chreah  Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kronhoung Saen Chey  Commune, Snuol  Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Boeng Char   Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kampong Cham  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kbal Damrei  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kaoh Khnhaer  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Ou Krieng  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Roluos Mean Chey  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sambour  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sandan  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Srae Chis Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Voadthonak  Commune, Sambour  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Chambak Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Chrouy Banteay Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kampong Kor Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Koh Ta Suy Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Preaek Prasab Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Russey Keo Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Saob Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Ta Mao Commune, Prek Prasab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Bos Leav   Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Changkrang  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Dar  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kantuot  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kou Loab  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Kaoh Chraeng  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sambok  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Thma Andaeuk  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Thma Kreae  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Thmei  Commune, Chetr Borei Districts",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sangkat Kaoh Trong, Kracheh Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sangkat Krakor, Kracheh Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sangkat Krachen, Kracheh Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sangkat Ou Ruessei, Kracheh Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "100605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3986,
+    "state_code": "10",
+    "locality_name": "Sangkat Roka Kandal, Kracheh Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Chong Phlas Commune, Kaev Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Memang  Commune, Kaev Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Srae Chhuk  Commune, Kaev Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Srae Khtum  Commune, Kaev Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "ឃុំ ស្រែព្រះ, Kaev Seima District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Nang Khi Lik Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "A Buon Leu Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Roya Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Sokh Sant Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Srae Huy Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Srae Sangkum Commune, Kaoh Nheaek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Dak Dam Commune, Ou Reang  District: 2 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Saen Monourom Commune, Ou Reang  District: 2 Communes",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Krang The Commune, Pech Chreada District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Pu Chrey Commune, Pech Chreada District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Srae Ampum Commune, Pech Chreada District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Bu Sra Commune, Pech Chreada District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Sangkat Monourom, Saen Monourom Municipility",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Sangkat Sokh Dom, Saen Monourom Municipility",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Sangkat Spean Mean Chey, Saen Monourom Municipility",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "110504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3985,
+    "state_code": "11",
+    "locality_name": "Sangkat Romonea, Saen Monourom Municipility",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tonle Basak, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Keng Kong 1, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Keng Kong 2, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Keng Kong 3, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Olympic, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Svay Prey 1, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Svay Prey 2, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tumnob Tuek, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Tumpung 1, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Tumpung 2, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Trabaek, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Daeum Thkov, Khan Chamkar Mon",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Thei 1, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Thei 2, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Thei 3, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Rang, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Kandal 1, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Kandal 2, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chakto Mukh, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chey Chumneah, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Chas, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Srah Chak, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Voat Phnum, Khan Doun Penh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ou Ruessei 1, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ou Ruessei 2, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ou Ruessei 3, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ou Ruessei 4, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Monourrom, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Mittapheap, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Veal Vong, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Proluet, Khan Prampir Meakakra",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Depou 1, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Depou 2, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Depou 3, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuek L'ak 1, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuek L'ak 2, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuek L'ak 3, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Kak 1, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Kak 2, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phsar Daeum Kor, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Salang, Khan Tuol Kouk",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Dangkao, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Pong Tuek, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Prey Veaeng, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Prey Sa, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Krang Pongro, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Prateah Lang, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Sak Sampov, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Cheung Aek, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kong Noy, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek Kampues, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120511",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Roluos, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120512",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Spean Thma, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120513",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tiem, Khan Dangkao",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chak Angrae Leu, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chak Angrae Kraom, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Stueng Mean Chey 1, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Stueng Mean Chey 2, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Stueng Mean Chey 3, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Tumpun 1, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Tumpun 2, Khan Mean chey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Svay Pak, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kilomaetr Lekh Prammouy, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ruessei Kaev, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chrang Chamreh 1, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chrang Chamreh 2, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Sangkae 1, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuol Sangkae 2, Khan Russey Keo",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phnom Penh Thmei, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Tuek Thla, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Khmuonh, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Krang Thnong, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ou Baek K'am, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kouk Khleang, Khan Saensokh",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Samraong Kraom, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Trapeang Krasang, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Snaor, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ovlaok, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kamboul, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kantaok, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120907",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Boeng Thum, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120908",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Phleung Chheh Roteh, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120909",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chaom Chau 1, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120910",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chaom Chau 2, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120911",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chaom Chau 3, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120912",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kakab 1, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "120913",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kakab 2, Khan Pur Senchey",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chrouy Changvar, Khan Chrouy Changvar",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek Lieb, Khan Chrouy Changvar",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek Ta Sek, Khan Chrouy Changvar",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kaoh Dach, Khan Chrouy Changvar",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121005",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Bak Khaeng, Khan Chrouy Changvar",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat  Preaek Pnov, Khan Preaek Pnov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ponhea Pon, Khan Preaek Pnov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Samraong Kraom, Khan Preaek Pnov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Kouk Roka, Khan Preaek Pnov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Ponsang, Khan Preaek Pnov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chbar Ampov 1, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Chbar Ampov 2, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Nirouth, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek Pra, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Veal Sbov, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek Aeng, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat  Kbal Kaoh, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "121208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3994,
+    "state_code": "12",
+    "locality_name": "Sangkat Preaek thmei, Khan Chbar Ampov",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "S'ang Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Tasu Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Khyang Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Chrach Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Thmea Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Putrea Commune, Chey Saen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Chhaeb I Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Chhaeb II Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sangkae I Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sangkae II Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Mlu Prey I Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Mlu Prey II Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Kampong Sralau I Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Kampong Sralau II Commune, Chhaeb District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Choam Ksant Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Tuek Kraham Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Pring Thum Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rumdaoh Srae Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Yeang Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Kantuot Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Morokot Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sror Aem Commune, Choam Ksant District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Koleaen Tboung Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Koleaen Cheung Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Thmei Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Phnom Penh Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Phnom Tbaeng II Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Srayang Commune, Kuleaen District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Robieb Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Reasmei Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rohas Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rung Roeang Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rik Reay Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Ruos Roan Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Ratanak Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rieb Roy Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Reaksa Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Rumdaoh Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130511",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Romtum Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130512",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Romoneiy Commune, Rovieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Chamraeun Commune, Sangkum Thmei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Ro'ang Commune, Sangkum Thmei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Phum Tbaeng I Commune, Sangkum Thmei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sdau Commune, Sangkum Thmei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Ronak Ser Commune, Sangkum Thmei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Chhean Mukh Commune, Tbaeng Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Pou Commune, Tbaeng Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Prame Commune, Tbaeng Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Preah Khleang Commune, Tbaeng Mean Chey District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sangkat Kampong Pranak, Preah Vihear Minicipality: 2 Sangkats",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "130802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3973,
+    "state_code": "13",
+    "locality_name": "Sangkat Pal Hal, Preah Vihear Minicipality: 2 Sangkats",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "chong Ampil  Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kanhchriech Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kdoeang Reay Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kouk Kong Kaeut Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kouk Kong Lech Kouk Kong, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preal Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Thma Pun Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Tnaot Commune, Kanhchriech  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Angkor Angk  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kompong Prasat  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kaoh Chek  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kaoh Raka  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kaoh Sampov  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Krang Ta Yang  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Krabau  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Sambuor  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ruessei Srok  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Svay Phluoh  Commune, Peam Chor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ba Baong  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Banlich Prasat  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Neak Loeang  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Peam Mean Chey  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Peam Ro  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Khsay Ka  Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Khsay Kha   Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Kandieng   Commune, Peam Ro  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Angkor Reach  Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Bantean Chakrei Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Boeng Daol Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chey Kampok Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kampong Soeng Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Krang Svay Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Lvea Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preah Sdach Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Reathor Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Rumchek Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Sena Reach Otdam Commune, Preah Sdach   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Cheach Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Doun Koeng Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kranhung Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Krabau Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Seang Khveang Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Smaong Khang Cheung  Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Smaong Khang Tboung  Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Trabaek  Commune, Kamchay Mear  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ampil Krau  Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chrey Khmum   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Lve   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Pnov I   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Pnov II   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Pou Ti   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Changkran   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Daeum Thnoeng   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Tueng   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Rumlech   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ruessei Sanh   Commune, Sithor Kandal   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Boeng Preah  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Cheung Phnum  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chheu Kach  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Reak Chey  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Roung Damrei  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Sdau Kaong  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Spueu Ka  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140708",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Spueu Kha  Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140709",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Theay Commune, Ba Phnum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Angkor Tret Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chea Khlang  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chrey   Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Damrei Puon  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Me Bon  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Pean Roung  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Popueus  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Khla  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Samraong  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Svay Antor  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140811",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Tuek Thla  Commune, Svay Antor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Pou Rieng  Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Anteah  Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Chrey Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Kanlaong  Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ta Keo  Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Preaek Ta Sar Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "140907",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kampong Ruessei Commune, Pur Rieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Angkor Sar Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chres Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chi Phoch Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Khnes Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141005",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Rumdeng Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141006",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "prey Totueng Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141007",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Svay Chrum Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141008",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Trapeang Srae Commune, Me Sang  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Ansaong Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Cham Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Cheang Daek Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Chrey Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kansoam Ak Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kou Khchak Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kampong Trabaek Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Peam Montear Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prasat Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "pratheat Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Chhor Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "prey poun Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Thkov Commune, Kampong Trabaek  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kampong popil Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kanhcham Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Kampong Prang Kampong, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Mesar Prachan Kampong, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey pnov Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Prey Sniet Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "prey Sralet Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Reab Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Roka Commune, Pea Reang   District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Sangkat Baray, Prey Veng Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Sangkat Cheung Tuek, Prey Veng Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "141303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3974,
+    "state_code": "14",
+    "locality_name": "Sangkat Kampong Leav, Prey Veng Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Anglong Tnaot Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Ansa Chambak Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Boeng Kantuot Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Chheu Tom Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kampong Luong Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kampong Pou Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kbal Trach Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Ou Sandan Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sna Ansa Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Svay Sa Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Tnaot Chum Commune, Krakor District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Anlong Vil Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kandieng Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kanhchor Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Reang Til Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Srae Sdok Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Svay Luong Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sya Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Veal Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Kaoh Chum Commune, Kandieng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Boeng Bat Kandaol Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Boeng Khnar Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Khnar Totueng Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Me Tuek Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Ou Ta Paong Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Rumlech Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Snam Preah Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Svay Doun Kaev Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Ta Lou Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Traeang Chorng Commune, Bakan District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Ou Saom Commune, Veal Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Krapeu Pir Commune, Veal Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Anlong Reab Commune, Veal Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Pramaoy Commune, Veal Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Thma Da Commune, Veal Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Bak Chenhchien Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Leach Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Phteah Rung Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Prongil Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Rokat Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Santreae Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Samraong Commune, Phnum Kravanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Chamraeun Phal, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Lolok Sa, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Phteah Prey, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Prey Nhi, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Roleab, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Svay At, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "150607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3977,
+    "state_code": "15",
+    "locality_name": "Sangkat Banteay Dei, Pursat Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Malik Commune, Andoung Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Nhang Commune, Andoung Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ta Lav Commune, Andoung Meas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Kak Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Keh Chong Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "La Minh Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Lung Khung Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Saeung Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ting Chak Commune, Bar Kaev District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Serei Mongkol Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Srae Angrorng Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ta Ang Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Teun Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Trapeang Chres Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Trapeang Kraham Commune, Koun Mom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Chey Otdam Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ka Laeng Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Lbang I Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Lbang II Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ba Tang Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Seda Commune, Lumphat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Cha Ung Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Pouy Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Aekakpheap Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Kalai Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ou Chum Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sameakki Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "L'ak Commune, Ou Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Bar Kham Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Lum Choar Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Pak Nhai Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Pa Te Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sesan Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Saom Thum Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ya Tung Commune, Ou Ya Dav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ta Veaeng Leu Commune, Ta Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ta Veaeng Kraom Commune, Ta Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Pong Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Hat Pak Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Ka Choun Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Kaoh Pang Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Kaoh Peak Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Kok Lak Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Pa Kalan Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Phnum Kok Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Veun Sai Commune, Veun Sai District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sangkat Kachanh, Ban Long Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sangkat Labasiek, Ban Long Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sangkat Yeak Laom, Ban Long Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "160904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3990,
+    "state_code": "16",
+    "locality_name": "Sangkat Boeng Kansaeng, Ban Long Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Prasat Commune, Varin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Lvea Krang Commune, Varin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Srae Nouy Commune, Varin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Svay Sa Commune, Varin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Varin Commune, Varin District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Boeng Mealea Commune, Svay Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kantuot Commune, Svay Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khnang Phnum Commune, Svay Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Svay Leu Commune, Svay Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ta Siem Commune, Svay Leu District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Chrouy Neang Ngoun Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Klang Hay Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Tram Sasar Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Moung Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Prei Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Slaeng Spean Commune, Srei Snam District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Chan Sa Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Dam Daek Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Dar Run Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kampong Khleang Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kien Sangkae Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khchas Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khnar Pou Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Popel Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Samraong Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ta Yaek Commune, Soutr Nikom District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Bakong Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ballangk Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kampong Phluk Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kantreang Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kandaek Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Mean Chey Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Roluos Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Trapeang Thum Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ampil Commune, Prasat Bakong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sasar Sdam Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Doun Kaev Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kdei Run Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kaev Poar Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khnat Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Lvea Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Mukh Paen Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Pou Treay Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Puok Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Prey Chruk Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Reul Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170612",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Samraong Yea Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170613",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Trei Nhoar Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170614",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Yeang Commune, Puok District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Chanleas Dai Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kampong Thkov Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kralanh Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Krouch Kor Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Roung Kou Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sambuor Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Saen Sokh Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170708",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Snuol Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170709",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sranal Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170710",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ta An Commune, Kralanh District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Anglong Samnar Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Chi Kraeng Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kampong Kdei Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khvav Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kouk Thlok Kraom Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kouk Thlok Leu Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Lveaeng Ruessei Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Pongro Kraom Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Pongro Leu Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ruessei Lok Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170811",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangvaeuy Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170812",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Spean Tnaot Commune, Chi Kraeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khanr Sanday Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Khun Ream Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Preah Dak Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Rumcheck Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Run Ta Aek Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "170906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Tbaeng Commune, Banteay Srei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Chob Ta Trav Commune, Angkor Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Leang Dai Commune, Angkor Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Peak Snaeng Commune, Angkor Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171004",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Svay Check Commune, Angkor Thum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Char Chhuk Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Doun Peng Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Kouk Doung Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Koul Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Nokor Pheas Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Srae Khvav Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Ta Saom Commune, Angkor Chum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Sla Kram, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Svay Dangkum, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Kok Chak, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Sala Kamreuk, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Nokor, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Chreav, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Chong Khnies, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Sambuor, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Siem Reap, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Srangae, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Tuek Vil, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "171212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3992,
+    "state_code": "17",
+    "locality_name": "Sangkat Krabei Riel, Siem Reap Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Andoung Thma Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Boeng Ta Prum Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Bet Trang Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Cheung Kou Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ou Chrov Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ou oknha Heng Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Prey Nob Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ream Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sameakki Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Samrong Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Tuek L'ak Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Tuek Thla Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Tuol Totueng Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180114",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Veal Renh Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180115",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ta Ney Commune, Prey Nob  District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Kampenh Commune, Steung Hav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ou Treh Commune, Steung Hav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Tumnob Rolok Commune, Steung Hav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Kaev Phos Commune, Steung Hav District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Chamkar Luong Commune, Kampong Seila District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Kampong Seila Commune, Kampong Seila District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Ou Bak Roteh Commune, Kampong Seila District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Stueng Chhay Commune, Kampong Seila District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Lek I, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Lek II, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Lek III, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Lek IV, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Kaoh Rung, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "180406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3989,
+    "state_code": "18",
+    "locality_name": "Sangkat Koah Rung Soplem, Preah Sihanouk Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kamphun Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kbal Romeas Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Phluk Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Samkhuoy Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sdau Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Srae Kor Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Talat Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kaoh Preah Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kaoh Sampeay Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kaoh Sralay Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Ou Mreah Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Ou Ruessey Kandal Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Siem Bouk Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Srae Krasang Commune, Siem Bouk District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Preaek Meas Commune, Siem Pang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sekong Commune, Siem Pang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Santepheap Commune, Siem Pang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Srae Sambour Commune, Siem Pang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Tma Kaev Commune, Siem Pang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Anglong Phe Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Chamkar Leu Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kang Cham Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Kaoh Snaeng Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Anlong Chrey Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Ou Rai Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Ou Svay Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Preah Rumkel Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sam Ang Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Srae Ruessei Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Thal Barivat Commune, Thala Bariat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sangkat Steung Treng, Steung Treng Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sangkat Srah Ruessei, Steung Treng Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sangkat Preah Bat, Steung Treng Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "190504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3993,
+    "state_code": "19",
+    "locality_name": "Sangkat Sameakki, Steung Treng Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chantrea Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chress Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Me Sar Thngak Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Prey Kokir Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Samraong Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Tuol Sdei Commune, Chantrea District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Banteay Krang Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Nhor Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Khsaetr Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Preah Ponlea Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Prey Thum Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Reach Montir Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Samlei Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Samyaong Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Ta Yean Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Thmei Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Tnaot Commune, Kompong Rou District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Bos Mon Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Thmea Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kampong Chak Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chrung Popel Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kampong Ampil Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Meun Chey Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Pong Tuek Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkae Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Check Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Than Thnong Commune, Rumduol District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Ampil Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Andoung Pou Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Andoung Trabaek Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Angk Prasrae Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chantrei Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chrey Thum Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Doung Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kampong Trach Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kokir Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Krasang Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Mukh Da Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200412",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Mream Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200413",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sambuor Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200414",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sambatt Mean Chey Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200415",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Trapeang Sdau Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200416",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Tras Commune, Romeas Haek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Angk Ta Sou Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Basak Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chambak Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kampong Chamlang Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Ta Suos Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Chheu Teal Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Doun Sa Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kouk Pring Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200509",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kraol Kou Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200510",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Krous Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200511",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Pouthi Reach Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200512",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Angk Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200513",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Chrum Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200514",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Thum Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200515",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Yea Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200516",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Thlok Commune, Svay Chrum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Koki Saom Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Kandieng Reay Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Monourom Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Ppeaet Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Prey Ta Ei Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Prasoutr Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Romeang Thkaol Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sambuor Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Svay Rumpear Commune, Svay Teab District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Svay Reang, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Prey Chhlak, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Koy Trabaek, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Pou Ta Hao, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Chek, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200706",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Svay Toea, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200707",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Sangkhoar, Svay Reang Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Bati, Bavet Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Bavet, Bavet Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Chrak Mtes, Bavet Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Prasat, Bavet Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "200805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3972,
+    "state_code": "20",
+    "locality_name": "Sangkat Prey Angkunh, Bavet Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angkanh Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angk Khnor Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Chi Khma Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Khvav Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prambei Mum Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angk Kaev Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Sloek Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210108",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Roneam Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210109",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Sambuor Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210110",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Sanlung Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210111",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Smaong Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210112",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Srangae Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210113",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Thlok Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210114",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Tralach Commune, Treang District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angk Ta Saom Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Cheang Tong Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kus Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Leay Bour Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Nhaeng Nhang Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ou Saray Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trapeang Kranhoung Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Otdam Sorya Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Popel Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Samraong Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Srae Ronoung Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ta Phem Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210213",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Tram kak Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210214",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trapeang Thum Khang Cheung Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210215",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trapeang Thum Khang Tboung Commune, Tram Kak District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Boeng Tranh Khang Cheung Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Boeng Tranh Khang Tboung Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Cheung Kuon Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Chumreah Pen Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Khvav Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Lumchang Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Rovieng Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Samraong Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Soengh Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Sla Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trea Commune, Samraong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angkanh Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ban Kam Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Champa Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Char Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kampeaeng Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kampong Reab Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kdanh Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210408",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Pou Rumchak Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210409",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Kabbas Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210410",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Lvea Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210411",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Phdau Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210412",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Snao Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210413",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Tang Yab Commune, Prey Kabbas District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Krapum Chhuk Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Pech Sar Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Khla Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey  Yuthka Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Romenh Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Thlea Prachum Commune, Kaoh Andaet District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angk Prasat Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Preah Bat Choan Chum Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kamnab Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kampeaeng Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kiri Chong Kaoh Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kouk Prech Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Phnum Den Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Ampok Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Rumdeng Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ream Andaeuk Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Saom Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210612",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ta Ou Commune, Kiri Vong District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Borei  Cholsar Commune, Borei Cholsar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Chey Chouk Commune, Borei Cholsar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210703",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Doung Khpos Commune, Borei Cholsar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210704",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kampong Krasang Commune, Borei Cholsar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210705",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kouk Pou Commune, Borei Cholsar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210801",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Chambak Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210802",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Champei Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210803",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Doung Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210804",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kandoeng Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210805",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Komar Reachea Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210806",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Krang Leav Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210807",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Krang Thnong Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210808",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Lumpong Commung, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210809",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Pea Ream Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210810",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Pot Sar Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210811",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Sour Phi Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210812",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Tang Doung Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210813",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Tnaot Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210814",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trapeang Krasang Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210815",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Trapeang Sab Commune, Bati District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210901",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Angkor Borei Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210902",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ba Srae Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210903",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Kouk Thlok Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210904",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Ponley Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210905",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Preaek Phtoul Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "210906",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "Prey Phkoam Commune, Angkor Borei District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "211001",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "សង្កាត់ បារាយណ៍, Doun Kaev Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "211002",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "សង្កាត់ រកាក្នុង, Doun Kaev Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "211003",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3975,
+    "state_code": "21",
+    "locality_name": "សង្កាត់ រកាក្រៅ, Doun Kaev Minicipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "220101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3987,
+    "state_code": "22",
+    "locality_name": "Angkaol Commune, Damnak Chang'aeur District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "220102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3987,
+    "state_code": "22",
+    "locality_name": "Pong Tuek Commune, Damnak Chang'aeur District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "220201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3987,
+    "state_code": "22",
+    "locality_name": "Sangkat Kaeb, Kaeb Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "220202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3987,
+    "state_code": "22",
+    "locality_name": "Sangkat Prey Thum, Kaeb Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "220203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3987,
+    "state_code": "22",
+    "locality_name": "Sangkat Ou Krasar, Kaeb Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Sala Krau Commune, Sala Krau District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Stueng Trang Commune, Sala Krau District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Stueng Kach  Commune, Sala Krau District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Ou Andoung  Commune, Sala Krau District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Sangkat Pailin, Pailin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Sangkat Ou Ta Vau, Pailin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Sangkat Tuol Lvea, Pailin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "230204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3978,
+    "state_code": "23",
+    "locality_name": "Sangkat Bar Yakha, Pailin Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Anlong Veaeng Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Trapeang Tav Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Trapeang Prei Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Thlat  Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Thlat Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Lumtong  Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Lumtong Commune, Anlong Veaeng District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Ampil Commune, Banteay Ampil District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Beng Commune, Banteay Ampil District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Kouk Khpos Commune, Banteay Ampil District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Kouk Mon Commune, Banteay Ampil District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Cheung Tien Commune, Chong kal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Chong Kal Commune, Chong kal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Krasang Commune, Chong kal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Pongro Commune, Chong kal District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Bak Anloung Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Ph'av Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Ou Svay Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Preah Pralay Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Tumnob Dach Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Trapeang Prasat Commune, Trapeang Prasat District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Sangkat Bansay Reak, Samraong Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Sangkat Bos Sbov, Samraong Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Sangkat Koun Kriel, Samraong Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Sangkat Samraong, Samraong Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "240505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 3980,
+    "state_code": "24",
+    "locality_name": "Sangkat Ou Smach, Samraong Municipality",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250101",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chong Cheach Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250102",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Dambae Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250103",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kouk Srok Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250104",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Neang Teut Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250105",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Seda Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250106",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tuek Chrov Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250107",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Trapeang Pring Commune, Dambae District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250201",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chhuk Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250202",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chumnik Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250203",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kampong Treas Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250204",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kaoh Pir Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250205",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Krouch Chhmar Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250206",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Peus 1 Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250207",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Peus 2 Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250208",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Preaek A Chi Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250209",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Roka Khnor Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250210",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Svay Khleang Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250211",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Trea Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250212",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tuol Snuol Commune, Krouch Chhmar District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250301",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chan Mul Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250302",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Choam Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250303",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Choam Kravien Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250304",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Choam Ta Mau Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250305",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Dar Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250306",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kampoan Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250307",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Memong Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250308",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Memot Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250309",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Rung Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250310",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Rumchek Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250311",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tramung Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250312",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tonlung Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250313",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Triek Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250314",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kokri Commune, Memot District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250401",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Ampil Ta Pok Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250402",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chak Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250403",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chak Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250404",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Damril Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250405",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kong Chey Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250406",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Preah Theat Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250407",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tuol Souphi Commune, Ou Reang Ov District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250501",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Dountei Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250502",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kak Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250503",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kandaol Chrum Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250504",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kaong Kang Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250505",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kraek Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250506",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Popel Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250507",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Trapeang Phlong Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250508",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Veal Mlu Commune, Ponhea Kraek District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250601",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Anhchaeum Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250602",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Boeng Pruol Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250603",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chikor Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250604",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chirou I Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250605",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Chirou II Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250606",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Cob Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250607",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Kor Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250608",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Lngieng Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250609",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Mong Riev Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250610",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Peam Chileang Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250611",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Roka Po Pram Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250612",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "sralab Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250613",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Thma pech Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250614",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Tonle Bet Commune, Tboung Khmum District",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250701",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Sangkat Vihear Luong, Suong Municipatity",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  },
+  {
+    "code": "250702",
+    "country_id": 37,
+    "country_code": "KH",
+    "state_id": 5537,
+    "state_code": "25",
+    "locality_name": "Sangkat Suong, Suong Municipatity",
+    "type": "full",
+    "source": "cambodia-post-via-seanghay"
+  }
+]


### PR DESCRIPTION
## Summary

Adds 1,640 Cambodia postcodes spanning all 25 provinces of Cambodia
Post's 2017-reform 6-digit catalogue, sourced from the
``seanghay/cambodia-postal-codes`` JSON.

- **Coverage**: 100% province resolution.
- **Granularity**: sangkat (commune) level — one record per
  ``(6-digit code, sangkat + district)`` pair.

## Also fixes Cambodia regex bug

The previous ``countries.json`` entry for Cambodia had:

```
"postal_code_format": "#####"
"postal_code_regex":  "^(\\d{5})$"
```

That never matched Cambodia Post's post-2017 6-digit codes (e.g.
``120101`` for Phnom Penh / Khan Chamkar Mon / Tonle Basak) and
would have rejected every legitimate row in this PR. Updated to:

```
"postal_code_format": "######"
"postal_code_regex":  "^(\\d{6})$"
```

Same kind of fix as the EC regex correction in #1463 and the MN
fix in #1469.

## How it works

The source's ``id`` field (1-25) is identical to CSC's
``state.iso2`` for Cambodia provinces, so ``state_id`` resolves via
a direct numeric lookup with no name matching needed.

## Source & licence

- Source URL: https://raw.githubusercontent.com/seanghay/cambodia-postal-codes/main/cambodia-postal-codes.json
- Origin: Cambodia Post 2017-reform publicly published index,
  redistributed by seanghay.
- Each row: ``"source": "cambodia-post-via-seanghay"``

## Validation

- ``python3 -m py_compile`` clean.
- 100% of 1,640 codes match the **fixed** ``country.postal_code_regex``
  (``^(\d{6})$``).
- 100% of records resolve a valid ``state_id`` whose ``country_id == 37``
  and whose ``iso2`` matches ``state_code``.
- No auto-managed fields (``id``, ``created_at``, ``updated_at``, ``flag``).

## Test plan

- [x] Importer compiles and runs on a clean checkout.
- [x] Cross-reference validator passes (regex + FK + state_code agreement).
- [x] Idempotent merge verified.
- [ ] CI pipeline green.

Refs #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)