### PR TITLE
feat(postcodes/TW): 371 Chunghwa Post codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_taiwan_postcodes.py
+++ b/bin/scripts/sync/import_taiwan_postcodes.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Taiwan -> contributions/postcodes/TW.json importer for issue #1039.
+
+Source data
+-----------
+The community ``flying-itmen-eagle/eagle-tw-open-data`` repository
+publishes Taiwan government open-data feeds, including the canonical
+3-digit Chunghwa Post postal-area code list:
+
+    100,臺北市中正區,"Zhongzheng Dist., Taipei City"
+    103,臺北市大同區,"Datong Dist., Taipei City"
+    ...
+
+Each row: 3-digit zip prefix, Chinese district label (city+district),
+English district label.
+
+Source URL: https://raw.githubusercontent.com/flying-itmen-eagle/eagle-tw-open-data/master/files/taiwan_postal_code_information.csv
+
+What this script does
+---------------------
+1. Fetches the CSV via urllib (curl is blocked).
+2. Decodes the CSV as **CP950 / Big5** (Taiwan government default
+   encoding; UTF-8 read produces mojibake).
+3. Resolves state FK by parsing the trailing ``X City`` / ``X County``
+   from the English column and mapping via ENGLISH_TO_ISO2.
+4. Emits one row per (3-digit code, Chinese district, English label).
+5. Writes contributions/postcodes/TW.json idempotently.
+
+Regex note
+----------
+Before this PR, countries.json had TW regex ``^\\d{5}$`` (5-digit).
+Taiwan has used three postcode generations:
+    - pre-2020: 3-digit area codes (this dataset)
+    - intermediate: 3+2 = 5-digit (still listed in some sources)
+    - 2020+: 3+3 = 6-digit (Chunghwa Post current canonical)
+The companion regex fix sets it to ``^\\d{3}(\\d{2,3})?$`` to accept
+all three generations.
+
+Edge cases
+----------
+The 26 source labels include 22 standard administrative divisions +
+4 special cases:
+    - 'Taoyuan City City'   typo -> TAO
+    - 'Diaoyutai'           Senkaku/Diaoyu islands (ROC -> Yilan/ILA)
+    - 'Dongsha Islands'     Pratas (administered by Kaohsiung/KHH)
+    - 'Nansha Islands'      Spratlys (administered by Kaohsiung/KHH)
+These are mapped via SPECIAL_LABEL_TO_ISO2.
+
+License & attribution
+---------------------
+- Source: flying-itmen-eagle/eagle-tw-open-data (GPL-3 — unusual for
+  data but redistribution permitted with attribution; flagged in PR)
+- Upstream: Chunghwa Post / Ministry of Interior open data
+- Each row: ``source: "chunghwa-post-via-eagle-tw-open-data"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_taiwan_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/flying-itmen-eagle/eagle-tw-open-data/"
+    "master/files/taiwan_postal_code_information.csv"
+)
+
+# Trailing English city/county label -> CSC iso2 in TW states.json.
+ENGLISH_TO_ISO2: Dict[str, str] = {
+    "Taipei City": "TPE",
+    "New Taipei City": "NWT",
+    "Keelung City": "KEE",
+    "Hsinchu City": "HSZ",
+    "Hsinchu County": "HSQ",
+    "Taoyuan City": "TAO",
+    "Miaoli County": "MIA",
+    "Taichung City": "TXG",
+    "Changhua County": "CHA",
+    "Nantou County": "NAN",
+    "Yunlin County": "YUN",
+    "Chiayi City": "CYI",
+    "Chiayi County": "CYQ",
+    "Tainan City": "TNN",
+    "Kaohsiung City": "KHH",
+    "Pingtung County": "PIF",
+    "Taitung County": "TTT",
+    "Hualien County": "HUA",
+    "Yilan County": "ILA",
+    "Penghu County": "PEN",
+    "Kinmen County": "KIN",
+    "Lienchiang County": "LIE",
+}
+
+# Edge-case English labels not following 'X City' / 'X County' pattern.
+SPECIAL_LABEL_TO_ISO2: Dict[str, str] = {
+    "Taoyuan City City": "TAO",  # source typo
+    "Diaoyutai": "ILA",  # Senkaku/Diaoyu (ROC administers under Yilan)
+    "Dongsha Islands, Nanhai Islands": "KHH",  # Pratas (under Kaohsiung)
+    "Nansha Islands, Nanhai Islands": "KHH",  # Spratlys (under Kaohsiung)
+}
+
+
+def fetch_csv(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("cp950")
+
+
+def resolve_iso2(english_label: str) -> str | None:
+    label = english_label.strip()
+    if label in SPECIAL_LABEL_TO_ISO2:
+        return SPECIAL_LABEL_TO_ISO2[label]
+    # 'Zhongzheng Dist., Taipei City' -> trailing 'Taipei City'
+    if "," in label:
+        tail = label.rsplit(",", 1)[1].strip()
+        if tail in ENGLISH_TO_ISO2:
+            return ENGLISH_TO_ISO2[tail]
+        if tail in SPECIAL_LABEL_TO_ISO2:
+            return SPECIAL_LABEL_TO_ISO2[tail]
+    if label in ENGLISH_TO_ISO2:
+        return ENGLISH_TO_ISO2[label]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local CSV (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="cp950")
+        if args.input
+        else fetch_csv(SOURCE_URL)
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    tw_country = next((c for c in countries if c.get("iso2") == "TW"), None)
+    if tw_country is None:
+        print("ERROR: TW not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(tw_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    tw_states = [s for s in states if s.get("country_id") == tw_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in tw_states if s.get("iso2")
+    }
+    print(
+        f"Country: Taiwan (id={tw_country['id']}); states indexed: {len(tw_states)}"
+    )
+
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_labels: Dict[str, int] = {}
+
+    for row in rows:
+        if len(row) < 3:
+            continue
+        code, zh_label, en_label = row[0].strip(), row[1].strip(), row[2].strip()
+        if not code:
+            continue
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        iso2 = resolve_iso2(en_label)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_labels[en_label] = unknown_labels.get(en_label, 0) + 1
+            skipped_no_state += 1
+
+        # Locality = English district name (Chinese kept implicit via source col)
+        locality = en_label
+
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(tw_country["id"]),
+            "country_code": "TW",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "chunghwa-post-via-eagle-tw-open-data"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_labels:
+        print("Unknown labels (not in ENGLISH_TO_ISO2 or SPECIAL_LABEL_TO_ISO2):")
+        for label, n in sorted(unknown_labels.items(), key=lambda x: -x[1]):
+            print(f"  {label!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/TW.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -14384,8 +14384,8 @@
     "subregion_id": 12,
     "nationality": "Chinese, Taiwanese",
     "area_sq_km": 35980.0,
-    "postal_code_format": "#####",
-    "postal_code_regex": "^(\\d{5})$",
+    "postal_code_format": "###/#####/######",
+    "postal_code_regex": "^(\\d{3}(?:\\d{2,3})?)$",
     "timezones": [
       {
         "zoneName": "Asia/Taipei",

--- a/contributions/postcodes/TW.json
+++ b/contributions/postcodes/TW.json
@@ -1,0 +1,3712 @@
+[
+  {
+    "code": "100",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Zhongzheng Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "103",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Datong Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "104",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Zhongshan Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "105",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Songshan Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "106",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Da’an Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "108",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Wanhua Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "110",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Xinyi Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "111",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Shilin Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "112",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Beitou Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "114",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Neihu Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "115",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Nangang Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "116",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3422,
+    "state_code": "TPE",
+    "locality_name": "Wenshan Dist., Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "200",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Ren’ai Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "201",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Xinyi Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "202",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Zhongzheng Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "203",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Zhongshan Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "204",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Anle Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "205",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Nuannuan Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "206",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4965,
+    "state_code": "KEE",
+    "locality_name": "Qidu Dist., Keelung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "207",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Wanli Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "208",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Jinshan Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "209",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3420,
+    "state_code": "LIE",
+    "locality_name": "Nangan Township, Lienchiang County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "210",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3420,
+    "state_code": "LIE",
+    "locality_name": "Beigan Township, Lienchiang County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "211",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3420,
+    "state_code": "LIE",
+    "locality_name": "Juguang Township, Lienchiang County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "212",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3420,
+    "state_code": "LIE",
+    "locality_name": "Dongyin Township, Lienchiang County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "220",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Banqiao Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "221",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Xizhi Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "222",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Shenkeng Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "223",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Shiding Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "224",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Ruifang Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "226",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Pingxi Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "227",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Shuangxi Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "228",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Gongliao Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "231",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Xindian Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "232",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Pinglin Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "233",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Wulai Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "234",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Yonghe Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "235",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Zhonghe Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "236",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Tucheng Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "237",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Sanxia Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "238",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Shulin Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "239",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Yingge Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "241",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Sanchong Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "242",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Xinzhuang Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "243",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Taishan Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "244",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Linkou Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "247",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Luzhou Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "248",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Wugu Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "249",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Bali Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "251",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Tamsui Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "252",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Sanzhi Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "253",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 4966,
+    "state_code": "NWT",
+    "locality_name": "Shimen Dist., New Taipei City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "260",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Yilan City, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "261",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Toucheng Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "262",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Jiaoxi Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "263",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Zhuangwei Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "264",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Yuanshan Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "265",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Luodong Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "266",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Sanxing Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "267",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Datong Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "268",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Wujie Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "269",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Dongshan Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "270",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Su’ao Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "272",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Nan’ao Township, Yilan County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "290",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3402,
+    "state_code": "ILA",
+    "locality_name": "Diaoyutai",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "300",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3417,
+    "state_code": "HSZ",
+    "locality_name": "East Dist., Hsinchu City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "300",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3417,
+    "state_code": "HSZ",
+    "locality_name": "North Dist., Hsinchu City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "300",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3417,
+    "state_code": "HSZ",
+    "locality_name": "Xiangshan Dist., Hsinchu City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "302",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Zhubei City, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "303",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Hukou Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "304",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Xinfeng Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "305",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Xinpu Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "306",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Guanxi Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "307",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Qionglin Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "308",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Baoshan Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "310",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Zhudong Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "311",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Wufeng Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "312",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Hengshan Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "313",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Jianshi Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "314",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Beipu Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "315",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5705,
+    "state_code": "HSQ",
+    "locality_name": "Emei Township, Hsinchu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "320",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Zhongli Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "324",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Pingzhen Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "325",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Longtan Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "326",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Yangmei Dist., Taoyuan City City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "327",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Xinwu Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "328",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Guanyin Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "330",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Taoyuan Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "333",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Guishan Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "334",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Bade Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "335",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Daxi Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "336",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Fuxing Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "337",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Dayuan Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "338",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3419,
+    "state_code": "TAO",
+    "locality_name": "Luzhu Dist., Taoyuan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "350",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Zhunan Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "351",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Toufen City, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "352",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Sanwan Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "353",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Nanzhuang Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "354",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Shitan Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "356",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Houlong Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "357",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Tongxiao Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "358",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Yuanli Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "360",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Miaoli City, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "361",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Zaoqiao Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "362",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Touwu Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "363",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Gongguan Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "364",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Dahu Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "365",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Tai’an Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "366",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Tongluo Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "367",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Sanyi Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "368",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Xihu Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "369",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3413,
+    "state_code": "MIA",
+    "locality_name": "Zhuolan Township, Miaoli County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "400",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Central Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "401",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "East Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "402",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "South Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "403",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "West Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "404",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "North Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "406",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Beitun Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "407",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Xitun Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "408",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Nantun Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "411",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Taiping Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "412",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Dali Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "413",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Wufeng Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "414",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Wuri Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "420",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Fengyuan Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "421",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Houli Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "422",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Shigang Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "423",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Dongshi Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "424",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Heping Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "426",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Xinshe Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "427",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Tanzi Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "428",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Daya Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "429",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Shengang Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "432",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Dadu Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "433",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Shalu Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "434",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Longjing Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "435",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Wuqi Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "436",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Qingshui Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "437",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Dajia Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "438",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Waipu Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "439",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3406,
+    "state_code": "TXG",
+    "locality_name": "Da’an Dist., Taichung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "500",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Changhua City, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "502",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Fenyuan Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "503",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Huatan Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "504",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Xiushui Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "505",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Lukang Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "506",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Fuxing Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "507",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Xianxi Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "508",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Hemei Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "509",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Shengang Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "510",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Yuanlin City, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "511",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Shetou Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "512",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Yongjing Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "513",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Puxin Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "514",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Xihu Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "515",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Dacun Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "516",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Puyan Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "520",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Tianzhong Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "521",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Beidou Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "522",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Tianwei Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "523",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Pitou Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "524",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Xizhou Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "525",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Zhutang Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "526",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Erlin Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "527",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Dacheng Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "528",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Fangyuan Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "530",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3404,
+    "state_code": "CHA",
+    "locality_name": "Ershui Township, Changhua County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "540",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Nantou City, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "541",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Zhongliao Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "542",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Caotun Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "544",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Guoxing Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "545",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Puli Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "546",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Ren’ai Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "551",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Mingjian Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "552",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Jiji Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "553",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Shuili Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "555",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Yuchi Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "556",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Xinyi Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "557",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Zhushan Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "558",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3407,
+    "state_code": "NAN",
+    "locality_name": "Lugu Township, Nantou County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "600",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3408,
+    "state_code": "CYI",
+    "locality_name": "East Dist., Chiayi City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "600",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3408,
+    "state_code": "CYI",
+    "locality_name": "West Dist., Chiayi City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "602",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Fanlu Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "603",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Meishan Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "604",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Zhuqi Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "605",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Alishan Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "606",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Zhongpu Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "607",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Dapu Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "608",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Shuishang Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "611",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Lucao Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "612",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Taibao City, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "613",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Puzi City, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "614",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Dongshi Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "615",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Liujiao Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "616",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Xingang Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "621",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Minxiong Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "622",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Dalin Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "623",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Xikou Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "624",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Yizhu Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "625",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 5704,
+    "state_code": "CYQ",
+    "locality_name": "Budai Township, Chiayi County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "630",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Dounan Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "631",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Dapi Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "632",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Huwei Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "633",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Tuku Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "634",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Baozhong Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "635",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Dongshi Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "636",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Taixi Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "637",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Lunbei Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "638",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Mailiao Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "640",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Douliu City, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "643",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Linnei Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "646",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Gukeng Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "647",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Citong Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "648",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Xiluo Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "649",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Erlun Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "651",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Beigang Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "652",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Shuilin Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "653",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Kouhu Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "654",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Sihu Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "655",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3416,
+    "state_code": "YUN",
+    "locality_name": "Yuanzhang Township, Yunlin County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "700",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "West Central Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "701",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "East Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "702",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "South Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "704",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "North Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "708",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Anping Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "709",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Annan Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "710",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Yongkang Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "711",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Guiren Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "712",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xinhua Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "713",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Zuozhen Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "714",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Yujing Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "715",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Nanxi Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "716",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Nanhua Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "717",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Rende Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "718",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Guanmiao Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "719",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Longqi Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "720",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Guantian Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "721",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Madou Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "722",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Jiali Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "723",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xigang Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "724",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Qigu Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "725",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Jiangjun Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "726",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xuejia Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "727",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Beimen Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "730",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xinying Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "731",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Houbi Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "732",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Baihe Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "733",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Dongshan Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "734",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Liujia Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "735",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xiaying Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "736",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Liuying Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "737",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Yanshui Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "741",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Shanhua Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "742",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Danei Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "743",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Shanshang Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "744",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Xinshi Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "745",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3421,
+    "state_code": "TNN",
+    "locality_name": "Anding Dist., Tainan City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "800",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Xinxing Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "801",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qianjin Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "802",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Lingya Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "803",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Yancheng Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "804",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Gushan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "805",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qijin Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "806",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qianzhen Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "807",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Sanmin Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "811",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Nanzi Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "812",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Xiaogang Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "813",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Zuoying Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "814",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Renwu Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "815",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Dashe Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "817",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Dongsha Islands, Nanhai Islands",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "819",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Nansha Islands, Nanhai Islands",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "820",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Gangshan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "821",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Luzhu Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "822",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Alian Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "823",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Tianliao Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "824",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Yanchao Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "825",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qiaotou Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "826",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Ziguan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "827",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Mituo Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "828",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Yong’an Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "829",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Hunei Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "830",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Fengshan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "831",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Daliao Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "832",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Linyuan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "833",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Niaosong Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "840",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Dashu Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "842",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qishan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "843",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Meinong Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "844",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Liugui Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "845",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Neimen Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "846",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Shanlin Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "847",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Jiaxian Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "848",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Taoyuan Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "849",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Namaxia Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "851",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Maolin Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "852",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3412,
+    "state_code": "KHH",
+    "locality_name": "Qieding Dist., Kaohsiung City",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "880",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Magong City, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "881",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Xiyu Township, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "882",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Wang’an Township, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "883",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Qimei Township, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "884",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Baisha Township, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "885",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3403,
+    "state_code": "PEN",
+    "locality_name": "Huxi Township, Penghu County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "890",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Jinsha Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "891",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Jinhu Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "892",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Jinning Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "893",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Jincheng Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "894",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Lieyu Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "896",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3415,
+    "state_code": "KIN",
+    "locality_name": "Wuqiu Township, Kinmen County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "900",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Pingtung City, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "901",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Sandimen Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "902",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Wutai Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "903",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Majia Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "904",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Jiuru Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "905",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Ligang Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "906",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Gaoshu Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "907",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Yanpu Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "908",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Changzhi Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "909",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Linluo Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "911",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Zhutian Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "912",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Neipu Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "913",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Wandan Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "920",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Chaozhou Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "921",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Taiwu Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "922",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Laiyi Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "923",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Wanluan Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "924",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Kanding Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "925",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Xinpi Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "926",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Nanzhou Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "927",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Linbian Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "928",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Donggang Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "929",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Liuqiu Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "931",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Jiadong Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "932",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Xinyuan Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "940",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Fangliao Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "941",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Fangshan Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "942",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Chunri Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "943",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Shizi Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "944",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Checheng Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "945",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Mudan Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "946",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Hengchun Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "947",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3405,
+    "state_code": "PIF",
+    "locality_name": "Manzhou Township, Pingtung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "950",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Taitung City, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "951",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Ludao Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "952",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Lanyu Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "953",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Yanping Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "954",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Beinan Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "955",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Luye Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "956",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Guanshan Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "957",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Haiduan Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "958",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Chishang Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "959",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Donghe Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "961",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Chenggong Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "962",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Changbin Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "963",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Taimali Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "964",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Jinfeng Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "965",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Dawu Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "966",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3410,
+    "state_code": "TTT",
+    "locality_name": "Daren Township, Taitung County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "970",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Hualien City, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "971",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Xincheng Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "972",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Xiulin Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "973",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Ji’an Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "974",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Shoufeng Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "975",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Fenglin Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "976",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Guangfu Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "977",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Fengbin Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "978",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Ruisui Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "979",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Wanrong Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "981",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Yuli Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "982",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Zhuoxi Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  },
+  {
+    "code": "983",
+    "country_id": 216,
+    "country_code": "TW",
+    "state_id": 3411,
+    "state_code": "HUA",
+    "locality_name": "Fuli Township, Hualien County",
+    "type": "full",
+    "source": "chunghwa-post-via-eagle-tw-open-data"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Taiwan's 3-digit Chunghwa Post postal-area codes (371 rows) for #1039
- 100% state FK resolution across all 22 CSC TW states
- Fixes TW regex `^\d{5}$` → `^\d{3}(\d{2,3})?$` to accept the three Taiwan postcode generations

## Source
- [`flying-itmen-eagle/eagle-tw-open-data`](https://github.com/flying-itmen-eagle/eagle-tw-open-data) — community mirror of Taiwan government open data feeds (GPL-3 — flagged per #1039 license-tier policy)
- File: `taiwan_postal_code_information.csv` (CP950 / Big5 — UTF-8 read produces mojibake)
- Upstream: Chunghwa Post / Ministry of Interior

## Regex fix
Taiwan has used three postcode generations:
| Era | Form | Example |
|---|---|---|
| pre-2020 | 3-digit area code | `100` |
| intermediate | 3+2 = 5-digit | `10001` |
| 2020+ (Chunghwa current) | 3+3 = 6-digit | `100002` |

This dataset is the 3-digit form. Old regex would have failed all three modern forms.

## Edge cases handled
| Source label | Mapped to | Reason |
|---|---|---|
| `'Taoyuan City City'` | TAO | source typo |
| `'Diaoyutai'` | ILA Yilan | Senkaku/Diaoyu — ROC administers under Yilan County |
| `'Dongsha Islands, Nanhai Islands'` | KHH Kaohsiung | Pratas — administered by Kaohsiung |
| `'Nansha Islands, Nanhai Islands'` | KHH Kaohsiung | Spratlys — administered by Kaohsiung |

## Distribution (top 5)
| iso2 | division | rows |
|---|---|---|
| KHH | Kaohsiung | 40 |
| TNN | Tainan | 37 |
| PIF | Pingtung County | 33 |
| NWT | New Taipei | 29 |
| TXG | Taichung | 29 |

All 22 CSC TW states covered.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_taiwan_postcodes.py`
- [x] All 371 codes match `^\d{3}(\d{2,3})?$`
- [x] 100% state_id valid; state.country_id == 216; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)