### PR TITLE
feat(postcodes/BN): 547 Brunei Postal Services codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_brunei_postcodes.py
+++ b/bin/scripts/sync/import_brunei_postcodes.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Brunei -> contributions/postcodes/BN.json importer for issue #1039.
+
+Source data
+-----------
+The community ``xplorasia/brunei-zipcode`` repository publishes the
+full Brunei Postal Services postcode list in CSV form:
+
+    zipcode,area,city
+    KF4138,"Kampong Bang Pukul, Bukit Sawat",Belait
+
+The "city" column is actually the **district** (one of the four
+Brunei districts). Codes follow the alphanumeric format `XXNNNN`
+(2-letter prefix encoding the postal sector + 4-digit office code),
+matching the country regex `^[A-Z]{2}\\d{4}$`.
+
+Source URL: https://raw.githubusercontent.com/xplorasia/brunei-zipcode/master/bn-zipcode.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib.
+2. Maps the 4 source district labels onto CSC's 4 BN iso2 states
+   via SOURCE_TO_ISO2 (handles 'Brunei Muara' -> CSC 'Brunei-Muara').
+3. Emits one row per (code, area) pair.
+4. Writes contributions/postcodes/BN.json idempotently.
+
+License
+-------
+Repo has no LICENSE file. Postcode data is publicly published by the
+Brunei Postal Services Department. Tier 5 (free redistribution
+permitted, no formal licence) per #1039 license-tier policy.
+
+Each row carries: ``source: "brunei-post-via-xplorasia"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_brunei_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/xplorasia/brunei-zipcode/"
+    "master/bn-zipcode.csv"
+)
+
+# Source district label -> CSC iso2 in BN states.json
+SOURCE_TO_ISO2: Dict[str, str] = {
+    "Brunei Muara": "BM",  # CSC name is 'Brunei-Muara' (with hyphen)
+    "Belait": "BE",
+    "Tutong": "TU",
+    "Temburong": "TE",
+}
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local CSV (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    bn_country = next((c for c in countries if c.get("iso2") == "BN"), None)
+    if bn_country is None:
+        print("ERROR: BN not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(bn_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    bn_states = [s for s in states if s.get("country_id") == bn_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in bn_states if s.get("iso2")
+    }
+    print(
+        f"Country: Brunei (id={bn_country['id']}); states indexed: {len(bn_states)}"
+    )
+
+    reader = csv.DictReader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_no_code = 0
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_district: Dict[str, int] = {}
+
+    for row in rows:
+        code = (row.get("zipcode") or "").strip().upper()
+        if not code:
+            skipped_no_code += 1
+            continue
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        district = (row.get("city") or "").strip()
+        area = (row.get("area") or "").strip()
+
+        iso2 = SOURCE_TO_ISO2.get(district)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_district[district] = unknown_district.get(district, 0) + 1
+            skipped_no_state += 1
+
+        key = (code, area.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(bn_country["id"]),
+            "country_code": "BN",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if area:
+            record["locality_name"] = area
+        record["type"] = "full"
+        record["source"] = "brunei-post-via-xplorasia"
+        records.append(record)
+
+    print(f"Skipped (no code):     {skipped_no_code:,}")
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_district:
+        print("Unknown district labels (not in SOURCE_TO_ISO2):")
+        for d, n in sorted(unknown_district.items(), key=lambda x: -x[1]):
+            print(f"  {d!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/BN.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/BN.json
+++ b/contributions/postcodes/BN.json
@@ -1,0 +1,5472 @@
+[
+  {
+    "code": "BA1000",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "JPM (Istana Nurul Iman), Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1111",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Mabohai, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1311",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Tong Kadeh, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1511",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kumbang Pasang, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Hospital RIPAS, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1711",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Seri Kompleks, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1712",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Institut Pengajian Islam Brunei Darussalam, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Kehakiman, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Keselamatan Dalam Negeri, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Undang-Undang, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian UNDANG-UNDANG, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA1912",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Parit (Serigan), Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Hal Ehwal Masjid, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Urusan Haji, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2112",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Tumasek, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2312",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Telanai, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2511",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Liang, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BA2711",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pintu Malim, Kianggeh",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1114",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lambak Kiri (Kurnia Rakyat Jati), Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1214",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lambak Kiri 'B', Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1314",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lambak Kiri 'A', Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1414",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lambak Kanan 'B', Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1514",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Terunjing Baru, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB1714",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lambak Kanan 'B', Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB2114",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Terunjing Lama, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB2314",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Serusop, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB2513",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Penerbangan Awam, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB2513",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Lapangan Terbang AntaraBangsa, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB2713",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jaya Setia, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3113",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jaya Bakti, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3313",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Burong Pinggai Berakas, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Angkatan Bersenjata Diraja Brunei, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Dewan Bahasa dan Pustaka, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Belia dan Sukan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Biro Mencegah Rasuah, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Daerah Brunei Muara, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Kemajuan Perumahan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Kenaziran Sekola-Sekolah, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Kerja Raya, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Penerangan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pentadbiran dan Perkhidmatan-Perkhidmatan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Peperiksaan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perancang Bandar dan Desa, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perancangan dan Pemiliharaan Bangunan dan Kawasan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Percetakan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkhdmatan Bomba, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkhidmatan Awam, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkhidmatan Elektrik, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkhidmatan Pos, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pertanian, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perubatan dan Kesihatan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Sekolah-Sekolah, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Telekom, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian PEMBANGUNAN, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian PENDIDIKAN, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian PERHUBUNGAN, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian PERTAHANAN, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pejabat Tanah, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pejabat Ukur, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Suruhanjaya Perkhidmatan Awam, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3513",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Lapangan Terbang Lama, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3713",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Anggerek Desa, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Badan Kemajuan Industri Brunei (BINA), Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan AuditB, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Buruh, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Imigresen dan Pendaftaran, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perhutanan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perikanan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkhidmatan Pengurusan, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian HAL EHWAL UGAMA, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian KESIHATAN, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian PERINDUSTRIAN DAN SUMBER-SUMBER UTAMA, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pusat Persidangan AntaraBangsa, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Semaun Holdings, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3910",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Unit Petroleum, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB3913",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Jalan Menteri Besar, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4113",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Orang Kaya Besar Imas, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4310",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pusat Dakwah Islamiah, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4310",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Unit Perkhidmatan Hal Ehwal Masyarakat - Pulaie, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4313",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pulaie, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4513",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pancha Delima, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB4713",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Delima Satu, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB5113",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengiran Siraja Muda, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BB5313",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Delima Dua, Berakas 'A'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC1115",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Taman Salambigar, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC1515",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Salambigar, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC1715",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Orok, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC2115",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Hanching, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC2315",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Kawasan 1, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC2515",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Kawasan 2, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC2715",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Kawasan 3, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC2915",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Kawasan 4, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3115",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Kawasan 5, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3315",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Tilong, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3515",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Manggis Dua, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3615",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Manggis Satu, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3715",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Madang, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC3915",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Akar, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BC4115",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Akar, Berakas 'B'",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD1310",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pejabat Pengajian Islam, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD1510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Muzium-Muzium, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD1517",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kota Batu, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD1717",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Datu Gandi, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD1917",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Matan, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2117",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Serdang/Sungai Belukut, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2317",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pelambayan, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2517",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Besar, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian HAL EHWAL LUAR NEGERI, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2717",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Subok, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2917",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Belimbing, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD2917",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Unit Gurkha Simpanan, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD3117",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tanjong Cendana, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD3317",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Bunga, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD3517",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pudak, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD3717",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Berambang, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD3917",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Buang Kepayang, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD4117",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Riong, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD4317",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Menunggol, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BD4517",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pulau Baru-Baru dan Berbunut, Kota Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pengangkutan Darat, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Teknologi Maklumat dan Stor Negara, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1118",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Beribi, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1310",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Kurikulum, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1310",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pendidikan Teknik, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1318",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kiarong, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1410",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Universiti Brunei Darussalam, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1518",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kiulap, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Polis Diraja Brunei, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1718",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Mata-Mata, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE1918",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Mata-Mata, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Biro Kawalan Narkotik, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2119",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tungku, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2319",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Katok, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2519",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Tungku, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2719",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Gadong, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE2919",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Gadong Estate, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3119",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Rimba, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3319",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perumahan Negara Rimba, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3519",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Batu Bersurat, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3619",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Tungku Link, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3719",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengkalan Gadong, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE3919",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Menglait I, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BE4119",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Menglait II, Gadong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF1120",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Madewa, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF1320",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bunot, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF1520",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tasek Meradun, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF1720",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Burong Lepas, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF1920",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bengkurong, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF2120",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sinarubai, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF2320",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jalan Bebatik Kilanas, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF2520",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kilanas, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF2720",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jangsak, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BF2920",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tanjong Bunut, Kilanas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1121",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sengkurong 'A', Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1221",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pasai, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1321",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sengkurong 'B', Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1521",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tagap, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1721",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Selayun, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG1921",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Tampoi, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG2121",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Mulaut, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG2321",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tanjong Nangka, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG2521",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kulapis, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG2721",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Katimahar, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG2921",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lugu, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG3110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pusat Tahanan, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG3122",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Penjara, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG3122",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jerudong, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BG3322",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bukit Bunga, Sengkurong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH1123",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengkalan Batu, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH1323",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Batu Ampar, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH1523",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Batang Perhentian, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH1723",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bukit Belimbing, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH1923",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kuala Lurah, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH2123",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Junjongan, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH2323",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Limau Manis, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH2523",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Wasan, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH2723",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Masin, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH2923",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Batong, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH3123",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Panchor Murai, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH3223",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bebatik (Masin), Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH3223",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Jalan Bebatik Kilanas, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BH3323",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bebuloh, Pengkalan Batu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ1124",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kupang, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ1324",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Putat, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ1524",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengkalan Batang, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ1724",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kasat, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ1924",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Buang Sakar, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ2124",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tarap Bau, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ2324",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bukit Merikan, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ2524",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lupak Luas, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ2924",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Buang Tengkurok/Sengkirap, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ3324",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kelugus, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ3324",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lumapas 'A', Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ3324",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pancur, Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BJ3524",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lumapas 'B', Lumapas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK1125",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bolkiah 'A', Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK1325",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bolkiah 'B', Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK1525",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Setia 'A', Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK1725",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Setia 'B', Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK1925",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Siamas, Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK2125",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Ujong Kelinik, Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BK2325",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Kebun, Sungai Kebun",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL1112",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Ujong Bukit, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL1312",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Limbongan, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL1512",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bendahara Lama, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL1712",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengiran Kerma Indera, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL1912",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengiran Tajuddin Hitam, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL2112",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tamoi Tengah, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BL2312",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tamoi Ujong, Tamoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM1126",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Burong Pinggai Ayer, Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM1326",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lurong Dalam, Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM1526",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pandai Besi 'A', Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM1726",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pandai Besi 'B', Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM1926",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Pandan 'A', Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM2126",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Pandan 'B', Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM2326",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pg. Setia Negara, Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM2526",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pekan Lama, Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BM2726",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Asam, Burong Pinggai Ayer",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN1111",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sumbiling Lama, Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN1311",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bukit Salat, Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN1511",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Kedayan 'B', Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN1711",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Kedayan 'A', Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN1911",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Ujong Tanjong, Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN2111",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kuala Peminyak, Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BN2311",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pemancha Lama, Sungai Kedayan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP1126",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Peramu, Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP1326",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pekilong Muara, Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP1526",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Setia Pahlawan, Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP1726",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bakut Seraja Muda 'A', Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP1926",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bakut Seraja Muda 'B', Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP2126",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Lurong sekuna, Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BP2326",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bakut Berumput, Peramu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BR1126",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Saba Laut, Saba",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BR1326",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Saba Darat 'A', Saba",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BR1526",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Saba Darat 'B', Saba",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BR1726",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Saba Ujong, Saba",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BR1926",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Saba Tengah, Saba",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian KEBUDAYAAN, BELIA DAN SUKAN, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8110",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pusat Kesenian dan Pertukangan, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8111",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kianggeh, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8211",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Berangan, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8311",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Tasek Lama, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8410",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perkembangan Kurikulum, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8411",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Padang, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Hal Ehwal Syariah, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Mufti Kerajaan Brunei, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8510",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pejabat Kadi Besar, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8511",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Sumbiling, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Adat Istiadat Negara, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Agensi Pelaburan Brunei, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "JPM (Bangunan Setiausaha Kerajaan), Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Perbendaharan, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pusat Sejarah, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian HAL EHWAL DALAM NEGERI, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Lembaga Mata Wang, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Majlis-Majlis Mesyuarat Negara, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8610",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Radio Dan Televisyen Brunei, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8611",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Pusat Sejarah, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kementerian KEWANGAN, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perancangan dan Kemajuan Ekonomi, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8710",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Tabung Amanah Pekerja, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8711",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Yayasan Sultan Haji Hassanal Bolkiah, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8810",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Bandaran, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8810",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kastam dan Eksais DiRaja, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BS8811",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kawasan Perdagangan Bumi Putera, Bandar Seri Begawan",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1128",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Pekan Muara, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1328",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pelumpong, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1528",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tanjong Batu, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1728",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Laut, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1728",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Jabatan Pelabuhan-Pelabuhan, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1728",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Serasa, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT1928",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Masjid Lama, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT2128",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sabun, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT2328",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Kapok, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT2728",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Meragang, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT2928",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Bukit Kabun, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT3128",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengalayan, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT3328",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pulau Muara Besar, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BT3528",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pelumpong, Serasa",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1129",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Tanah Jambu, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1229",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Buloh I, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1329",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Sungai Buloh II, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1429",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Salar, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1529",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Batu Marang, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1729",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Panchor, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU1929",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Mentiri, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU2129",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Perpindahan Mentiri, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU2329",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Paring, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "BU2529",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1216,
+    "state_code": "BM",
+    "locality_name": "Kampong Pengkalan Sibabau, Mentiri",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1131",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Jabatan Bandaran, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1131",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Jabatan Daearah Kuala Belait, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1131",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Pekan Kuala Belait, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1331",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Melayu Asli, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1531",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Mumong Utara, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1731",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Mumong Selatan, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA1931",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pandan, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA2131",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Perumahan Negara Kampung Pandan, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA2331",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong China, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA2731",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Rasau, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA2931",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Perumahan BSP, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA3131",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Duhon, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA3331",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Teraban, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KA3531",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Sungai Satu Hingga Sungai Tujoh, Kuala Belait",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB1133",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pekan Seria, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB1333",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Lorong Tiga Selatan, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB1533",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Perumahan Negara, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB1733",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Perakong, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB1933",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Bera, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB2133",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Jalan Bedas, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB2333",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Anduki, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB2533",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Perpindahan Baru, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB2733",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Masjid, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB2933",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kawasan Perumahan B.S.P, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB3133",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kawasan Perumahan B.S.P, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB3333",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kawasan Perumahan B.S.P, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB3533",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kawasan Shell, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB3733",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Military Area, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB3933",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Jabang, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB4133",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Sekolah Mission, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB4333",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kawasan Jalan Bolkiah, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KB4533",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Panaga, Seria",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC1135",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Liang, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC1335",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Gana, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC1535",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Andalau, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC1735",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Keluyoh, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC1935",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Perumpong, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC2135",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Padang, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC2335",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Liang Kecil, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC2535",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Lilas, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC2735",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tunggulian, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC2935",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Lumut Satu, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KC3135",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Lumut Dua, Liang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KD1132",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Kuala Balai, Kuala Balai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KD1332",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Mala'as, Kuala Balai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KD1532",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Damit, Kuala Balai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE1137",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bukit Puan, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE1337",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Patai, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE1537",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Malayan, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE1737",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tupan Lupak, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE1937",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tenajor, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE2137",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Ratan, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE2337",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Terunan, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE2537",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Gatas, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE2737",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Kenapol, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE2937",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pesilin, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE3137",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tarawan, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE3337",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Rampayoh, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE3537",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Mendaram Besar, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE3737",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Mendaram Kecil, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KE3937",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Teraja, Labi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF1138",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Mau, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF1338",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bisut, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF1538",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sungai Ubar, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF1738",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bukit Sawat, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF1938",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Ubok-Ubok, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF2138",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bukit Kandol, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF2338",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Labi Lakang, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF2538",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Kagu, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF2738",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bukit Serawong, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF2938",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Singap, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF3138",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Merangking Ulu, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF3338",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Merangking Hilir, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF3538",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Laong Arut, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF3738",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tarap, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF3938",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pengkalan Siong, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF4138",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bang Pukul, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF4338",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bang Tajuk, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF4538",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pulu Apil, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KF4738",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Pengkalan Sungai Mau, Bukit Sawat",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG1139",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Apak - Apak, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG1339",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Saud, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG1539",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Buau, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG1739",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Kukup, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG1939",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Sukang, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG2139",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Dungun, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG2339",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Ambawang, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG2539",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Biadong Tengah, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KG2739",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Biadong Ulu, Sukang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KH1139",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Tempinak, Melilas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KH1339",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Melilas, Melilas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "KH1539",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1217,
+    "state_code": "BE",
+    "locality_name": "Kampong Bengerang II, Melilas",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Pekan Bangar Lama, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Jabatan Daerah Temburong, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Pekan Bangar Baru, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Perkhemahan Bangar, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Menengah, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA1951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sungai Sulok, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA2151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sungai Tanit, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA2351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sungai Tanam, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA2551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Balayang, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA2751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Semamang, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA2951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Buang Bulan, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA3151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Belingus, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA3351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Batang Tuau, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA3551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Seri Tanjong Belayang, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA3751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Puni, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PA3951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Ujong Jalan, Bangar",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PB1151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Labu Estate, Labu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PB1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Senukoh, Labu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PB1551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Piasau-Piasau, Labu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PB1751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Payau, Labu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PB1951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Ayam-Ayam, Labu",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC1151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Batu Apoi, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sungai Radang, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC1551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Peliunan, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC1751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sungai Bantaian, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC1951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Gadong Baru, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC2151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Luagan, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC2351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Negalang Iring, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC2551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Negalang Unat, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC2751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Lakiun, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC2951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Tanjong Bungar, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC3151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Lamaling, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC3351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Selapon, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PC3551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sekurop, Batu Apoi",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD1151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Amo 'A', Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Amo 'B', Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD1551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Amo 'C', Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD1751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sumbiling, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD1951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Batang Duri, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD2151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sibut, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD2351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Parit, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD2551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Biang Menengah, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD2751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Selangan, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD2951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Sibulu, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD3151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Belaban, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD3351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Bukit Belalong, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PD3551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Bukit Belutut, Amo",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE1151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Buda-Buda, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE1351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Belais, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE1551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Belais Kecil, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE1751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Paya Bagangan, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE1951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Bokok, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE2151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Meniup, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE2351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Bakarut, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE2551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Simbatang, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE2751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Rataie, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE2951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Perpindahan Rataie, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE3151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Rakyat Jati, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE3351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Kenua, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE3551",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Lepong Baru, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE3751",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Lepung Lama, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE3951",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Semabat Bahagia, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE4151",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Semabat, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "PE4351",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1218,
+    "state_code": "TE",
+    "locality_name": "Kampong Temada, Bukok",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Jabatan Bandaran, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Jabatan Daerah Tutong, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Pekan Tutong, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Bukit Bendera, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sungai Basong, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1741",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Suran, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA1941",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Panchor Papan, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA2141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Panchor Dulit, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA2341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sengkarai, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA2541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Serambangun, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA2741",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Penanjong, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA2941",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tanah Burok, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA3141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Binturan, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA3341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kuala Tutong, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TA3541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Penabai, Pekan Tutong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB1141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Keriam, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB1341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit Panggal, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB1541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Luangan Dudok, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB1741",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sinaut, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB1941",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Meragang, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB2141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit Nenas, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB2341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Santul, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB2541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kerakas Payau, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB2741",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sungai Kelugos, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB2941",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kupang, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB3141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Maraburong Batu 16, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TB3341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Ikas, Keriam",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC1145",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Telisai, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC1345",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Perumahan Negara Telisai, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC1545",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Telamba, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC1745",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Lalit, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC1945",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tanah Jambu, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC2145",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sungai Paku, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC2345",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Danau, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC2545",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Penapar, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC2745",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Keramut, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC2945",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tumpuan Ugas, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC3145",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit Beruang, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TC3345",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Perumahan Negara Bukit Beruang, Telisai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD1141",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tanjong Maya/Meranti, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD1341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sebakit, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD1541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Banggunggos, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD1741",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Penapar, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD1941",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sungai Damit Pemadang, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD2341",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit Udal, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TD2541",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Lubok Pulau, Tanjong Maya",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE1143",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bakiau, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE1343",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Mau, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE1543",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kiudang, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE1743",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Mungkom, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE1943",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pad Nunok, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE2143",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Birau, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE2343",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Luangan Timbaran, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE2543",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Batang Mitus, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TE2743",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kebia, Kiudang",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF1147",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Ukong, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF1347",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Ran, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF1547",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Dong, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF1747",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tong Kundai, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF1947",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Nong Anggeh, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF2147",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sungai Damit Ulu, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF2347",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pitau Lambang, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF2547",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bang Pangan, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF2747",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pak Meligai, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF2947",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pak Bidang, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF3147",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF3347",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Panchor, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF3547",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Talat, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF3747",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Melaboi, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF3947",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Padang, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF4147",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bang Ligi, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF4347",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Litad, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF4547",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bang Bingol, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TF4747",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Long Mayan, Ukong",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG1143",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Layong, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG1343",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kuala Abang, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG1543",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Tangsi, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG1743",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Belunu, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG1943",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pengkalan Dong, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG2143",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Tanjong Dangar, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG2343",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Lamunin, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG2543",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Piasan, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG2743",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bukit Sulang, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG2943",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bentudoh, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG3143",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Panchong, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TG3343",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Biong, Lamunin",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH1149",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Rambai, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH1349",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Merimbun, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH1549",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kuala Ungar, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH1749",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Benutan, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH1949",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Batang Piton, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH2149",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Sengkowang, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH2349",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Pelajau, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH2549",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Kerancing, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH2749",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Belaban, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH2949",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Mapol, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH3149",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Supon Besar, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH3349",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Takalit, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH3549",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Supon Kecil, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH3749",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Lalipo, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH3949",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Bedawan, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  },
+  {
+    "code": "TH4149",
+    "country_id": 33,
+    "country_code": "BN",
+    "state_id": 1219,
+    "state_code": "TU",
+    "locality_name": "Kampong Belabau, Rambai",
+    "type": "full",
+    "source": "brunei-post-via-xplorasia"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Brunei's full alphanumeric postcode list (547 codes) for #1039
- 100% state FK resolution across all 4 Brunei districts

## Source
- [`xplorasia/brunei-zipcode`](https://github.com/xplorasia/brunei-zipcode) — community mirror of Brunei Postal Services Department's published list
- File: `bn-zipcode.csv`
- License: no formal LICENSE file; publicly published government data (Tier 5 per #1039 policy)

## State FK
Source's `city` column is actually the district name. 4-entry hand map handles `'Brunei Muara'` → CSC `'BM'` (CSC name `Brunei-Muara` uses hyphen). Other three districts match CSC verbatim.

## Distribution
| iso2 | district | rows |
|---|---|---|
| BM | Brunei-Muara | 289 |
| TU | Tutong | 102 |
| BE | Belait | 92 |
| TE | Temburong | 64 |

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_brunei_postcodes.py`
- [x] All 547 codes match `^[A-Z]{2}\d{4}$`
- [x] 100% state_id valid; state.country_id == 33; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)