### PR TITLE
feat(postcodes/PE): 2,669 SERPOST codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_peru_postcodes.py
+++ b/bin/scripts/sync/import_peru_postcodes.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Peru -> contributions/postcodes/PE.json importer for issue #1039.
+
+Source data
+-----------
+The community ``peru-pe/cpn`` repository ships ``onlyCodes.json`` —
+the 2,669 SERPOST 5-digit Código Postal Nacional codes published by
+Peru's Ministerio de Transportes y Comunicaciones.
+
+    ["01001", "01000", "01230", ...]
+
+The 2-digit prefix is the department code (alphabetical, 01-25).
+
+Source URL: https://raw.githubusercontent.com/peru-pe/cpn/master/onlyCodes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Resolves state FK via 2-digit prefix -> CSC iso2 (PREFIX_TO_ISO2,
+   25-entry hand map matching SERPOST's alphabetical ordering).
+3. Writes contributions/postcodes/PE.json idempotently.
+
+Locality
+--------
+Source ships postcode-only (no district / locality / centroid). Each
+record carries `state_id` + `state_code` but no `locality_name` —
+matching the country-only-with-state pattern used for similar lists.
+
+Research-doc correction
+-----------------------
+The research doc Tier B note for Peru read
+`UBIGEO admin codes != SERPOST 5-digit postal codes`. That note was
+based on `mvegap/ubigeo-peru-select` which exposed UBIGEO admin codes
+(not postal). `peru-pe/cpn` is the actual SERPOST national list with
+2,669 codes — fully shippable.
+
+License & attribution
+---------------------
+- Source: peru-pe/cpn (no formal LICENSE file)
+- Upstream: SERPOST / MTC público
+- Each row: ``source: "serpost-via-peru-pe-cpn"``
+
+Tier 5 per #1039 license-tier policy.
+
+Usage
+-----
+    python3 bin/scripts/sync/import_peru_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = "https://raw.githubusercontent.com/peru-pe/cpn/master/onlyCodes.json"
+
+# 2-digit postcode prefix -> CSC iso2.
+# SERPOST orders prefixes alphabetically by department name; the 25
+# Peruvian departments + Constitutional Province of Callao (07) get
+# 01-25. Lima prefix (15) covers both LIM (department) and LMA (Lima
+# Metropolitan); we map to LIM since the source has no inner split.
+PREFIX_TO_ISO2: Dict[str, str] = {
+    "01": "AMA",  # Amazonas
+    "02": "ANC",  # Áncash
+    "03": "APU",  # Apurímac
+    "04": "ARE",  # Arequipa
+    "05": "AYA",  # Ayacucho
+    "06": "CAJ",  # Cajamarca
+    "07": "CAL",  # Callao (Constitutional Province)
+    "08": "CUS",  # Cusco
+    "09": "HUV",  # Huancavelica
+    "10": "HUC",  # Huánuco
+    "11": "ICA",  # Ica
+    "12": "JUN",  # Junín
+    "13": "LAL",  # La Libertad
+    "14": "LAM",  # Lambayeque
+    "15": "LIM",  # Lima (department + metropolitan)
+    "16": "LOR",  # Loreto
+    "17": "MDD",  # Madre de Dios
+    "18": "MOQ",  # Moquegua
+    "19": "PAS",  # Pasco
+    "20": "PIU",  # Piura
+    "21": "PUN",  # Puno
+    "22": "SAM",  # San Martín
+    "23": "TAC",  # Tacna
+    "24": "TUM",  # Tumbes
+    "25": "UCA",  # Ucayali
+}
+
+
+def fetch_json(url: str) -> List[str]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local JSON (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    codes = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+    print(f"Source codes: {len(codes):,}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    pe_country = next((c for c in countries if c.get("iso2") == "PE"), None)
+    if pe_country is None:
+        print("ERROR: PE not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(pe_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    pe_states = [s for s in states if s.get("country_id") == pe_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in pe_states if s.get("iso2")
+    }
+    print(
+        f"Country: Peru (id={pe_country['id']}); states indexed: {len(pe_states)}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_prefixes: Dict[str, int] = {}
+
+    for raw in codes:
+        code = str(raw).strip().zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        prefix = code[:2]
+        iso2 = PREFIX_TO_ISO2.get(prefix)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_prefixes[prefix] = unknown_prefixes.get(prefix, 0) + 1
+            skipped_no_state += 1
+
+        if code in seen:
+            continue
+        seen.add(code)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(pe_country["id"]),
+            "country_code": "PE",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        record["type"] = "full"
+        record["source"] = "serpost-via-peru-pe-cpn"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_prefixes:
+        print("Unknown prefixes (not in PREFIX_TO_ISO2):")
+        for p, n in sorted(unknown_prefixes.items(), key=lambda x: -x[1]):
+            print(f"  {p!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/PE.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/PE.json
+++ b/contributions/postcodes/PE.json
@@ -1,0 +1,24023 @@
+[
+  {
+    "code": "01000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01375",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01485",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01486",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01505",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01556",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01565",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01566",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01575",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01580",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01821",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "01841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3685,
+    "state_code": "AMA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02103",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02109",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02113",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02119",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02123",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02127",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02133",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02139",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02148",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02152",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02158",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02162",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02163",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02167",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02171",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02174",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02181",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02184",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02185",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02190",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02193",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02195",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02203",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02209",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02218",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02222",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02228",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02234",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02243",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02249",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02254",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02258",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02262",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02264",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02265",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02273",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02275",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02279",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02283",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02285",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02289",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02290",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02291",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02295",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02303",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02304",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02314",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02318",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02324",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02333",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02342",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02348",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02352",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02358",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02375",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02385",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02390",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02391",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02395",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02396",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02403",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02407",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02413",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02422",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02426",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02432",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02447",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02483",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02485",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02489",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02495",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02603",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02607",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02613",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02616",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02618",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02627",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02633",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02651",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02661",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02675",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02676",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02681",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02685",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02695",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02712",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02802",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02803",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02804",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02816",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02865",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02866",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02875",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "02876",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3680,
+    "state_code": "ANC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03271",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03290",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03580",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03871",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03880",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "03881",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3699,
+    "state_code": "APU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04009",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04011",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04012",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04013",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04014",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04016",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04017",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04018",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04076",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04102",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04108",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04112",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04118",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04124",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04146",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04185",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04190",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04195",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04406",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04416",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04426",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04436",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04446",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04451",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04456",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04466",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04580",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04590",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04606",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04656",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "04860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3681,
+    "state_code": "ARE",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05171",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05181",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05271",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05290",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05306",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05316",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05326",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05375",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05385",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05390",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05395",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05485",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05606",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05675",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05685",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05695",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05790",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05816",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05821",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05836",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05846",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "05855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3692,
+    "state_code": "AYA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06116",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06126",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06146",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06206",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06226",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06236",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06246",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06306",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06316",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06346",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06356",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06366",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06403",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06407",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06411",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06412",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06422",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06437",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06451",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06452",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06456",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06481",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06485",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06495",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06633",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06644",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06651",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06653",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06666",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06675",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06683",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06685",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06691",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06705",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06706",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06715",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06725",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06726",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06735",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06736",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06745",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06746",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06751",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06755",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06756",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06765",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06766",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06775",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06785",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06816",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06821",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06826",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06836",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06846",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06856",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "06861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3688,
+    "state_code": "CAJ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07011",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07016",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07021",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07026",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07031",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07036",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07041",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07046",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07051",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07056",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07061",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07066",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07071",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "07076",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3701,
+    "state_code": "CAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08051",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08106",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08116",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08126",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08166",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08171",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08185",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08204",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08207",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08219",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08222",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08223",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08234",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08238",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08242",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08243",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08254",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08257",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08258",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08264",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08265",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08267",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08268",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08274",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08275",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08277",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08278",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08285",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08290",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08295",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08411",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08461",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08471",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08505",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08561",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08565",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08566",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08616",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08626",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08636",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08651",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08656",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08661",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08675",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08676",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08681",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08751",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "08851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3691,
+    "state_code": "CUS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09146",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09156",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09306",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09316",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09346",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09375",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09376",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09381",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09385",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09390",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09395",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09406",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09416",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09705",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09715",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09725",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09735",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09745",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09755",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09880",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "09890",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3679,
+    "state_code": "HUV",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10031",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10171",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10181",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10511",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10521",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10541",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10580",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10590",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10626",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10685",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10705",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10745",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10755",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10775",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10880",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10881",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10890",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "10891",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3687,
+    "state_code": "HUC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11061",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11651",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11702",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11703",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11751",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "11850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3700,
+    "state_code": "ICA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12051",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12116",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12126",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12236",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12246",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12256",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12404",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12405",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12408",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12415",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12419",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12425",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12428",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12435",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12436",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12442",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12445",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12451",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12455",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12456",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12465",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12466",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12475",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12485",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12495",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12496",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12504",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12505",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12513",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12565",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12575",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12576",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12585",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12590",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12591",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12595",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12596",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12651",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12751",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12826",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12836",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12856",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12865",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12866",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12867",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12875",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "12876",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3693,
+    "state_code": "JUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13009",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13011",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13012",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13013",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13014",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13105",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13146",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13156",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13181",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13185",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13186",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13190",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13191",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13195",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13196",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13361",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13505",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13511",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13526",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "13871",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3683,
+    "state_code": "LAL",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14009",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14011",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14012",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14013",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14051",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14821",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "14841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3702,
+    "state_code": "LAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15009",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15011",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15012",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15018",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15019",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15021",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15022",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15023",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15024",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15026",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15033",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15034",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15036",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15037",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15038",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15039",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15046",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15047",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15048",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15049",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15054",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15056",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15057",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15058",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15063",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15064",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15066",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15067",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15072",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15073",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15074",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15076",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15079",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15081",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15082",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15083",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15084",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15086",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15087",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15088",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15093",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15094",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15096",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15102",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15103",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15106",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15107",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15108",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15109",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15112",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15113",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15116",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15117",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15118",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15122",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15123",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15126",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15137",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15138",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15157",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15161",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15162",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15169",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15174",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15178",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15182",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15185",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15190",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15191",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15195",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15197",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15202",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15237",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15246",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15265",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15266",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15274",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15275",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15280",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15285",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15302",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15304",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15306",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15307",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15312",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15313",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15314",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15316",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15318",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15319",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15324",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15326",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15327",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15328",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15332",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15333",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15336",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15404",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15408",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15412",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15416",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15419",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15423",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15427",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15434",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15438",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15442",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15446",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15449",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15453",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15457",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15461",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15464",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15468",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15472",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15476",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15479",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15483",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15487",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15491",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15494",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15498",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15505",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15516",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15536",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15537",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15556",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15561",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15564",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15565",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15571",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15575",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15577",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15580",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15585",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15586",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15590",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15593",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15594",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15605",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15608",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15615",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15625",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15635",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15645",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15655",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15661",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15665",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15675",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15681",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15685",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15689",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15712",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15715",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15716",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15717",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15719",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15723",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15725",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15727",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15735",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15736",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15742",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15745",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15748",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15753",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15755",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15763",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15765",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15768",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15775",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15785",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15786",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15790",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15792",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15795",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15796",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15803",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15804",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15806",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15809",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15812",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15816",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15817",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15818",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15822",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15823",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15824",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15828",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15829",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15834",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15836",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15837",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15842",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15846",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15856",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15865",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15866",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15870",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "15871",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3695,
+    "state_code": "LIM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16411",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16451",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16471",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16481",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16491",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16511",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16561",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16571",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16751",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "16821",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 4922,
+    "state_code": "LOR",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "17800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3678,
+    "state_code": "MDD",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "18620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3698,
+    "state_code": "MOQ",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19031",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "19750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3686,
+    "state_code": "PAS",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20007",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20008",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20009",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20102",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20103",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20131",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20361",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20381",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20411",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20441",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20451",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20461",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20471",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20481",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20491",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20511",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20541",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20561",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20671",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20680",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20690",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20691",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20761",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20830",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20831",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "20851",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3697,
+    "state_code": "PIU",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21102",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21103",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21104",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21107",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21108",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21113",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21115",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21116",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21117",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21119",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21123",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21125",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21127",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21135",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21136",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21137",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21139",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21143",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21145",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21146",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21149",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21153",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21155",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21157",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21162",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21165",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21166",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21169",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21175",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21205",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21216",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21225",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21236",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21246",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21251",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21256",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21261",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21265",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21270",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21275",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21301",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21305",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21306",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21315",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21316",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21321",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21325",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21335",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21341",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21345",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21346",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21355",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21356",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21361",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21365",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21366",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21375",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21376",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21380",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21381",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21385",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21390",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21395",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21421",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21511",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21515",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21516",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21521",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21525",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21526",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21535",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21536",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21545",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21546",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21555",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21565",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21571",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21575",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21576",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21611",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21631",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21641",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21661",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21711",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21780",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21781",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21801",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21815",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21865",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21866",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21875",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21876",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21885",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21886",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21895",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "21896",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3682,
+    "state_code": "PUN",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22051",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22110",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22111",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22121",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22130",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22141",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22160",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22170",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22180",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22190",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22202",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22215",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22235",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22236",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22241",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22245",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22255",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22260",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22310",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22311",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22320",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22330",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22331",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22340",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22360",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22370",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22371",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22410",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22430",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22431",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22470",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22471",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22481",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22490",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22491",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22510",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22521",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22541",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22561",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22570",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22610",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22620",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22621",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22630",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22640",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22660",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22661",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22670",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22710",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22720",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22721",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22730",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22731",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22740",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22741",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22760",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22770",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22771",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22805",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22810",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22811",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22820",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22825",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22826",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22835",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22840",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22841",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22845",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22846",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22855",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22860",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22861",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22865",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "22866",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3694,
+    "state_code": "SAM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23041",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23120",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23140",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23240",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23420",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23440",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23460",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23480",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23650",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23750",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23800",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "23850",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3696,
+    "state_code": "TAC",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24150",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24151",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24250",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24350",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24351",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24401",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24450",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24520",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24521",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24540",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24541",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "24560",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3689,
+    "state_code": "TUM",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25000",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25001",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25002",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25003",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25004",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25006",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25100",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25101",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25200",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25201",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25210",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25211",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25220",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25221",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25230",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25231",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25300",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25400",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25500",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25501",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25530",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25531",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25550",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25551",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25600",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25601",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25700",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  },
+  {
+    "code": "25701",
+    "country_id": 173,
+    "country_code": "PE",
+    "state_id": 3684,
+    "state_code": "UCA",
+    "type": "full",
+    "source": "serpost-via-peru-pe-cpn"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Peru's full SERPOST 5-digit Código Postal Nacional list (2,669 codes) for #1039
- 100% state FK resolution across all 25 departments via 2-digit prefix mapping

## Source
- [`peru-pe/cpn`](https://github.com/peru-pe/cpn) — `onlyCodes.json` (35 KB)
- Upstream: SERPOST / Ministerio de Transportes y Comunicaciones (MTC) público
- License: no formal LICENSE file (Tier 5 per #1039 policy)

## Research-doc correction
The research doc Tier B note for Peru read `UBIGEO admin codes ≠ SERPOST 5-digit postal codes`. That was based on `mvegap/ubigeo-peru-select` which exposes UBIGEO admin codes (different system). `peru-pe/cpn` is the **actual SERPOST list** — 2,669 5-digit postal codes — and is fully shippable.

## State FK strategy
Source ships postcode-only (no department/locality field). Resolution is via the 2-digit prefix, which corresponds 1:1 to SERPOST's alphabetical department ordering:

| prefix | iso2 | department |
|---|---|---|
| 01 | AMA | Amazonas |
| 02 | ANC | Áncash |
| 03 | APU | Apurímac |
| 04 | ARE | Arequipa |
| 05 | AYA | Ayacucho |
| 06 | CAJ | Cajamarca |
| 07 | CAL | Callao (Constitutional Province) |
| 08 | CUS | Cusco |
| 09 | HUV | Huancavelica |
| 10 | HUC | Huánuco |
| ... | ... | ... |
| 15 | LIM | Lima (department + metropolitan) |
| ... | ... | ... |
| 25 | UCA | Ucayali |

Lima prefix (15) covers both LIM (department) and LMA (Lima Metropolitan); we map to LIM since the source has no inner split.

## Locality
Source ships postcode-only — each record carries `state_id` + `state_code` but no `locality_name`. Future PRs could enrich via SERPOST's address API.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_peru_postcodes.py`
- [x] All 2,669 codes match `^\d{5}$`
- [x] 100% state_id valid; state.country_id == 173; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)