### PR TITLE
feat(postcodes/HU): 3,569 Magyar Posta codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_hungary_postcodes.py
+++ b/bin/scripts/sync/import_hungary_postcodes.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Hungary -> contributions/postcodes/HU.json importer for issue #1039.
+
+Source data
+-----------
+Tamás Ferenci's ``ferenci-tamas/IrszHnk`` repo joins the official
+Magyar Posta postal-code workbook with the KSH Helységnévtár
+(Hungarian Central Statistical Office gazetteer) to produce a single
+CSV keyed on `(IRSZ, Helység.megnevezése, Településrész)`.
+
+Last refresh in repo: 09-Feb-2026.
+
+Source URL: https://raw.githubusercontent.com/ferenci-tamas/IrszHnk/master/IrszHnk.csv
+
+Schema (semicolon-delimited):
+    Helység.megnevezése  -- settlement name
+    IRSZ                  -- 4-digit postal code
+    Településrész         -- sub-district / locality fragment (often blank)
+    Vármegye.megnevezése -- megye/county name (state FK)
+    Járás.kódja           -- subdistrict (járás) code
+    Járás.neve            -- subdistrict name
+    Helység.jogállása     -- legal status: község / város / fővárosi kerület / ...
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Joins the 20 source megye labels (19 megyék + ``főváros``) onto
+   CSC's 20 county-level iso2 codes via SOURCE_TO_ISO2.
+3. Emits one row per (code, settlement[+sub-district]) pair.
+4. Writes contributions/postcodes/HU.json idempotently.
+
+Why a hand-curated megye map (not name match)
+---------------------------------------------
+CSC's HU states.json has 43 entries: 19 megyék + Budapest + 23 cities
+of county rank (megyei jogú város). The CSV authoritatively reports
+megye, not city-of-county-rank, so the only meaningful join key is
+the 20 county-level entries. Hand-curated map handles two name drifts:
+``főváros`` (lit. "the capital") -> Budapest; ``Csongrád-Csanád``
+(2020 renaming) -> CSC's older ``Csongrád County`` label.
+
+License
+-------
+Repo has no LICENSE file. The two upstream sources (Magyar Posta and
+KSH) are official Hungarian government open data — `data.gov.hu` style
+but no formal CC-BY label. Acceptable per #1039 license-tier policy
+(Tier 5: free redistribution permitted, no formal licence; flagged
+in PR).
+
+Each row carries: ``source: "magyar-posta-via-ferenci-tamas"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_hungary_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/ferenci-tamas/IrszHnk/master/IrszHnk.csv"
+)
+
+# 20 source megye labels (19 counties + 'főváros' = Budapest)
+# -> CSC iso2 in states.json.
+SOURCE_TO_ISO2: Dict[str, str] = {
+    "Baranya": "BA",
+    "Borsod-Abaúj-Zemplén": "BZ",
+    "Bács-Kiskun": "BK",
+    "Békés": "BE",
+    "Csongrád-Csanád": "CS",  # 2020 rename; CSC entry still 'Csongrád County'
+    "Fejér": "FE",
+    "Győr-Moson-Sopron": "GS",
+    "Hajdú-Bihar": "HB",
+    "Heves": "HE",
+    "Jász-Nagykun-Szolnok": "JN",
+    "Komárom-Esztergom": "KE",
+    "Nógrád": "NO",
+    "Pest": "PE",
+    "Somogy": "SO",
+    "Szabolcs-Szatmár-Bereg": "SZ",
+    "Tolna": "TO",
+    "Vas": "VA",
+    "Veszprém": "VE",
+    "Zala": "ZA",
+    "főváros": "BU",  # Budapest
+}
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8-sig")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local CSV (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8-sig")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    hu_country = next((c for c in countries if c.get("iso2") == "HU"), None)
+    if hu_country is None:
+        print("ERROR: HU not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(hu_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    hu_states = [s for s in states if s.get("country_id") == hu_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in hu_states if s.get("iso2")
+    }
+    print(
+        f"Country: Hungary (id={hu_country['id']}); states indexed: {len(hu_states)}"
+    )
+
+    reader = csv.DictReader(io.StringIO(text), delimiter=";")
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_no_code = 0
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_megye: Dict[str, int] = {}
+
+    for row in rows:
+        raw_code = (row.get("IRSZ") or "").strip()
+        if not raw_code:
+            skipped_no_code += 1
+            continue
+        code = raw_code.zfill(4) if raw_code.isdigit() else raw_code
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        megye = (row.get("Vármegye.megnevezése") or "").strip()
+        helyseg = (row.get("Helység.megnevezése") or "").strip()
+        resz = (row.get("Településrész") or "").strip()
+
+        iso2 = SOURCE_TO_ISO2.get(megye)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_megye[megye] = unknown_megye.get(megye, 0) + 1
+            skipped_no_state += 1
+
+        # Locality = settlement + sub-district (when present)
+        if resz:
+            locality = f"{helyseg}, {resz}"
+        else:
+            locality = helyseg
+
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(hu_country["id"]),
+            "country_code": "HU",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "magyar-posta-via-ferenci-tamas"
+        records.append(record)
+
+    print(f"Skipped (no code):     {skipped_no_code:,}")
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_megye:
+        print("Unknown megye labels (not in SOURCE_TO_ISO2):")
+        for m, n in sorted(unknown_megye.items(), key=lambda x: -x[1]):
+            print(f"  {m!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/HU.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/HU.json
+++ b/contributions/postcodes/HU.json
@@ -1,0 +1,35692 @@
+[
+  {
+    "code": "1007",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1011",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1012",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1013",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1014",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1015",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1016",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 01. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1021",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1022",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1023",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1024",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1025",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1026",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1027",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1028",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1029",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 02. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1031",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1032",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1033",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1034",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1035",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1036",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1037",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1038",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1039",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 03. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1041",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1043",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1044",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1046",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1047",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1048",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 04. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1052",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1054",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1055",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1056",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 05. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1061",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1068",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 06. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1072",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1073",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1076",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1077",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1078",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 07. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1084",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1087",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1088",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1089",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 08. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1091",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1094",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1098",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 09. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1101",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1102",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1103",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1104",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1105",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1106",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1107",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1108",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 10. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1112",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1113",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1114",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1115",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1116",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1117",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1118",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1119",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 11. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 12. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1137",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1138",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1139",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 13. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1147",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1148",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1149",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 14. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1151",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1152",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1153",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1154",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1155",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1156",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1157",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1158",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 15. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 16. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 16. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 16. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 16. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 16. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1171",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 17. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1172",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 17. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1173",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 17. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 17. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1185",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1186",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1188",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 18. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1191",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1192",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1193",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1194",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1195",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1196",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 19. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1201",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 20. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1202",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 20. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1203",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 20. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1204",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 20. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1205",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 20. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 21. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 21. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1213",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 21. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1214",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 21. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1215",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 21. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1221",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 22. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1222",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 22. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1223",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 22. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1224",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 22. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 22. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1237",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 23. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1238",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 23. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "1239",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1064,
+    "state_code": "BU",
+    "locality_name": "Budapest 23. ker.",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szentendre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2009",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2011",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Budakalász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2013",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pomáz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2014",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csobánka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2015",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetmonostor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2016",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Leányfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2017",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pócsmegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2021",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tahitótfalu, Tótfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2022",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tahitótfalu, Tahi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2023",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dunabogdány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2024",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kisoroszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2025",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Visegrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2026",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Visegrád, Gizellatelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2027",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dömös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2028",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Pilismarót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2030",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Érd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2038",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Sóskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2039",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pusztazámor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2040",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Budaörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Törökbálint",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2049",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Diósd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Biatorbágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Herceghalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2060",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Bicske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Óbarok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csabdi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Szár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Újbarok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Szárliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Páty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2072",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Zsámbék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2073",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Perbál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2080",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisjászfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Piliscsaba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Solymár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2084",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisvörösvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tinnye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2089",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Telki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2090",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Remeteszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2091",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Etyek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Budakeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Budajenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2094",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagykovácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Üröm",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisborosjenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2098",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisszentkereszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2099",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilisszentkereszt, Dobogókő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Gödöllő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szada",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2112",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Veresegyház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2113",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Erdőkertes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2114",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Valkó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2115",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vácszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2116",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Zsámbok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2117",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Isaszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2118",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2119",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pécel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2120",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dunakeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Göd, Alsógöd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Göd, Felsőgöd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Sződliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Sződ",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csörög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csömör",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagytarcsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kistarcsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kerepes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kerepes, Szilasliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Mogyoród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2151",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Fót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csomád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Őrbottyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vácrátót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Váchartyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kisnémedi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2166",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Püspökszilágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2167",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vácduka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2170",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Aszód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2173",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kartal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Verseg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kálló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2176",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Erdőkürt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2177",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Erdőtarcsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Iklad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Domony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Galgamácsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vácegres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2185",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Váckisújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2191",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Bag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2192",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Hévízgyörk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2193",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Galgahévíz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2194",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tura",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Monor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2209",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Péteri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vasad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csévharaszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2213",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Monorierdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2214",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2215",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Káva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2216",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Bénye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2217",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Gomba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2220",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vecsés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Üllő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2230",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Gyömrő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ecser",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2234",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Maglód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Mende",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Sülysáp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kóka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2244",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Úri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2251",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápiószecső",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2252",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tóalmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápióság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2254",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szentmártonkáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2255",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szentlőrinckáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ráckeve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2309",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Lórév",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2310",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2314",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Halásztelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2315",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigethalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2316",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tököl",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2317",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetcsép",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2318",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2319",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szigetbecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2322",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Makád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2330",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dunaharaszti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2335",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Taksony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2336",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dunavarsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2337",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Délegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2338",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Áporka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2339",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Majosháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2340",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kiskunlacháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dömsöd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Apaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2347",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Bugyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Alsónémedi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2360",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Gyál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2363",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Felsőpakony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2364",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2365",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Inárcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2366",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kakucs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2367",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Újhartyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dabas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2371",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dabas, Sári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2373",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dabas, Gyón",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tatárszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2376",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Hernád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2377",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Örkény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2378",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pusztavacs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2381",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Táborfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Dunaújváros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2407",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Dunaújváros, Pálhalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2421",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nagyvenyim",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2422",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mezőfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2423",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Daruszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2424",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Előszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2425",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nagykarácsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2426",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Baracs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2427",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Baracs, Apátszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2428",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kisapostag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Perkáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Szabadegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2433",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárosd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Hantos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nagylók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2440",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Százhalombatta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Ercsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2453",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Ercsi, Sinatelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2454",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Iváncsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2455",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Beloiannisz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2456",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Besnyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2457",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Adony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2458",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kulcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2459",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Rácalmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tárnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2462",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Martonvásár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Tordas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Gyúró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2465",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Ráckeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Baracska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2472",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kajászó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Vál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kápolnásnyék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2476",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Pázmánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Vereb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2481",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Velence",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2483",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Gárdony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Gárdony, Agárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2485",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Gárdony, Dinnyés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2490",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Pusztaszabolcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Esztergom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2508",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Esztergom, Pilisszentlélek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2509",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Esztergom, Kertváros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2510",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dorog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kesztölc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2518",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Leányvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2519",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Piliscsév",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Csolnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Sárisáp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2524",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Nagysáp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bajna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2526",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Epöl",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Máriahalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2528",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Úny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2529",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Annavölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2531",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tokod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tokodaltáró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bajót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2535",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Mogyorósbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2536",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Nyergesújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2541",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Lábatlan",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2543",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Süttő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2544",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Neszmély",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2545",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dunaalmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vác",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2610",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nőtincs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2610",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ősagárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2611",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Felsőpetény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2612",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kosd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2613",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Rád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2614",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Penc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2615",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csővár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2616",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Keszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2617",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Alsópetény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2618",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nézsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2619",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Legénd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Verőce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kismaros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szokolya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kóspallag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2626",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagymaros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Zebegény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2628",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Szob",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2629",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Márianosztra",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2631",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ipolydamásd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2632",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Letkés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2633",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ipolytölgyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2634",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagybörzsöny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Vámosmikola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tésa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2637",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Perőcsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2638",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kemence",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2639",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Bernecebaráti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2640",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szendehely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2641",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Berkenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2642",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2643",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Diósjenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2644",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Borsosberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2645",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nagyoroszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2646",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Drégelypalánk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2647",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Hont",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Patak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2649",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Dejtár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2651",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Rétság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2652",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Tereske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2653",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bánk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2654",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Romhány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2655",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kisecset",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2655",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kétbodony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2655",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szente",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2656",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szátok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2657",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Tolmács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2658",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Horpács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2658",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Pusztaberki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2659",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Érsekvadkert",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Balassagyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ipolyszög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2668",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Patvarc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2669",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ipolyvece",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Őrhalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Hugyag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Csitár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2674",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Iliny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádmarcal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2676",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Cserhátsurány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2677",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Herencsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2678",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Csesztve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Galgagyörk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2682",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Püspökhatvan",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Acsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2685",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádsáp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2686",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Galgaguta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2687",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bercel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2688",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Vanyarc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2691",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádkövesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2692",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szécsénke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2693",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Becske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2694",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Cserháthaláp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2694",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Debercsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2694",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Magyarnándor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2696",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Terény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2697",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szanda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2698",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mohora",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2699",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szügy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Cegléd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2711",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápiószentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nyársapát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2713",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Csemő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Pilis",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nyáregyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Újlengyel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2730",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Albertirsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Dánszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2736",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Mikebuda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Ceglédbercel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2738",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Cegléd, Budai út",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2740",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Abony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kőröstetétlen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2746",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Jászkarajenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Törtel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2750",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagykőrös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2755",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Kocsér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2760",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Nagykáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápióbicske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Farmos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápiószele",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápiógyörgye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Újszilvás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2769",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1059,
+    "state_code": "PE",
+    "locality_name": "Tápiószőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tatabánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Gyermely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2822",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Szomor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2823",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Vértessomló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2824",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Várgesztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tarján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2832",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Héreg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Vértestolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tardos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2835",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tata, Agostyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Baj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Vértesszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2840",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Oroszlány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2851",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Környe",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2852",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kecskéd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2853",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kömlőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2854",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2855",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bokod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2856",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Szákszend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2858",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Császár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2859",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Vérteskethely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2861",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bakonysárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2862",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Aka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2870",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kisbér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2879",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kisbér, Hánta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2881",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Ászár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2882",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kerékteleki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2883",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bársonyos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2884",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bakonyszombathely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2885",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bakonybánk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2886",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Réde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2887",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Ácsteszér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2888",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Csatka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2889",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Súr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2890",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tata",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2896",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Szomód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2897",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Dunaszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2898",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2899",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Naszály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Komárom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2903",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Komárom, Koppánymonostor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2911",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Mocsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Komárom, Szőny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Almásfüzitő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2941",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Ács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2942",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Nagyigmánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bábolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tárkány, Ölbőpuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Bana",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Tárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Csép",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2947",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Ete",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2948",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Kisigmánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "2949",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 5085,
+    "state_code": "KE",
+    "locality_name": "Csém",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Hatvan",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3009",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kerekharaszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3011",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Heréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3012",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagykökényes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3013",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Ecséd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3014",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Hort",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3015",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Csány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3016",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Boldog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3021",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Lőrinci",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3022",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Lőrinci, Mátravidéki erőmű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3023",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Petőfibánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3024",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Lőrinci, Selyp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3031",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Zagyvaszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3032",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Apc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3033",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Rózsaszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3034",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szűcsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3035",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyöspata",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3036",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyöstarján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3041",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Héhalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Palotás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3043",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Egyházasdengeleg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3044",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szirák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3046",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kisbágyon",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3047",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Buják",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szarvasgede",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3052",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Csécse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ecseg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kozárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3060",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Pásztó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Jobbágyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szurdokpüspöki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Pásztó, Hasznos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bokor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Cserhátszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kutasó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Felsőtold",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Garáb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3068",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátraszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3069",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Alsótold",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3070",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bátonyterenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3073",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Tar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Sámsonháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kisbárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Márkháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nagybárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3077",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátraverebély",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3078",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bátonyterenye, Kisterenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Pásztó, Mátrakeresztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Salgótarján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3102",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Salgótarján, Baglyasalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3104",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Salgótarján, Zagyvapálfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3109",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Salgótarján, Salgóbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Somoskőújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Cered",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Zabar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szilaspogony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Bárna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3127",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kazár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3128",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Vizslás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3129",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Lucfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3129",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nagykeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Sóshartyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádmegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Magyargéc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Piliny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szécsényfelfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Etes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3137",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Karancsberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3138",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ipolytarnóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Salgótarján, Zagyvaróna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátraszele",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátranovák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátranovák, Bányatelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátraterenye, Homokterenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátraterenye, Nádújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3147",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kazár, Mizserfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3151",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Rákóczibánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3152",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nemti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3153",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Dorogháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3154",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szuha",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3155",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mátramindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Kishartyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ságújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Karancsság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szalmatercs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Endrefalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3170",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Szécsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nagylóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3176",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Hollókő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3177",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Rimóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3178",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Varsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3179",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádsipek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Karancsalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Karancslapujtő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Karancskeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Mihálygerge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3185",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Egyházasgerge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3186",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Litke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3187",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Nógrádszakál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3188",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1051,
+    "state_code": "NO",
+    "locality_name": "Ludányhalászi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyösoroszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyöshalász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3213",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Atkár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3214",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagyréde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3221",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyös, Kékestető",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3231",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyössolymos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3232",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyös, Mátrafüred",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Gyöngyös, Mátraháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3234",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mátraszentimre, Galyatető",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mátraszentimre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3240",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Parád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3242",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Parádsasvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bodony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3245",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Recsk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3246",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mátraderecske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3247",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mátraballa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3248",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Ivád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3250",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Pétervására",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3252",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Erdőkövesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Istenmezeje",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3254",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Váraszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3255",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Fedémes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3256",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kisfüzes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3257",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bükkszenterzsébet",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3258",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnalelesz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3259",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szentdomonkos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3261",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Abasár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3261",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Pálosvörösmart",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3262",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Markaz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3263",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Domoszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3264",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kisnána",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3265",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Vécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3271",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Visonta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Visonta, Mátrai Erőmű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3273",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Halmajugra",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3274",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Ludas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3275",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Detk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3281",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Karácsond",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3282",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagyfüged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3283",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnazsadány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3284",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnaméra",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3291",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Vámosgyörk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3292",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Adács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3293",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Visznek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3294",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnaörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3295",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Erk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3296",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Zaránk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Eger",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egerbakta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3322",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Hevesaranyos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3323",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szarvaskő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3324",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Felsőtárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3325",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Noszvaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3326",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Ostoros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3327",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Novaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3328",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egerszólát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3331",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnaszentmária",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3332",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Sirok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3333",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Terpes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3334",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szajla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3335",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bükkszék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3336",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bátor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3337",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egerbocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egercsehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szúcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bekölce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mikófalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mónosbél",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bélapátfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Bükkszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3347",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Balaton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szilvásvárad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3349",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagyvisnyó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3350",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Verpelét",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Feldebrő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Aldebrő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tófalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3355",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3356",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kompolt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3357",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagyút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3358",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Erdőtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3359",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tenk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3360",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Heves",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3368",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Boconád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3369",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnabod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3371",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Átány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3372",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kömlő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3373",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Besenyőtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3374",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Dormánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mezőtárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3377",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Szihalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3378",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Mezőszemere",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3379",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egerfarmos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3381",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Pély",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3382",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tarnaszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3383",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Hevesvezekény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3384",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kisköre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3385",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Tiszanána",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3386",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Sarud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3387",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Újlőrincfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3388",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Poroszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3390",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Füzesabony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3394",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Egerszalók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3395",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Demjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3396",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Kerecsend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3397",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Maklár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3398",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Nagytálya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3399",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1040,
+    "state_code": "HE",
+    "locality_name": "Andornaktálya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőkövesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3411",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szomolya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3412",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bogács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3413",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Cserépfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3414",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bükkzsérc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3416",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tard",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3417",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Cserépváralja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3418",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szentistván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3421",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőnyárád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3422",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bükkábrány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3423",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tibolddaróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3424",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3425",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3426",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodgeszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vatta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Emőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3433",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nyékládháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3441",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőkeresztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3442",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csincse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőnagymihály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3444",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gelej",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3450",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőcsát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3458",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszakeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3459",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Igrici",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Egerlövő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3462",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodivánka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Négyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszavalk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3465",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszabábolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3466",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszadorogma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3467",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ároktő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3501",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3508",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3518",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3519",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3524",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3526",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3528",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3529",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3530",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3531",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3535",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ónod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Muhi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kistokaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3554",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bükkaranyos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Harsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kisgyőr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3557",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bükkszentkereszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3558",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Miskolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3559",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Répáshuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőzsolca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3562",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Onga",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3563",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádkak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3564",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádnémeti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3565",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszalúc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3571",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsózsolca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3572",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajólád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3573",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajópetri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3574",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bőcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3575",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Berzék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3576",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóhídvég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3577",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Köröm",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3578",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Girincs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3578",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kiscsécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3579",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kesznyéten",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3580",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszaújváros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3586",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóörös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3587",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszapalkonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3588",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejőkürt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3589",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszatarján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3591",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Oszlár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3592",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nemesbikk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3593",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejőbába",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3594",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejőpapi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3595",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejőszalonta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3596",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szakáld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3597",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejőkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3598",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nagycsécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3599",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajószöged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3604",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Bánszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3608",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Farkaslyuk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Uraj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Uppony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Szentsimon",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3626",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hangony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Domaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kissikátor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3630",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Putnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Dubicsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajógalgóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vadna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3641",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nagybarca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3642",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bánhorváti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3643",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Dédestapolcsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3644",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tardona",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3645",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mályinka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3646",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nekézseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3647",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csokvaomány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bükkmogyorósd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csernely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Lénárddaróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3651",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Center",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3652",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajónémeti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3653",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajópüspöki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3654",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bánréve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3655",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hét",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3656",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajómercse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3656",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóvelezd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3657",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Királd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3658",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodbóta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3659",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Hódoscsépány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3662",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ózd, Somsálybánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3663",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Arló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Járdánháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodnádasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodnádasd, Lemezgyár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kazincbarcika",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3704",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Berente",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3711",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szirmabesenyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajósenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóvámos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3713",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Arnót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3714",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajópálfala",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3715",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gesztely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3716",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sóstófalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3716",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Újcsanálos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3717",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsódobsza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3718",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Megyaszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóivánka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajókaza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Dövény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőnyárád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Jákfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3722",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőkelecsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Zubogy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ragály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Trizs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Imola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsószuha",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szuhafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Zádorfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gömörszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kelemér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3729",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Serényfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szuhakálló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kurityán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rudabánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3734",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szuhogy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsótelekes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőtelekes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kánó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Izsófalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rudolftelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ormosbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3744",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Múcsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szendrőlád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Galvács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szendrő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3753",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Meszes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szalonna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3755",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Martonyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Perkupa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Varbóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szőlősardó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Teresztenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Égerszög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3758",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Jósvafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3759",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Aggtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szin",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szinpetri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornakápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szögliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bódvaszilas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bódvarákó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Komjáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornabarakony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornaszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornanádaska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Becskeháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bódvalenke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hidvégardó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3769",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornaszentjakab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3770",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajószentpéter",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajókápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajólászlófalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kondó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3776",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Radostyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3777",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Parasznya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3778",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Varbó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3779",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alacska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3780",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Balajt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3780",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Damak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3780",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Edelény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3780",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ládbesenyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3783",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Edelény, Finke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3786",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hegymeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3786",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Irota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3786",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Lak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3786",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szakácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3787",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tomor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3791",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajókeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3792",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóbábony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3793",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sajóecseg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3794",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Boldva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3794",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ziliz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3795",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hangács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3795",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nyomár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3796",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Borsodszirák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szikszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3809",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújszolnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3809",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nyésta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3809",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Selyeb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsóvadász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3812",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Homrogd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3812",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Monaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3813",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kupa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsővadász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3815",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3815",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gadna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3816",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gagyvendégi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3817",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gagybátor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Büttös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Keresztéte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Krasznokvajda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pamlény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Perecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szászfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Debréte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rakaca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Viszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3826",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rakacaszend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kázsmárk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3832",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Léh",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rásonysápberencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Beret",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Detek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Baktakék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsógagy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csenyéte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőgagy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gagyapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Aszaló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3842",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Halmaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kiskinizs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3844",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nagykinizs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3844",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szentistvánbaksa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3846",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádkércs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3847",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsődobsza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3848",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csobád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3849",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Forró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3851",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ináncs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3852",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3853",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádbűd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3853",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pere",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3854",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gibárt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3855",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Fancsal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3860",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Encs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3863",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szalaszend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3864",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Fulókércs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3865",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Fáj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3866",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Litka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3866",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szemere",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3871",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Méra",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3872",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Novajidrány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3873",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Garadna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3874",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádpetri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3874",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádvécse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3874",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pusztaradvány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3875",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádszurdok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3876",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hidasnémeti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3877",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tornyosnémeti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3881",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3881",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Baskó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3881",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sima",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3882",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújalpár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3882",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújkér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3884",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Boldogkőújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3885",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Arka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3885",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Boldogkőváralja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3886",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Korlát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3887",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hernádcéce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3888",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vizsoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3891",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vilmány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3892",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hejce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3893",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Fony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3893",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mogyoróska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3893",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Regéc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3894",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Göncruszka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3895",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gönc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3896",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Telkibánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3897",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Zsujta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3898",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Abaújvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3898",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pányok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3899",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kéked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szerencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3902",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szerencs, Ond",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3903",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bekecs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3904",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Legyesbénye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3905",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Monok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3906",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Golop",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3907",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tállya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3908",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Rátka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3909",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3910",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tokaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tarcal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3916",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bodrogkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3917",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bodrogkisfalud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szegi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Szegilong",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Taktaszada",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3922",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Taktaharkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Gesztely, Újharangod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3924",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Taktakenéz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Prügy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3926",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Taktabáj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3927",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Csobaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3928",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszatardos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3929",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszaladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mezőzombor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Erdőbénye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3933",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Olaszliszka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tolcsva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Erdőhorváti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3936",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Háromhuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3937",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Komlóska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3941",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vámosújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3942",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sárazsadány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bodrogolaszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sátoraljaújhely, Károlyfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sátoraljaújhely, Rudabányácska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3950",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sárospatak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Györgytarló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3955",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kenézlő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3956",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Viss",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Zalkod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3958",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hercegkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3959",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Makkoshotyka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3961",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vajdácska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3962",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Karos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3963",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Karcsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3964",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pácin",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3965",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kisrozvágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3965",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nagyrozvágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3967",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Lácacséke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3971",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszakarád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3972",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Tiszacsermely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Cigánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3974",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Ricse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3974",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Semjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Révleányvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Zemplénagárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3978",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Dámóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3980",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sátoraljaújhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsóberecki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőberecki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3987",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bodroghalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3988",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Sátoraljaújhely, Széphalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3989",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Alsóregmec",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3989",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Felsőregmec",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3989",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Mikóháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3991",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vilyvitány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kovácsvágás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Vágáshuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3993",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Füzérradvány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Bózsva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Filkeháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Füzérkajata",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Kishuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nagyhuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pálháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3995",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Pusztafalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3996",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Füzér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3997",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Füzérkomlós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3998",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Nyíri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "3999",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1058,
+    "state_code": "BZ",
+    "locality_name": "Hollóháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4002",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4024",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4025",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4026",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4027",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4028",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4029",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4030",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4031",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4032",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4033",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4034",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4060",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Balmazújváros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nagyhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Újszentmargita",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Tiszacsege",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Egyek, Telekháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4069",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Egyek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hortobágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúböszörmény, Nagypród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Görbeháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4078",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4079",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4080",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúnánás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúnánás, Tedej",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúböszörmény, Hajdúvid",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4087",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúdorog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4090",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Polgár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Folyás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Újtikos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Tiszagyulaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Berettyóújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4110",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Biharkeresztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4114",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bojt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4115",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Ártánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4116",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Berekböszörmény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4117",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Told",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4118",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Mezőpeterd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4119",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Váncsod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Szentpéterszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Gáborján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hencida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Esztár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Pocsaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Kismarja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4127",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nagykereki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4128",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bedő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4130",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Derecske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Tépe",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Konyár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Mezősas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Körösszegapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Körösszakál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4137",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Magyarhomorog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4138",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Komádi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Furta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Zsáka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Vekerd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Darvas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Csökmő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Újiráz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4150",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Püspökladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Báránd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Szerep, Hosszúhát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Szerep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bakonszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4171",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Sárrétudvari",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4172",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Biharnagybajom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4173",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nagyrábé",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bihartorda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bihardancsháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4176",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Sáp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4177",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Földes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nádudvar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Kaba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Tetétlen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúszoboszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Ebes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúszovát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4220",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúböszörmény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4224",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúböszörmény, Bodaszőlő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Debrecen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4231",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Bököny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4232",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Geszteréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Balkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4234",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szakoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Biri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bocskaikert",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4242",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúhadház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Téglás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4244",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Újfehértó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4245",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Érpatak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4246",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Butykatelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4251",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúsámson",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4252",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyíradony, Tamásipuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyíradony, Aradványpuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4254",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyíradony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4262",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyíracsád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4263",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyírmártonfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4264",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Nyírábrány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4266",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Fülöp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4267",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Penészlek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4271",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Mikepércs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Sáránd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4273",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hajdúbagos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4274",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Hosszúpályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4275",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Monostorpályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4281",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Létavértes, Nagyléta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4283",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Létavértes, Vértes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4284",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Kokad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4285",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Álmosd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4286",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Bagamér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4287",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Vámospércs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4288",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1063,
+    "state_code": "HB",
+    "locality_name": "Újléta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírbátor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4311",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírgyulaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4320",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagykálló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4324",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kállósemjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4325",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisléta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4326",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Máriapócs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4327",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Pócspetri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4331",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírcsászári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4332",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírderzs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4333",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírkáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4334",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Hodász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4335",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kántorjánosi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4336",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Őr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4337",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Jármi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4338",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Papos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírvasvári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4342",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Terem",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Bátorliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vállaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mérk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiborszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Fábiánháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4355",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyecsed",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4356",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírcsaholy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4361",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírbogát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírgelse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4363",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírmihálydi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4371",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírlugos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4372",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírbéltek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4373",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ömböly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4374",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Encsencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Piricse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4376",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírpilis",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4405",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Borbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Sóstófürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Nyírszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4433",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Felsősima",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kálmánháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4440",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszavasvári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4441",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szorgalmatos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4445",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagycserkesz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4446",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszaeszlár, Bashalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4447",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszalök, Kisfástanya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4450",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszalök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4455",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszadada",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4456",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszadob",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszanagyfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszaeszlár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4465",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Rakamaz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4466",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Timár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4467",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szabolcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4468",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Balsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gávavencsellő, Gáva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4472",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gávavencsellő, Vencsellő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszabercel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Paszab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4481",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Sóstóhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4482",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kótaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4483",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Buj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ibrány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4485",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyhalász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4486",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszatelek, Kétérköz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4487",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszatelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4488",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Beszterec",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4491",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Újdombrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4492",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Dombrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4493",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszakanyár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4494",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kékcse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4495",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Döge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4496",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szabolcsveresmart",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4501",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kemecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4502",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vasmegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4503",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszarád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4511",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírbogdány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Demecser",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gégény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Berkesz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírtass",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Pátroha",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4524",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ajak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Rétközberencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4531",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírpazony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírtura",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Sényő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Székely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4535",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíribrony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4536",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ramocsaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4537",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírkércs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4541",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírjákó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4542",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Petneháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4543",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Laskod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4544",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírkarász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4545",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gyulaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4546",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Anarcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4547",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szabolcsbáka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyíregyháza, Oros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Napkor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Apagy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4554",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírtét",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Levelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Magy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4557",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Besenyőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4558",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ófehértó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Baktalórántháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4562",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vaja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4563",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Rohod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4564",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírmada",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4565",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Pusztadobos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4566",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ilk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4567",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gemzse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisvárda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4611",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Jéke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Fényeslitke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Komoró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tuzsér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszabezdéd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Győröcske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Záhony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Zsurk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4628",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszaszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4631",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Pap",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4632",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírlövő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4633",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Lövőpetri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4634",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Aranyosapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Újkenéz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4641",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mezőladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4642",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tornyospálca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4643",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Benk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4644",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mándok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4645",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszamogyorós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4646",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Eperjeske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mátészalka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamoskér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4722",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírmeggyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tunyogmatolcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Cégénydányád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gyügye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4734",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamosújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Hermánszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamossályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Darnó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisnamény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Jánkmajtis",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csegöld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csengersima",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamosbecs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4746",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamostatárfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kocsord",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Győrtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Fülpösdaróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Géberjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4755",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ököritófülpös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Rápolt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Porcsalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tyukod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ura",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csengerújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csenger",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Komlódtótfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Pátyod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamosangyalos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vásárosnamény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4803",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vásárosnamény, Gergelyiugornya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4804",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vásárosnamény, Vitka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisvarsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4812",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyvarsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4813",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gyüre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Ópályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4822",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nyírparasznya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4823",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagydobos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4824",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szamosszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4826",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Olcsva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszaszalka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4832",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszavid",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszaadony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszakerecseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4835",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mátyus",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Lónya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Jánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4842",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gulács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Hetefejércse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4844",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csaroda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4845",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tákos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Fehérgyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4911",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nábrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kérsemjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Panyola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Olcsvaapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tivadar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4922",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tarpa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Márokpapi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4933",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Beregsurány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Beregdaróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gelénes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4936",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vámosatya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4937",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Barabás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4941",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Penyige",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4942",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Mánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4942",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nemesborzova",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kömörő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Túristvándi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Szatmárcseke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszakóród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4947",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszacsécse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4948",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Milota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tiszabecs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4952",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Uszka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4953",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Magosliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Sonkád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4955",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Botpalád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4956",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kispalád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4961",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Zsarolyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4962",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyszekeres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4963",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kisszekeres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4964",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Fülesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4965",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kölcse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4966",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Vámosoroszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4967",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Csaholc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4968",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Túrricse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4969",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Tisztaberek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4971",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Rozsály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4972",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Gacsály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Császló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4974",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Zajta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4975",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Méhtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Garbolc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Kishódos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "4977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1045,
+    "state_code": "SZ",
+    "locality_name": "Nagyhódos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Szolnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5008",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Szolnok, Szandaszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Zagyvarékas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5052",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Újszász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Szászberek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5054",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászalsószentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5055",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5061",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszasüly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kőtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Hunyadfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Csataszög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Nagykörű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Besenyszög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Szajol",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszatenyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kengyel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5084",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Rákócziújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Rákóczifalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5091",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tószeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszavárkony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Vezseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5094",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszajenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszavárkony, Tiszavárkonyi Szőlők",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászfelsőszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászjákóhalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászdózsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászárokszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászágó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Pusztamonostor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászfényszaru",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5130",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászivány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5137",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászkisér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jásztelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Alattyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jánoshida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászboldogháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5152",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Jászberény, Portelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Törökszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszapüspöki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Törökszentmiklós, Surjány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5213",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Fegyvernek, Szapárfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5222",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Örményes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5231",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Fegyvernek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5232",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszabő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszagyenda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5234",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaroff",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszabura",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Abádszalók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaderzs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5244",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Karcag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5309",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Berekfürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5310",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kisújszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kunmadaras",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5322",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaszentimre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5323",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaszentimre, Újszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5324",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tomajmonostora",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5331",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kenderes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5340",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kunhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5349",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kenderes, Bánhalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5350",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszafüred",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5358",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszafüred, Tiszaörvény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5359",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszafüred, Kócsújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5361",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaigar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5363",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Nagyiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Mezőtúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5411",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kétpó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5412",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kuncsorba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5420",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Túrkeve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5430",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaföldvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Martfű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5440",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kunszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5449",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Kunszentmárton, Kungyalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Öcsöd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5452",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Mesterszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5453",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Mezőhék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszaföldvár, Homok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5462",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Cibakháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Nagyrév",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszainoka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5465",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Cserkeszőlő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszakürt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Tiszasas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Csépa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5476",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1043,
+    "state_code": "JN",
+    "locality_name": "Szelevény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gyomaendrőd, Gyoma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5502",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gyomaendrőd, Endrőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5510",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Dévaványa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Ecsegfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Körösladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5520",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Szeghalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Füzesgyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5526",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kertészsziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Bucsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5530",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Vésztő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Okány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5536",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Körösújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5537",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Zsadány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5538",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Biharugra",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5539",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Körösnagyharsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5540",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Szarvas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Csabacsűd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kardos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kondoros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Hunya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Örménykút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békésszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békéscsaba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5609",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Csabaszabadi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Csárdaszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Köröstarcsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békéscsaba, Gerla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Doboz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5630",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5641",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Tarhos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5643",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Bélmegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5650",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Mezőberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Újkígyós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5662",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Csanádapáca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5663",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Medgyesbodzás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Medgyesbodzás, Gábortelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5665",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Pusztaottlaka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5666",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Medgyesegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5667",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Magyarbánhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5668",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Nagybánhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békéscsaba, Mezőmegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Murony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kamut",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5674",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kétsoprony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Telekgerendás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gyula",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5711",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gyula, Gyulavári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Szabadkígyós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Sarkad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kötegyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Méhkerék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5727",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Újszalonta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Sarkadkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Mezőgyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5734",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Geszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kétegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Elek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Lőkösháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5744",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kevermes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Dombiratos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5746",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kunágota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Almáskamarás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Nagykamarás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Medgyesegyháza, Bánkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Mezőkovácsháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Végegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5820",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Mezőhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5830",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Battonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Dombegyház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kisdombegyház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Magyardombegyház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Orosháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5903",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Orosháza, Rákóczitelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5904",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Orosháza, Gyopárosfürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5905",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Orosháza, Szentetornya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5919",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Pusztaföldvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5920",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Csorvás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gerendás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Nagyszénás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Gádoros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5940",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Tótkomlós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kardoskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Békéssámson",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "5948",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1060,
+    "state_code": "BE",
+    "locality_name": "Kaszaper",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kecskemét",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6008",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kecskemét, Méntelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6031",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6032",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Nyárlőrinc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6033",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Városföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6034",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Helvécia",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6035",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Ballószög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6041",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kerekegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Fülöpháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6043",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunbaracs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6044",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kecskemét, Hetényegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Ladánybene",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6050",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Lajosmizse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6055",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Felsőlajos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6060",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tiszakécske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tiszakécske, Tiszabög",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tiszaug",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Lakitelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tiszaalpár, Alpár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tiszaalpár, Tiszaújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6070",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Izsák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6075",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Páhi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6076",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Ágasegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6077",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Orgovány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6078",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Jakabszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6080",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szabadszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Fülöpszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szalkszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6087",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunavecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6088",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Apostag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6090",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunpeszér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunadacs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6098",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tass",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kiskunfélegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Gátér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6112",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Pálmonostora",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6113",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Petőfiszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6114",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bugac",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6114",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bugacpusztaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6115",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6116",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Fülöpjakab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6120",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kiskunmajsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szank",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Móricgát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Jászszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kömpöc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Csólyospálos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Harkakötöny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kiskőrös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kaskantyú",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6221",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Akasztó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6222",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Csengőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6223",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Soltszentimre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6224",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tabdi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6230",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Soltvadkert",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6236",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tázlár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6237",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kecel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6238",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Imrehegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6239",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Császártöltés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kalocsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6311",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Öregcsertő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6320",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Solt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Újsolt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6323",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunaegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6325",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunatetétlen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6326",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Harta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6327",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Harta, Állampuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6328",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunapataj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6331",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Foktő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6332",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Uszód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6333",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunaszentbenedek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6334",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Géderlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6335",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Ordas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6336",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szakmár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6337",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Újtelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Homokmégy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6342",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Drágszél",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Miske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Hajós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Nemesnádudvar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Sükösd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6347",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Érsekcsanád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Érsekhalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bátya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Fajsz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dusnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kiskunhalas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6411",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Zsana",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6412",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Balotaszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6413",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunfehértó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6414",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Pirtó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6421",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kisszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6422",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tompa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6423",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kelebia",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6424",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Csikéria",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6425",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bácsszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6430",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bácsalmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kunbaja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6440",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Jánoshalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6444",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Kéleshalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6445",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Borota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6446",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Rém",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6447",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Felsőszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6448",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Csávoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6449",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Mélykút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Tataháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6452",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Mátételke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6453",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bácsbokod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6454",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bácsborsód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6455",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Katymár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6456",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Madaras",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Baja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6503",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Baja, Bajaszentistván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6511",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bácsszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6512",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Szeremle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6513",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dunafalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Vaskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Gara",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Csátalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6524",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Dávod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Hercegszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Nagybaracska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6528",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1048,
+    "state_code": "BK",
+    "locality_name": "Bátmonostor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szentes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6612",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Nagytőke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Derekegyház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Nagymágocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Árpádhalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Eperjes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Fábiánsebestyén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6630",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Mindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szegvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Mártély",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6640",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csongrád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6645",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Felgyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6646",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Tömörkény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6647",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csanytelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csongrád, Bokros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6710",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6722",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6727",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6729",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6750",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Algyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6753",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Újszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6755",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Kübekháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Tiszasziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6758",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Röszke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6760",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Kistelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Sándorfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szatymaz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Balástya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csengele",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Dóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Ópusztaszer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Baks",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6769",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Pusztaszer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6771",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Deszk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Klárafalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Ferencszállás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Kiszombor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6781",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Domaszék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Mórahalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6783",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Ásotthalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Öttömös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6785",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Pusztamérges",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6786",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Ruzsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6787",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Zákányszék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6791",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Szeged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6792",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Zsombó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6793",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Forráskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6794",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Üllés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6795",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Bordány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Hódmezővásárhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6805",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Hódmezővásárhely, Kútvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6806",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Hódmezővásárhely, Szikáncs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Székkutas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Makó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6903",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Makó, Rákos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6911",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Királyhegyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Kövegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csanádpalota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Pitvaros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Csanádalberti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6916",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Ambrózfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6917",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Nagyér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Maroslele",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6922",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Földeák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Óföldeák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Apátfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Magyarcsanád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "6933",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1031,
+    "state_code": "CS",
+    "locality_name": "Nagylak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárbogárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7003",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárbogárd, Sárszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7011",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Alap",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7012",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Alsószentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7013",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Cece",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7014",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sáregres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7015",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Igar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7016",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Igar, Vámszőlőhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7017",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mezőszilas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7018",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárbogárd, Pusztaegres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7019",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárbogárd, Sárhatvan",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7020",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Dunaföldvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7025",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bölcske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7026",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Madocsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7027",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Paks, Dunakömlőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7030",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Paks",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7038",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Pusztahencse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7039",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Németkér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7041",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Vajta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Pálfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7043",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bikács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7044",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagydorog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Györköny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7047",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Sárszentlőrinc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kajdacs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7052",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kölesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7054",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tengelic",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7056",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szedres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7057",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Medina",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7061",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Belecska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Keszőhidegkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szárazd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Gyönk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Miszla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Udvari",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7067",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Varsád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7068",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kistormás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szakadát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7072",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Diósberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Simontornya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kisszékely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tolnanémedi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7084",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Pincehely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagyszékely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Ozora",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7087",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Fürged",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7090",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tamási",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7091",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Pári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagykónyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Értény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7094",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Koppányszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Iregszemcse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Újireg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagyszokoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7098",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Magyarkeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7099",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Felsőnyék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szekszárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szálka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kakasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7130",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tolna, Mözs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bogyiszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Fadd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Gerjen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Dunaszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Fácánkert",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7140",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bátaszék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Pörböly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Őcsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Decs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Sárpilis",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Várdomb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7147",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Alsónána",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7148",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Alsónyék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7149",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Báta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7150",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bonyhád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7158",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bonyhádvarasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7159",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kisdorog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Cikó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Grábóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Mőcsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bátaapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Mórágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7171",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Sióagárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7172",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Harc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7173",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Zomba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kéty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Felsőnána",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7176",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Murga",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Tevel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Závod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kisvejke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Lengyel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7185",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Mucsfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7186",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Aparhant",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7186",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagyvejke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7187",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Bonyhád, Majos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7188",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szárász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7191",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Hőgyész",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7192",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szakály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7193",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Regöly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7194",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kalaznó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7195",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Mucsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Dombóvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Dalmand",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7212",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kocsola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7213",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Szakcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7214",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Lápafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7214",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Várong",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7215",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7224",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Dúzs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Csibrák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7226",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kurd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7227",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Gyulaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7228",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Döbrököz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7251",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kapospula",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7252",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Attala",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csoma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szabadi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7255",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagyberki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7256",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kercseliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7257",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Mosdós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7258",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Baté",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7258",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7261",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposhomok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7261",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Taszár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7271",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Fonó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gölle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7273",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Büssü",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7274",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kazsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7275",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Igal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7276",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gadács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7276",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyszil",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7279",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kisgyalán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7281",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bonnya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7282",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Fiad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7282",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kisbárapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7283",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyacsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7284",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogydöröcske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7285",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kára",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7285",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szorosad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7285",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Törökkoppány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Komló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7304",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mánfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7305",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mecsekpölöske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7331",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Liget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7332",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyaregregy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7333",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kárász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7333",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vékény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7334",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Köblény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7334",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szalatnak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Csikóstőttős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7342",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mágocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagyhajmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mekényes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Alsómocsolád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bikal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7347",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Egyházaskozár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hegyhátmaróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tófű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7349",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szászvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Máza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Györe",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Izmény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Váralja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7355",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Nagymányok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7356",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kismányok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7357",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Jágónak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7361",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1038,
+    "state_code": "TO",
+    "locality_name": "Kaposszekcső",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gerényes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tarrós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vásárosdombó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Felsőegerszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Meződ",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Oroszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Palé",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sásd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Varga",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7370",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vázsnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7381",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisvaszar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7381",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tékes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7381",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7383",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Baranyaszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7383",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7383",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tormás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7384",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Baranyajenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7385",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gödre, Gödreszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7386",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gödre, Gödrekeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7391",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisbeszterce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7391",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kishajmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7391",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mindszentgodisa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7393",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bakóca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7394",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bodolyabér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7394",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarhertelend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7396",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarszék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zselickislak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Juta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csombárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hetes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Mezőcsokonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogysárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7436",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Újvárfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7439",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bodrog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7441",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Magyaregres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7442",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Várda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Alsóbogát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Edde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyjád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7444",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Osztopán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposvár, Kaposfüred",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7452",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyaszaló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7453",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Mernye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7454",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somodor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7455",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogygeszti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7456",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Felsőmocsolád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7457",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ecseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7458",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Polány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Orci",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Magyaratád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Patalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ráksi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7465",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szentgáloskér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zimány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7472",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Cserénfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7472",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szentbalázs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gálosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hajmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposgyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Simonfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zselicszentpál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bőszénfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7476",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposszerdahely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Patca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szenna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szilvásszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zselickisfalud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7478",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bárdudvarnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7479",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Sántos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagyatád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7511",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ötvöskónyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7512",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Mike",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7513",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Rinyaszentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7514",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tarany",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyudvarhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Berzence",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bolhás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposmérő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaposfő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kisasszond",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7524",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kiskorpád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7525",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Jákó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7526",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csököly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gige",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7527",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Rinyakovácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7530",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kadarkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7530",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kőkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hencse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hedrehely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Visnye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7535",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Lad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7536",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Patosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7537",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Homokszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7538",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kálmáncsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7539",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szulok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7541",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kutas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7542",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kisbajom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7543",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Beleg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7544",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szabás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7545",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagykorpád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Lábod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Rinyabesenyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Görgeteg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csokonyavisonta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Rinyaújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7557",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Barcs, Somogytarnóca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagybajom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Pálmajor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7562",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Segesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7563",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyszob",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7564",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kaszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7570",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Barcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7582",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Komlósd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7582",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Péterhida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7584",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Babócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7584",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Rinyaújnép",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7584",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyaracs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7585",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bakháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7585",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Háromfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7586",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bolhó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7587",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Heresznye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7588",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Vízvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7589",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bélavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7626",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7628",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7629",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7630",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7631",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7632",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7633",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7634",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7639",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kökény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7639",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Erzsébet",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kátoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kékesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szellő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7663",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Máriakéménd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Berkesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pereked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szilágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7666",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pogány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7668",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gyód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7668",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Keszü",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Aranyosgadány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bicsérd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Zók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Boda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Cserkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kővágószőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bakonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kővágótöttös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7677",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Orfű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7678",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Abaliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7678",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Husztót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7678",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kovácsszénája",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hetvehely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Okorvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szentkatalin",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7682",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bükkösd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Cserdi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Dinnyeberki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Helesfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7691",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7693",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7694",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hosszúhetény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7695",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mecseknádasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7695",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Óbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7695",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ófalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7696",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hidas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mohács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7711",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Dunaszekcső",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7714",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mohács, Újmohács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7715",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mohács, Sárhát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7716",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Homorúd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7717",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kölked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7718",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Udvar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Apátvarasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lovászhetény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Martonfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécsvárad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7720",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Zengővárkony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Erdősmecske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Feked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szebény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Véménd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7727",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Palotabozsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Görcsönydoboka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Somberek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagypall",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Fazekasboda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Geresdlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Maráza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Erdősmárok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Himesháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szűr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Székelyszabar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagykozár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bogád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Romonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7744",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ellend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hásságy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Olasz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Belvárdgyula",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Birján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Monyoród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szederkény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Versend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7753",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szajk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bóly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7755",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Töttös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Borjád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisbudmér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagybudmér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Babarc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Liptód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7759",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisnyárád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7759",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lánycsók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kozármisleny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lothárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarsarlós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécsudvard",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Egerág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisherend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szemely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szőkéd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Áta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kiskassa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Peterd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécsdevecser",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Újpetre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kistótfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7768",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vokány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7771",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Palkonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ivánbattyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Villánykövesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisjakabfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Villány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Márok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Illocska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kislippó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lapáncsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarbóly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7781",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ivándárda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7781",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lippó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7781",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sárok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bezedek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7783",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Majs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagynyárád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7785",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sátorhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisharsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagytótfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Siklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bisse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bosta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Csarnóta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szalánta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szilvás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Túrony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7812",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Garé",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7813",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szava",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Babarcszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisdér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Siklósbodony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ócsárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7815",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Harkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7817",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Diósviszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7817",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Márfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7817",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Rádfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7822",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagyharsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7823",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kistapolca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7823",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Siklósnagyfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7824",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Egyházasharaszti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Old",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7826",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Alsószentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7827",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Beremend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7827",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kásád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pellérd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Görcsöny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Regenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szőke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Baksa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tengeri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Téseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bogádmindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ózdfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7837",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hegyszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Besence",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hirics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Lúzsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagycsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Piskó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Páprád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vajszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7838",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vejti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7839",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kemse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7839",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Zaláta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Adorjás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Baranyahídvég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kórós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sámod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Cún",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávapiski",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kémes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szaporca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7843",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tésenfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7846",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávacsepely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7847",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávaszerdahely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7847",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ipacsfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7847",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kovácshida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7849",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávacsehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7850",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávapalkonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7851",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávaszabolcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7853",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gordisa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7854",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Matty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Botykapeterd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Csertő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szigetvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagypeterd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagyváty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nyugotszenterzsébet",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szentdénes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bánfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Katádfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Rózsafa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Dencsháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szentegát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Lakócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szentborbás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tótújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Somogyhatvan",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7922",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Somogyapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Basal",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Patapoklosi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7924",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Somogyviszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarlukafa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Somogyhárságy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7926",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Vásárosbéc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Almáskeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Mozsgó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szulimán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Almamellék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Csebény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Horváthertelend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Ibafa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7936",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7937",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Boldogasszonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7940",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Csonkamindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7940",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kacsóta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7940",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szentlőrinc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gerde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pécsbagota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szabadszentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Velény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7953",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Királyegyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gilvánfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gyöngyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisasszonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyarmecske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Magyartelek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Okorág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7958",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kákics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávaiványi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávasztára",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Marócsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sellye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sumony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Sósvertike",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7964",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Csányoszró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7966",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bogdása",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7967",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávafok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7967",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Drávakeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7967",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Markóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7968",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Felsőszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7971",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Hobol",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7972",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Gyöngyösmellék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Bürüs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Endrőc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Teklafalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Várad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7975",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kétújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Szörény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Zádor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Drávagárdony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kastélyosdombó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Potony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7979",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Drávatamási",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7980",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Pettend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kistamási",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Merenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Molvány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nemeske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Tótszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Kisdobsza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1055,
+    "state_code": "BA",
+    "locality_name": "Nagydobsza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7987",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Istvándi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "7988",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Darány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Székesfehérvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8019",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Székesfehérvár, Börgönd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8041",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csór",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8042",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Moha",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8043",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Iszkaszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8044",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kincsesbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8045",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Isztimér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8046",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Bakonykúti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8051",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárkeresztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8052",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Fehérvárcsurgó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8053",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Bodajk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8054",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Balinka, Eszény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8055",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Balinka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8056",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Bakonycsernye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8060",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mór",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8065",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nagyveleg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8066",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Pusztavám",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Magyaralmás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8072",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Söréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8073",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csákberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csókakő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8080",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Bodmér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Zámoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Gánt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csákvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Vértesboglár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Felcsút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8087",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Alcsútdoboz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8088",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Tabajd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8089",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Vértesacsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Pátka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Lovasberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Pákozd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sukoró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nadap",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Várpalota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8105",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pétfürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8109",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Seregélyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8112",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Zichyújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Tác",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Csősz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Soponya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Káloz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárszentágota",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8127",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Aba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8130",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Enying",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Enying, Balatonbozsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Lepsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mezőszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mátyásdomb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Dég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Lajoskomárom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8137",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Mezőkomárom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8138",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Szabadhídvég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8139",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Szabadhídvég, Pélpuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Úrhida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárszentmihály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Sárkeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Nádasdladány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Jenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8151",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Szabadbattyán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8152",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kőszárhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8154",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Polgárdi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8156",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Kisláng",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8157",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1044,
+    "state_code": "FE",
+    "locality_name": "Füle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ősi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Küngös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csajág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonfőkajár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8171",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonvilágos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8172",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonakarattya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonkenese",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonfűzfő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Berhida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Berhida, Peremartongyártelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Papkeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonfűzfő, Fűzfőgyártelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8191",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Öskü",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8192",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hajmáskér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8193",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Sóly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8194",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vilonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8195",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Királyszentistván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8196",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Litér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Veszprém",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8220",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonalmádi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentkirályszabadja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8226",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Alsóörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8227",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Felsőörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8228",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lovas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8229",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csopak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8229",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Paloznak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8230",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonfüred",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8237",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tihany",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Aszófő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8242",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonudvari",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8242",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Örvényes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonakali",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8244",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Dörgicse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8245",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pécsely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8245",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vászoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8246",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tótvázsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8247",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hidegkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8248",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemesvámos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8248",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Veszprémfajsz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8251",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zánka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8252",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonszepezd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8253",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Révfülöp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8254",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kékkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8254",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kővágóörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8255",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonrendes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8255",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kővágóörs, Pálköve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8256",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Salföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8256",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ábrahámhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8257",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Badacsonytomaj, Badacsonyörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8258",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Badacsonytomaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8261",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Badacsonytomaj, Badacsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8263",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Badacsonytördemic",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8264",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szigliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8265",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hegymagas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8271",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Mencshely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatoncsicsó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentantalfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentjakabfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tagyon",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8272",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Óbudavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8273",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Monoszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8274",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Köveskál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8275",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonhenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8281",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentbékkálla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8282",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Mindszentkálla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8283",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Káptalantóti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8284",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kisapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8284",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemesgulács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8286",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Gyulakeszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8291",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Barnag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8291",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagyvázsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8291",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pula",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8291",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vöröstó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8292",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Öcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8294",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kapolcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8294",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vigántpetend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8295",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Taliándörögd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8296",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hegyesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8296",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Monostorapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8297",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tapolca, Diszel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Raposka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tapolca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8308",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Sáska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8308",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zalahaláp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8311",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemesvita",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8312",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Balatonederics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8313",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Balatongyörök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8314",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vonyarcvashegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8315",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gyenesdiás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8316",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vállus",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8316",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Várvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8317",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lesencefalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8318",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lesencetomaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8319",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lesenceistvánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Uzsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8330",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Sümeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kisvásárhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Mihályfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szalapa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8342",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Óhíd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hetyefő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zalaerdőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Dabronc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Gógánfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8347",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ukk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Megyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Rigács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8348",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zalameggyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8349",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zalagyömörő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Sümegprága",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bazsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vindornyalak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszántó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Karmacs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vindornyafok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaköveskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8355",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vindornyaszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8356",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kisgörbő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8356",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagygörbő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8357",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Döbröce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8357",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sümegcsehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8360",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Keszthely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8371",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemesbük",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8372",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Cserszegtomaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8373",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Rezi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8380",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hévíz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8391",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sármellék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8392",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8393",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentgyörgyvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8394",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Alsópáhok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8395",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Felsőpáhok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ajka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8409",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Úrkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8411",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Veszprém, Kádárta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8412",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Veszprém, Gyulafirátót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8413",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Eplény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8414",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Olaszfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8415",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagyesztergár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8416",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Dudar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8417",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csetény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8418",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyoszlop",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8419",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csesznek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8420",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zirc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8422",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonynána",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8423",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szápár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8424",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Jásd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8425",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lókút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8426",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pénzesgyőr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8427",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonybél",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8428",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Borzavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8429",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Porva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8430",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyszentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bakonyszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8432",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fenyőfő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8433",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bakonygyirót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Románd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Gic",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8438",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Veszprémvarsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8439",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sikátor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8440",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Herend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8441",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Márkó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8442",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hárskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8444",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentgál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8445",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csehbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8445",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Városlőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8446",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kislőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8447",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ajka, Ajkarendek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8448",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ajka, Bakonygyepes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8449",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Magyarpolány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ajka, Padragkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8452",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Halimba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8452",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szőc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8454",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nyirád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8455",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pusztamiske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8456",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Noszlop",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8457",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonypölöske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8458",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Oroszi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8460",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Devecser",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8468",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kolontár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8469",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kamond",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bodorfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Káptalanfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemeshany",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Gyepükaján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csabrendek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Hosztót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Szentimrefalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Veszprémgalsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8476",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Zalaszegvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Apácatorna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kisberzseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8477",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Tüskevár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8478",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Somlójenő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8479",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Borszörcsök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8481",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Somlóvásárhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8482",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Doba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8483",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kisszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8483",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Somlószőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagyalásony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Somlóvecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vid",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8485",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Dabrony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8491",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Karakószörcsök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8492",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kerta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8493",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Iszkáz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8494",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kiscsősz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8495",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csögle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8496",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kispirit",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8496",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagypirit",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8497",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Adorjánháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8497",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Egeralja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8511",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápa, Borsosgyőr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8512",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nyárád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8513",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Mihályháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8514",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Mezőlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Békás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kemeneshőgyész",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Magyargencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8518",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kemenesszentpéter",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagyacsád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemesgörzsöny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Egyházaskesző",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Várkesző",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8531",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Marcaltő, Ihász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Marcaltő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Malomsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8541",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Takácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8542",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vaszar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8543",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Gecse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagygyimót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vanyola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Lovászpatona",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8554",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagydém",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonytamási",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápateszér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8557",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8557",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8558",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Csót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Adásztevel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8562",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nagytevel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8563",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Homokbödöge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8564",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ugod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8565",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Béb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8571",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonykoppány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8572",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyszücs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8581",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Bakonyjákó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8581",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Németbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8582",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Farkasgyepű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8591",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nóráp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8591",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápa, Kéttornyúlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8592",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Dáka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8593",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápadereske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8594",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápasalamon",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8595",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Kup",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8596",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápakovácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8597",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Döbrönte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8597",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Ganna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8598",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Pápa, Tapolcafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Siófok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8612",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nyim",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8613",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonendréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8614",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bálványos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8617",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kőröshegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8618",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kereki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8619",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Pusztaszemes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zamárdi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szántód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonföldvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonszárszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szólád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8626",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Teleki",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8627",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kötcse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8628",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagycsepely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8630",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonboglár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ordacsehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonszemes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8637",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonőszöd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8638",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonlelle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8640",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Fonyód",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8646",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonfenyves",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8647",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonmáriafürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8648",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8649",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8651",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonszabadi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8652",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Siójut",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8653",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ádánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8654",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Ságvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8655",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Som",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8656",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagyberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8658",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bábonymegyer",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Lulla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Sérsekszőlős",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Torvaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8660",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zala",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8666",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Bedegkér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8666",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyegres",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8667",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8668",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tengőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8669",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Miklósi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kapoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogymeggyes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8674",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nágocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Andocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8676",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Karád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Látrány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Visz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogytúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8684",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogybabod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8685",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gamás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8691",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonboglár, Szőlőskislak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8692",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gyugy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8692",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szőlősgyörök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8693",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kisberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8693",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Lengyeltóti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8694",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8695",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Buzsák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8696",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Táska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8697",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Öreglak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8698",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Pamuk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8698",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8699",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyvámos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csömend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Marcali",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8705",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyszentpál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8706",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nikla",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8707",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Libickozma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8707",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Pusztakovácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8708",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyfajsz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8709",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Marcali, Horvátkút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8710",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8711",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Vörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8712",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Balatonújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8713",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kéthely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8714",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Kelevíz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8714",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Marcali, Bize",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8715",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gadány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8716",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hosszúvíz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8716",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Mesztegnyő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8717",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nemeskisfalud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8717",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szenyér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8718",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tapsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8719",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Böhönye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Vése",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8722",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nemesdéd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Varászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Inke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Iharosberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Iharos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogycsicsó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8728",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Pogányszentpéter",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Hollád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8731",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Tikos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Főnyed",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szegerdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8732",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Sávoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogysámson",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8734",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogyzsitfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csákány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8736",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szőkedencs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogysimonyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8738",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nemesvid",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8739",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Nagyszakácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bókaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Esztergályhorváti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszabar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8744",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Orosztony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerecseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8746",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagyrada",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Garabonc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalamerenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8749",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalakaros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalakomár, Kiskomárom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalakomár, Komárváros",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8753",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Balatonmagyaród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Galambok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csapi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kisrécse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagyrécse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalasárszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pacsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaigrice",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gétye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentpéterúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Dióskál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8765",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Egeraracsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Alsórajk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Felsőrajk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8767",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pötréte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8771",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hahót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Börzönce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentbalázs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kacorlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pölöskefő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gelse",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gelsesziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kilimán",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8776",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bocska",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8776",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Magyarszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8776",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Magyarszerdahely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8777",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Fűzvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8777",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Homokkomárom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8777",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hosszúvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8778",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Újudvar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Ligetfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tilaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalacsány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kehidakustány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8785",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kallósd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8785",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentgrót, Zalakoppány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8788",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sénye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8788",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8789",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentgrót, Zalaudvarnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8790",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentgrót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8792",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalavég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8793",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tekenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8795",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentgrót, Csáford",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8796",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Türje",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8797",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Batyk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8798",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalabér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8799",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Dötk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8799",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pakod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykanizsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8808",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykanizsa, Palin",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8809",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykanizsa, Sánc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagybakónak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8822",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8824",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sand",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Miháld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8827",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentjakab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykanizsa, Miklósfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8832",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Liszó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Murakeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8835",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Fityeház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8840",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csurgó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8840",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Csurgónagymarton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8849",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Szenta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8851",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Gyékényes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8852",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zákány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8853",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Zákányfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8854",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Őrtilos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8855",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Belezna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8856",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Surd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8857",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemespátró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8858",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Porrog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8858",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Porrogszentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8858",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Porrogszentpál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8858",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1035,
+    "state_code": "SO",
+    "locality_name": "Somogybükkösd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8861",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szepetnek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8862",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Semjénháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8863",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Molnári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8864",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tótszerdahely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8865",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tótszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8866",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Becsehely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8866",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Petrivente",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8868",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kistolmács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8868",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Letenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8868",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Murarátka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8868",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zajk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8872",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Muraszemenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8872",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentmargitfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8873",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csörnyeföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8874",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Dobri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8874",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerkaszentkirály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8876",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tormafölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8877",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tornyiszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8878",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lovászi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8879",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerkateskánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8879",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szécsisziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8881",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sormás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8882",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Eszteregnye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8883",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Rigyác",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8885",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Borsfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8885",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Valkonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8886",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Oltárc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8887",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bázakerettye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8887",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lasztonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8888",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kiscsehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8888",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lispeszentadorján",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8888",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Maróc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8891",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bánokszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8891",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Várfölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8893",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bucsuta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8893",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentliszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8895",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pusztamagyaród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8896",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pusztaszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8897",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Söjtör",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaegerszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8904",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaegerszeg, Andráshida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8911",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kiskutas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8911",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykutas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kispáli",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagypáli",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Egervár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gősfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lakhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vasboldogasszony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemesrádó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8917",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Milejszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csonkahegyhát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Németfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8919",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kustánszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Alibánfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pethőhenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentiván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentlőrinc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemesapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8924",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Alsónemesapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Búcsúszentlászló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemesszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8925",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemessándorháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8926",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kisbucsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8928",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemeshetés",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8929",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pölöske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kemendollár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vöckönd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gyűrűs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pókaszepetk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaistvánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bezeréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Almásháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Misefa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagykapornak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Orbányosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Padár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8936",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentmihály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bocfölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csatár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Sárhida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Baktüttös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pusztaederics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Tófej",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8947",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentkozmadombja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8947",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalatárnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8948",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Barlahida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8948",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nova",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8949",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Mikekarácsonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csertalakos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gutorfölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8953",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentpéterfölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Ortaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8956",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kányavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8956",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Páka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8956",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pördefölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csömödér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hernyék",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kissziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8957",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zebecke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8958",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Iklódbördőce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gosztola",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8960",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lenti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8966",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lenti, Lentikápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8969",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bödeháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8969",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gáborjánháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8969",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szijártóháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8969",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszombatfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8971",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerkabarabás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8971",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalabaksa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Alsószenterzsébet",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csesztreg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Felsőszenterzsébet",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerkafalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kerkakutas",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Magyarföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8973",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Ramocsa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8975",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szentgyörgyvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Márokföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8976",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nemesnép",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Baglad",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lendvajakabfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8977",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Resznek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8978",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Belsősárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8978",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Külsősárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8978",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lendvadedes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8978",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Rédics",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gellénháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Lickóvadamos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8983",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Babosdöbréte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8983",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Nagylengyel",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8983",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Ormándlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8984",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Gombosszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8984",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Iborfia",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8984",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Petrikeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Becsvölgye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8986",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pusztaapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8986",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pórszombat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8986",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Szilvágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8988",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kozmadombja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8988",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kálócfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8989",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Dobronhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8990",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Pálfiszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8991",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Böde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8991",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hottó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8991",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Teskánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Bagod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Boncodfölde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Hagyárosbörönd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8992",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaboldogfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Kávás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8994",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8995",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Keménfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8995",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Salomvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8996",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalacséb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8997",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalaháshágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8998",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Ozmánbük",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8998",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Vaspör",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8999",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Csöde",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "8999",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1046,
+    "state_code": "ZA",
+    "locality_name": "Zalalövő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9000",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9011",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9012",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9019",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9021",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9022",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9023",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9024",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9025",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9026",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9027",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9028",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9029",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9030",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9061",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vámosszabadi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kisbajcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9062",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vének",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9063",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nagybajcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9064",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vámosszabadi, Szitásdomb",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9071",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Gönyű",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9072",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nagyszentjános",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9073",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bőny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9074",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rétalap",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9081",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrújbarát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9082",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nyúl",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9083",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Écs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9084",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9085",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pázmándfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9086",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Töltéstava",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9088",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bakonypéterd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9089",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Lázi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9090",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pannonhalma",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9091",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Ravazd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9092",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Tarjánpuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9093",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrasszonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9094",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Tápszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9095",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Táp",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9096",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nyalka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9097",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mezőörs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9098",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mezőörs, Mindszentpuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9099",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9100",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Tét",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9111",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Tényő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9112",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sokorópátka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9113",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Koroncó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9121",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrszemere",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9122",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Felpéc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9123",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kajárpéc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9124",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Gyömöre",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9125",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szerecseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9126",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Gyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9127",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csikvánd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9131",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mórichida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9132",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Árpás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kisbabot",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9133",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábaszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9134",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bodonhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9135",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábaszentmihály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mérges",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9136",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábacsécsény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9141",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Ikrény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9142",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábapatona",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9143",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Enese",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9144",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kóny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9145",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bágyogszovát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9146",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábapordány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9147",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dör",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9151",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Abda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9152",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Börcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9153",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Öttevény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9154",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9155",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Lébény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9161",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrsövényház",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9162",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bezi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9163",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fehértó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9164",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Markotabödöge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Cakóháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábcakapi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9165",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Tárnokréti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9167",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bősárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9167",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Jánossomorja, Hanságliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9168",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Acsalag",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9168",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csorna, Földsziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9169",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Barbacs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9169",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Maglóca",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9171",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9172",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrzámoly",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9173",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Győrladamér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9174",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dunaszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9175",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dunaszentpál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9176",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mecsér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9177",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Ásványráró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9178",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Hédervár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9181",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kimle",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9182",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Károlyháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonszentmiklós, Gyártelep",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9183",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonszentmiklós, Mosonújhely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9184",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kunsziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9200",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonmagyaróvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9211",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Feketeerdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9221",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Levél",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9222",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Hegyeshalom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9223",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bezenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9224",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rajka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9225",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dunakiliti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9226",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dunasziget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9228",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Halászi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9231",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Máriakálnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9232",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Darnózseli",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9233",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Lipót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9234",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kisbodak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dunaremete",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9235",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Püski",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Jánossomorja, Mosonszentjános",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9241",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Jánossomorja, Újtanya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9242",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Jánossomorja, Pusztasomorja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9243",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Várbalog",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9244",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Újrónafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9245",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonszolnok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9246",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mosonudvar",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9300",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csorna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9311",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pásztori",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9312",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szilsárkány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9313",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábacsanak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9314",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Egyed",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9315",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sobor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9316",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábaszentandrás",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9317",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szany",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9321",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Farád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9322",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábatamási",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9323",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Jobaháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9324",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Bogyoszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9324",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Potyond",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9325",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopronnémeti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9326",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szil",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9327",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábasebes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9327",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vág",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9330",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kapuvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9339",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kapuvár, Öntésmajor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9341",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kisfalud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9342",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Mihályi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Beled",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Edve",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9343",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vásárosfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9344",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Rábakecöl",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9345",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Páli",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Magyarkeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vadosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9346",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Zsebeháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9351",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Babót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9352",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Veszkény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9353",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szárföld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9354",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Osli",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9361",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Hövej",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9362",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Himod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9363",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Gyóró",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9364",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Cirák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9365",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Dénesfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9371",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Vitnyéd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9372",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csapod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9373",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pusztacsalád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9374",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Iván",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csáfordjánosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Csér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9375",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Répceszemere",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9400",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopron",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9407",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopron, Sopronkőhida",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9408",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopron, Brennbergbánya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9421",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőrákos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9422",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Harka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9423",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Ágfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9431",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9433",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőd, Tőzeggyármajor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9434",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sarród, Fertőújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9435",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sarród",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9436",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőszéplak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9437",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Hegykő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9438",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sarród, Nyárliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9441",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Agyagosszergény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9442",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőendréd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9443",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Petőháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9444",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőszentmiklós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Ebergőc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9451",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Röjtökmuzsaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9461",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Lövő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9462",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Völcsej",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9463",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopronhorpács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9464",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Und",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9471",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nemeskér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9472",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Újkér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9473",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Egyházasfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Gyalóka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9474",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Szakony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9475",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Répcevis",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9476",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Zsira",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9481",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pinnye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9482",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nagylózs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9483",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopronkövesd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9484",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Pereszteg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9485",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Nagycenk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9491",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Hidegség",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9492",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőhomok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9493",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Fertőboz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9494",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Sopron, Balf",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9495",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1042,
+    "state_code": "GS",
+    "locality_name": "Kópháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9500",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Celldömölk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9511",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemenesmihályfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9512",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ostffyasszonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9513",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csönge",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9514",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kenyeri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9515",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pápoc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9516",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vönöck",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9517",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemenessömjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9521",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemenesszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9522",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemenesmagasi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9523",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szergény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9531",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Mersevát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9532",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Külsővat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9533",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Nemesszalók",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Marcalgergelyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9534",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1054,
+    "state_code": "VE",
+    "locality_name": "Vinár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9541",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Celldömölk, Izsákfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9542",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Boba",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9542",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemeskocs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9544",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemenespálfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9545",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Jánosháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9547",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Karakó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9548",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemeskeresztúr",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9549",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Keléd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9551",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Mesteri",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9552",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vásárosmiske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemeneskápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9553",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Köcsk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9554",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Borgáta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9554",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Egyházashetye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9555",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kissomlyó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9556",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Duka",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagysimonyi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9561",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Tokorcs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9600",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sárvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9608",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sárvár, Rábasömjén",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9609",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sárvár, Lánkapuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9611",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csénye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9612",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bögöt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9612",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Porpác",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9621",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ölbő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9622",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szeleste",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9623",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Répceszentgyörgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9624",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Chernelházadamonya",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9625",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gór",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9631",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9632",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sajtoskál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9633",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Simaság",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9634",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Iklanberény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9634",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Lócs",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9635",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Zsédeny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9636",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pósfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9641",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rábapaty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9643",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Jákfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9651",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Uraiújfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9652",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nick",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9653",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Répcelak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9654",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csánig",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9661",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasegerszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9662",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Mesterháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9662",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Tompaládony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9663",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemesládony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9664",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagygeresd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9665",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vámoscsalád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9671",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sitke",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9672",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gérce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9673",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Káld",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9674",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vashosszúfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9675",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bögöte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9676",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hosszúpereszteg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9681",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sótony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9682",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nyőgér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9683",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bejcgyertyános",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9684",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Egervölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9685",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szemenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9700",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szombathely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9707",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szombathely, Herény",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9721",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gencsapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9722",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Perenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9723",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gyöngyösfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9724",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Lukácsháza",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Cák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kőszegdoroszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9725",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kőszegszerdahely",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9726",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Velem",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9727",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bozsok",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9730",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kőszeg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Horvátzsidány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kiszsidány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9733",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ólmod",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9734",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Peresznye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9735",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csepreg",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9736",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Tormásliget",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9737",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bük",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9738",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Tömörd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9739",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kőszegpaty",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9739",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemescsó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9739",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pusztacsó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9740",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bük, Bükfürdő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9741",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vassurány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9742",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Salköveskút",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9743",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Söpte",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9744",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasasszonyfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9745",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Meszlen",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9746",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Acsád",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9747",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasszilvágy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9748",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9749",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemesbőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9751",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vép",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bozzai",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9752",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kenéz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Megyehíd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9754",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pecöl",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9756",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ikervár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9757",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Meggyeskovácsi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9761",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Táplánszentkereszt",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9762",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Tanakajd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9763",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasszécseny",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csempeszkopács",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9764",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Meggyeskovácsi, Ilonapuszta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rum",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rábatöttös",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9766",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Zsennye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9771",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Balogunyom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9772",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kisunyom",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9773",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sorokpolány",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gyanógeregye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sorkifalud",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9774",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sorkikápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9775",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemeskolta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9776",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Püspökmolnári",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9777",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rábahídvég",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9781",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Egyházashollós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9782",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemesrempehollós",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9783",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Egyházasrádóc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Harasztifalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagykölked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9784",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rádóckölked",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9789",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sé",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9791",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Dozmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9791",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Torony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9792",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bucsu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9793",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Narda",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9794",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Felsőcsatár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9795",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vaskeresztes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9796",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Horvátlövő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9796",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pornóapáti",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9797",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nárai",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9798",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ják",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9799",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szentpéterfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9800",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9811",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Andrásfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9812",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Telekes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9813",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gersekarát",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9813",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Sárfimizdó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9814",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Halastó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Győrvár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9821",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyhátszentpéter",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9823",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pácsony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9824",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Olaszfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9825",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Oszkó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9826",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Petőmihályfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9831",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bérbaltavár",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9832",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagytilaj",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9833",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csehi",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9834",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csehimindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9835",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Mikosszéplak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9836",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csipkerek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9841",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kám",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9842",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Alsóújlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9900",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Körmend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9909",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Körmend, Horvátnádalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9909",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Magyarnádalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Magyarszecsőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9912",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Molnaszecsőd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Döröske",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagymizdó",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9913",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szarvaskend",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9914",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Döbörhegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyháthodász",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyhátsál",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Katafa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9915",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nádasd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9917",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Daraboshegy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9917",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Halogy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9918",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Felsőmarác",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9919",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csákánydoroszló",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9921",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasalja",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9922",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pinkamindszent",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9923",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kemestaródfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyhátszentmárton",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9931",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ivánc",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9932",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Viszák",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9933",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Őrimagyarósd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Felsőjánosfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Hegyhátszentjakab",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9934",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szaknyér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9935",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szőce",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9936",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kisrákos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9937",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Pankasz",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9938",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nagyrákos",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9938",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szatta",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9941",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Ispánk",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9941",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Őriszentpéter",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9942",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szalafő",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9943",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kondorfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Bajánsenye",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9944",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kerkáskápolna",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9945",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kercaszomor",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Magyarszombatfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9946",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Velemér",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9951",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rátót",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9952",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Gasztony",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9953",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Nemesmedves",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9953",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Vasszentmihály",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9954",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rönök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9955",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szentgotthárd, Rábafüzes",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9961",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Rábagyarmat",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9962",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Csörötnek",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9962",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Magyarlak",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9970",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szentgotthárd",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9981",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szentgotthárd, Farkasfa",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9982",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Apátistvánfalva",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9982",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Kétvölgy",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9982",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Orfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9983",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Alsószölnök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9983",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Szakonyfalu",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  },
+  {
+    "code": "9985",
+    "country_id": 99,
+    "country_code": "HU",
+    "state_id": 1039,
+    "state_code": "VA",
+    "locality_name": "Felsőszölnök",
+    "type": "full",
+    "source": "magyar-posta-via-ferenci-tamas"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports 3,569 Hungarian postal codes from Magyar Posta + KSH gazetteer (Feb 2026 refresh)
- 100% state FK resolution across all 19 megyék + Budapest

## Source
- [`ferenci-tamas/IrszHnk`](https://github.com/ferenci-tamas/IrszHnk) — joins Magyar Posta workbook with KSH Helységnévtár (Hungarian Central Statistics Office gazetteer)
- File: `IrszHnk.csv` (semicolon-delimited)
- License: no formal license file — upstream is official HU government open data; Tier 5 per #1039 license-tier policy (free redistribution permitted, no formal licence)

## State FK strategy
The CSV's `Vármegye.megnevezése` column gives the megye/county name. CSC has 43 HU iso2 entries (19 megyék + Budapest + 23 cities of county rank); since the CSV authoritatively reports megye, we map to those 20 county-level entries via a hand-curated `SOURCE_TO_ISO2`.

Two name drifts handled:
- `'főváros'` (lit. "the capital") → CSC `BU` Budapest
- `'Csongrád-Csanád'` (2020 rename) → CSC older `CS` "Csongrád County"

Cities of county rank (Pécs, Szeged, Debrecen, ...) resolve to their containing megye since the source has no city-of-county-rank flag in the postcode dataset.

## Distribution
| megye | rows |
|---|---|
| Borsod-Abaúj-Zemplén (BZ) | 392 |
| Baranya (BA) | 323 |
| Zala (ZA) | 267 |
| Somogy (SO) | 251 |
| Szabolcs-Szatmár-Bereg (SZ) | 242 |
| Veszprém (VE) | 232 |
| Vas (VA) | 225 |
| Győr-Moson-Sopron (GS) | 211 |
| Pest (PE) | 195 |
| Budapest (BU) | 161 |
| ... | ... |

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_hungary_postcodes.py`
- [x] All 3,569 codes match `^\d{4}$`
- [x] 100% state_id valid; state.country_id == 99; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)