### PR TITLE
feat(postcodes/FI): 3,748 Posti.fi PCF codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_finland_postcodes.py
+++ b/bin/scripts/sync/import_finland_postcodes.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Finland -> contributions/postcodes/FI.json importer for issue #1039.
+
+Source data
+-----------
+Posti's official PCF (postal code file) is the canonical 5-digit
+postal-code list for Finland, refreshed daily. The DAT format is
+fixed-width ISO-8859-1 with one record per line at 220 chars/line.
+
+URL pattern: https://www.posti.fi/webpcode/unzip/PCF_<YYYYMMDD>.dat
+
+The importer probes recent dates back from today and uses the
+freshest available file.
+
+Fixed-width fields (1-indexed positions per Posti spec):
+    1-5    record identifier (PONOT)
+    6-13   extraction date (YYYYMMDD)
+    14-18  postal code (5 digits)
+    19-48  postal name (Finnish, 30 chars)
+    49-78  postal name (Swedish, 30 chars)
+    79-90  abbreviation (Finnish, 12 chars)
+    91-102 abbreviation (Swedish, 12 chars)
+    103-110 effective date (YYYYMMDD)
+    111    type (1=normal)
+    112-116 region code (FI1xx)
+    117-146 region name (Finnish, 30 chars)
+    147-176 region name (Swedish, 30 chars)
+    177-179 municipality code
+    180-199 municipality name (Finnish, 20 chars)
+    200-219 municipality name (Swedish, 20 chars)
+    220    language code
+
+What this script does
+---------------------
+1. Probes the URL pattern back ~30 days to find the latest dated DAT.
+2. Decodes as ISO-8859-1 (Posti standard).
+3. Parses fixed-width records.
+4. Skips Ahvenanmaa (region FI200) — those records belong to the
+   separate AX (Åland Islands) CSC country and are shipped via a
+   companion importer.
+5. Resolves state FK via Finnish region-name match through
+   FI_REGION_TO_ISO2 (18 mainland Finnish maakunta + Helsinki-Uusimaa
+   merged into Uusimaa per ISO 3166-2:FI).
+6. Writes contributions/postcodes/FI.json idempotently.
+
+Coverage upgrade
+----------------
+The previously-tracked ``launis/areadata`` mirror is a wrapper-only
+package with no bulk export. The research-doc note flagged the
+date-stamped Posti URL as `difficult per memory`. Direct date probe
+of Posti's webpcode endpoint resolves the freshest URL automatically.
+
+License & attribution
+---------------------
+- Source: Posti.fi PCF (Finnish postal code file)
+- Posti's terms: free redistribution permitted with attribution
+  (Tier 5 per #1039 license-tier policy)
+- Each row: ``source: "posti-fi-pcf"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_finland_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+URL_TEMPLATE = "https://www.posti.fi/webpcode/unzip/PCF_{date}.dat"
+
+# Finnish maakunta name -> CSC FI iso2.
+# Helsinki-Uusimaa is a NUTS sub-division of the Uusimaa region;
+# both map to CSC '18' Uusimaa.
+FI_REGION_TO_ISO2: Dict[str, str] = {
+    "Etelä-Karjala": "02",          # South Karelia
+    "Etelä-Pohjanmaa": "03",         # Southern Ostrobothnia
+    "Etelä-Savo": "04",              # Southern Savonia
+    "Kainuu": "05",                  # Kainuu
+    "Kanta-Häme": "06",              # Tavastia Proper
+    "Keski-Pohjanmaa": "07",         # Central Ostrobothnia
+    "Keski-Suomi": "08",             # Central Finland
+    "Kymenlaakso": "09",             # Kymenlaakso
+    "Lappi": "10",                   # Lapland
+    "Pirkanmaa": "11",               # Pirkanmaa
+    "Pohjanmaa": "12",               # Ostrobothnia
+    "Pohjois-Karjala": "13",         # North Karelia
+    "Pohjois-Pohjanmaa": "14",       # Northern Ostrobothnia
+    "Pohjois-Savo": "15",            # Northern Savonia
+    "Päijät-Häme": "16",             # Päijänne Tavastia
+    "Satakunta": "17",               # Satakunta
+    "Helsinki-Uusimaa": "18",        # NUTS sub-region of Uusimaa
+    "Uusimaa": "18",                 # Uusimaa
+    "Varsinais-Suomi": "19",         # Finland Proper
+}
+
+
+def resolve_pcf_url(max_days_back: int = 30) -> str:
+    today = datetime.date.today()
+    for delta in range(0, max_days_back):
+        d = today - datetime.timedelta(days=delta)
+        url = URL_TEMPLATE.format(date=d.strftime("%Y%m%d"))
+        req = urllib.request.Request(
+            url, method="HEAD", headers={"User-Agent": "csc-database-postcode-importer"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                if r.status == 200:
+                    return url
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                raise
+    raise RuntimeError(f"No PCF DAT found in last {max_days_back} days")
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("iso-8859-1")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local DAT (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if args.input:
+        text = Path(args.input).read_text(encoding="iso-8859-1")
+        print(f"loaded local input: {args.input}")
+    else:
+        url = resolve_pcf_url()
+        print(f"fetching {url}")
+        text = fetch_text(url)
+    lines = text.splitlines()
+    print(f"Source rows: {len(lines):,}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    fi_country = next((c for c in countries if c.get("iso2") == "FI"), None)
+    if fi_country is None:
+        print("ERROR: FI not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(fi_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    fi_states = [s for s in states if s.get("country_id") == fi_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in fi_states if s.get("iso2")
+    }
+    print(
+        f"Country: Finland (id={fi_country['id']}); "
+        f"states indexed: {len(fi_states)}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_aland = 0
+    skipped_short = 0
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_regions: Dict[str, int] = {}
+
+    for line in lines:
+        if len(line) < 220:
+            skipped_short += 1
+            continue
+        code = line[13:18].strip()
+        postal_name_fi = line[18:48].strip()
+        postal_name_sv = line[48:78].strip()
+        region_code = line[111:116].strip()
+        region_fi = line[116:146].strip()
+        municipality_fi = line[179:199].strip()
+
+        # Skip Åland — separate CSC country
+        if region_code == "FI200" or region_fi == "Ahvenanmaa":
+            skipped_aland += 1
+            continue
+
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        iso2 = FI_REGION_TO_ISO2.get(region_fi)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_regions[region_fi] = unknown_regions.get(region_fi, 0) + 1
+            skipped_no_state += 1
+
+        # Locality: Finnish postal name + municipality (when distinct)
+        if postal_name_fi and municipality_fi and postal_name_fi.lower() != municipality_fi.lower():
+            locality = f"{postal_name_fi}, {municipality_fi}"
+        else:
+            locality = postal_name_fi or municipality_fi
+
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(fi_country["id"]),
+            "country_code": "FI",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "posti-fi-pcf"
+        records.append(record)
+
+    print(f"Skipped (Åland, ships to AX): {skipped_aland:,}")
+    print(f"Skipped (short row):           {skipped_short:,}")
+    print(f"Skipped (regex fail):          {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK):         {skipped_no_state:,}")
+    print(f"Records emitted:               {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:                  {matched_state:,} ({pct}%)")
+    if unknown_regions:
+        print("Unknown regions (not in FI_REGION_TO_ISO2):")
+        for r, n in sorted(unknown_regions.items(), key=lambda x: -x[1]):
+            print(f"  {r!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/FI.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/FI.json
+++ b/contributions/postcodes/FI.json
@@ -1,0 +1,37482 @@
+[
+  {
+    "code": "00002",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00003",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00011",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "POSTI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00012",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FUJITSU, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00013",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OP POHJOLA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINGIN YLIOPISTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00015",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OTAVAMEDIA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00016",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KESKO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00017",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FENNIA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00018",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ILMARINEN, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00019",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SSC, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00020",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NORDEA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00021",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LASKUTUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00022",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TILASTOKESKUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00023",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALTIONEUVOSTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00024",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "YLEISRADIO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00025",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "IF, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00026",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "BASWARE, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00027",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RUOKAVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00028",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "AZETS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00029",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00030",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "IIRIS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00031",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "GE, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00032",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TYÖTERVEYSLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00033",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MTV, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00034",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FIMEA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00036",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DINERS CLUB, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00037",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "EUROCARD, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00038",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOGICA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00039",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALIO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00041",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ELO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00042",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ITAPSA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00043",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "EDITA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00045",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOKIA GROUP, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00046",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ACCOUNTOR, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00047",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VISMA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00048",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FORTUM, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00049",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALTERI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00050",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NETS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00051",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TELIA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00052",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VERO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00053",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VERO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00054",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALTIOKONTTORI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00055",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TULOREKISTERI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00056",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KELA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00057",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALONA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00058",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SANTANDER, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00059",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TRAFICOM, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00060",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TEHY, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00061",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ELISA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00062",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LASKUTUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00063",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LASKUNET, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00064",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ADMINISTER, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00065",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ELÄKETURVAKESKUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00066",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HSY, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00067",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ULOSOTTOLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00068",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "CARUNA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00070",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "AMERICAN EXPRESS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00071",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OSTOLASKUT, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00072",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ELINVOIMAKESKUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00073",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KEHA-KESKUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00074",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "CGI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00075",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DANSKE BANK, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00076",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "AALTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00077",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HSL, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00079",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "METROPOLIA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00080",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "WÄRTSILÄ, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00081",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "A-LEHDET, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00082",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FIMX, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00084",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VAKUUTUSKESKUS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00085",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUOMIOISTUINVIRASTO, Vantaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00087",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KEVA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00088",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "S-RYHMÄ, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00089",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SANOMA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00090",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "Helen, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00091",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PRH, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00095",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NESTE, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00096",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VR, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00097",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAIDEYLIOPISTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00098",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VARMA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00099",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINGIN KAUPUNKI, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00102",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "EDUSKUNTA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00107",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOUTOPISTE, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00121",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00141",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00161",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00171",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00181",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00187",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOUTOPISTE, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00191",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00221",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00232",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00241",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00271",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00281",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00321",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00331",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00341",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00351",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00371",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00381",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00391",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00411",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00431",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00441",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00551",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00561",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00581",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00621",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00641",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00671",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00711",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00721",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00741",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00751",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00761",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00771",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00781",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00791",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00811",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00861",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00921",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00931",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00936",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RAPALA VMC, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00941",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00971",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00981",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "00990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HELSINKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01009",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VEIKKAUS, Vantaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01022",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAUPUNKILIIKENNE, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01030",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAAN KAUPUNKI, Vantaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01044",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DNA, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01051",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LASKUT, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01053",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FINNAIR, Vantaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01055",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ISS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01088",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAAN JA KERAVAN HYVINVOINTI, Vantaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VÄSTERSKOG, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SÖDERKULLA, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SÖDERKULLA, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KALKKIRANTA, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "BOX, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01261",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01281",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01351",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01361",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01371",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01391",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01451",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01481",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01532",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01621",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01631",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01641",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01651",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01671",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01691",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01711",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01721",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01731",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01741",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01761",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VANTAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KLAUKKALA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KLAUKKALA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LUHTAJOKI, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KLAUKKALA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LEPSÄMÄ, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KLAUKKALA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PERTTULA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NURMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NURMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "01940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PALOJOKI, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02008",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "POP PANKKI, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02010",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LÄHITAPIOLA, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MICROSOFT, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02020",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "METSÄ, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02022",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOKIA SOLUTIONS AND NETWORKS, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02033",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LÄNSI-UUDENMAAN HYVINVOINTIALU, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02044",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VTT, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02066",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DOCUSCAN, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02070",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOON KAUPUNKI, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02141",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02171",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02207",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOUTOPISTE, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02241",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02271",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02321",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02331",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02361",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SARVVIK, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KIRKKONUMMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KIRKKONUMMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KIRKKONUMMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JORVAS, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JORVAS, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MASALA, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02431",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MASALA, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LUOMA, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SUNDSBERG, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KANTVIK, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "UPINNIEMI, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02471",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "UPINNIEMI, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KIRKKONUMMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PIKKALA, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OITMÄKI, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAPINKYLÄ, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KYLMÄLÄ, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "EVITSKOG, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SIUNTIO KK, Siuntio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SIUNTIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAPPERS, Siuntio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02621",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02631",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02677",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOUTOPISTE, Espoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAUNIAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAUNIAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02711",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02761",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02771",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02781",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VEIKKOLA, Kirkkonummi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02921",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02941",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "02980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ESPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUMMELA, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUMMELA, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HUHMARI, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TERVALAMPI, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OJAKKALA, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OTALAMPI, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SELKI, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VIHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JOKIKUNTA, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "UUSITALO, Karkkila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VIHTIJÄRVI, Vihti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "IKKALA, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PUSULA, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "03870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYÖNÖLÄ, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SIPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SIPOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MARTINKYLÄ, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PAIPPINEN, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TALMA, Sipoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04261",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04321",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAHELA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NAHKELA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RUSUTJÄRVI, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TUUSULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄNIKSENLINNA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04431",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JÄRVENPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUMMENKYLÄ, Järvenpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HAARAJOKI, Järvenpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KELLOKOSKI, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KELLOKOSKI, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "OHKOLA, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MÄNTSÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MÄNTSÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MÄNTSÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SÄÄKSJÄRVI, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUMMINEN, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HIRVIHAARA, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SÄLINKÄÄ, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SAHAKYLÄ, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAUKALAMPI, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HAUTJÄRVI, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SAARENTAUS, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "04940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LEVANTO, Mäntsälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RÖYKKÄ, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RAJAMÄKI, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RAJAMÄKI, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KILJAVA, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JOKELA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JOKELA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUPPULINNA, Tuusula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUKARI, Nurmijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05831",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "05950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HYVINKÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06108",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NOUTOPISTE, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORVOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KERKKOO, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HAMARI, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TOLKKINEN, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KULLOONKYLÄ, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KULLOO, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KÄRRBY, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "06950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "EMÄSALO, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HINTHAARA, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ANTTILA, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAUKKOSKI, Pornainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORNAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07171",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORNAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HALKIA, Pornainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAARENKYLÄ, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ILOLA, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SANNAINEN, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "JAKARI, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "GÄDDRAG, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TIRMO, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PELLINKI, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SUURPELLINKI, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KRÅKÖ, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VOOLAHTI, Porvoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TORPPI, Pukkila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PUKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07565",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KANTELE, Pukkila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MYRSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ASKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KANKKILA, Myrskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KOSKENKYLÄN SAHA, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MALMGÅRD, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PERNAJAN VANHAKYLÄ, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ISNÄS, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HÄRKÄPÄÄ, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAPINJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "INGERMANINKYLÄ, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PORLAMMI, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PUKARO, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LINDKOSKI, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HEIKINKYLÄ, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SKINNARBY, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LILJENDAL, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MICKELSPILTOM, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOVIISA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOVIISA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VALKO, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOVIISA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PERNAJA, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOVIISA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07945",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KUGGOM, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07955",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TESJOKI, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "AHVENKOSKI, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RUOTSINPYHTÄÄ, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KUNINKAANKYLÄ, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "07990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RUOTSINKYLÄ, Loviisa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "08800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LOHJA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARJALOHJA, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SAMMATTI, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SAUKKOLA, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MILLOLA, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KOISJÄRVI, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "NUMMI, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "09930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LEPPÄKORPI, Lohja",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TÄHTELÄ, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PÄIVÖLÄ, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DEGERBY, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "INKOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "INKOO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "INKOO AS, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FAGERVIK, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "BARÖSUND, Inkoo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARJAA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARJAA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KARJAA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "PINJAINEN, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MELTOLA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MUSTIO, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KAUNISLAHTI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ÅMINNEFORS, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "POHJANKURU, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "POHJANKURU, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "BOLLSTA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "FISKARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "ANTSKOG, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TENHOLA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "BROMARV, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAMMISAARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAMMISAARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "RAASEPORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAMMISAARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DRAGSVIK, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10641",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "DRAGSVIK, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAMMISAARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TAMMISAARI, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SKOGBY, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "SNAPPERTUNA, Raasepori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "LAPPOHJA, Hanko",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HANKO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HANKO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HANGONKYLÄ, Hanko",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "10960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "HANKO POHJOINEN, Hanko",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11311",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "11910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIIHIMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "OITTI, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "OITTI, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "MOMMILA, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HIETOINEN, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HAUSJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HIKIÄ, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RYTTYLÄ, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TURKHAUTA, Hausjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LEPPÄKOSKI, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TERVAKOSKI, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TERVAKOSKI, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VÄHIKKÄLÄ, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "KORMU, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LAUNONEN, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LÄYLIÄINEN, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "SAJANIEMI, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "JOKINIEMI, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LOPPI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LOPPI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PILPALA, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RÄYSKÄLÄ, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TOPENO, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "12950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VOJAKKALA, Loppi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13035",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LVV, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HARVIALA, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HÄMEENLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PAROLANNUMMI, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PAROLANNUMMI, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PAROLA, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13721",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PAROLA, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "KATINALA, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HATTULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "13900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PEKOLA, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "JOKIMAA, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TURENKI, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TURENKI, Janakkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "JANAKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RENKO, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VUOHINIEMI, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "RIMMILÄ, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "IITTALA, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LETEENSUO, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LEPAA, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TYRVÄNTÖ, Hattula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "ALVETTULA, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TORVOILA, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HAUHO, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "ETELÄINEN, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TUULOS, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TUULOS, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TUULOS, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TUULOS, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "SAPPEE, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PUUTIKKALA, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "14980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KUOHIJOKI, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15141",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15207",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NOUTOPISTE, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15241",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KUKKILA, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MÄKELÄ, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VILLÄHDE, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NASTOLA, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NASTOLA, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "RUUHIJÄRVI, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HOLLOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HOLLOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15871",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HOLLOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HOLLOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "15980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MESSILÄ, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "UUSIKYLÄ, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "OKKERI, Lahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ARTJÄRVI, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ARTJÄRVI, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ARTJÄRVI KK, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HIETANA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VILLIKKALA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KUIVANTO, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ORIMATTILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ORIMATTILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VIRENOJA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PENNALA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINÄMAA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NIINIKOSKI, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PAKAA, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MALLUSJOKI, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HERRALA, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LUHTIKYLÄ, Orimattila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MERTIE, Kärkölä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "JÄRVELÄ, Kärkölä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "JÄRVELÄ, Kärkölä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KÄRKÖLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "TENNILÄ, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LAPPILA, Kärkölä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HOLLOLA KK, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KUTAJÄRVI, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MANSKIVI, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HÄMEENKOSKI, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HÄMEENKOSKI, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LAMMI, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LAMMI, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "ISO-EVO, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "16970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "EVO, Hämeenlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KALLIOLA, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PAIMELA, Hollola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VESIVEHMAA, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "URAJÄRVI, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VÄÄKSY, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VÄÄKSY, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PIETILÄ, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KALKKINEN, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ASIKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VIITAILA, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KURHILA, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VÄHIMAA, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ISO-ÄINIÖ, Asikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MAAKESKI, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PADASJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PADASJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NYYSTÖLÄ, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "AUTTOINEN, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VESIJAKO, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "TORITTU, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KASINIEMI, Padasjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HARMOINEN, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KUHMOINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KUHMOINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HARJUNSALMI, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIHLAJAKOSKI, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RUOLAHTI, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PÄIJÄLÄ, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KYLÄMÄ, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "17970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PUUKKOINEN, Kuhmoinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HEINOLA KK, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "18600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MYLLYOJA, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VIERUMÄKI, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VIERUMÄKI, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HUUTOTÖYRY, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LUSI, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "ONKINIEMI, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "SYRJÄKOSKI, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PAASO, Heinola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KARILANMAA, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NIKKAROINEN, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "NUORAMOINEN, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUORTTI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MANSIKKAMÄKI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PERTUNMAA, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RUORASMÄKI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LIHAVANPÄÄ, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HARTOSENPÄÄ, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LEPSALA, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KOITTI, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HARTOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HARTOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MURAKKA, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "POHELA, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KALHONKYLÄ, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JOUTSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19651",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JOUTSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MIESKONMÄKI, Joutsa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "SYSMÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "SYSMÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "SÄRKILAMPI, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LIIKOLA, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "VALITTULA, Sysmä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PUTKIJÄRVI, Hartola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TAMMIJÄRVI, Luhanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PAPPINEN, Joutsa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "19950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LUHANKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURUN YLIOPISTO, Turku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20025",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "IF, Turku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20032",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TYÖTERVEYSLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20241",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20321",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20361",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20381",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20541",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LITTOINEN, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20741",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20751",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PIISPANRISTI, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20761",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PIISPANRISTI, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KAARINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20781",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KAARINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20811",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "20960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TURKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VASTAUSLÄHETYS, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NAANTALI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NAANTALI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NAANTALI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "POIKKO, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RYMÄTTYLÄ, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RÖÖLÄ, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MERIMASKU, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIVONSAARI, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21195",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VELKUA, Naantali",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LEMU, Masku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ASKAINEN, Masku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MASKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MASKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NOUSIAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAISIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RUSKO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21291",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RUSKO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VAHTO, Rusko",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PAATTINEN, Turku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TORTINMÄKI, Turku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ILMARINEN, Lieto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIETO AS, Lieto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "AURA KK, Aura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "AURA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21381",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "AURA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VANHALINNA, Lieto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIETO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIETO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21422",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIETO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLISKULMA, Lieto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TARVASJOKI, Lieto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PRUNKILA, Marttila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MARTTILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PIIKKIÖ, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PIIKKIÖ, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HEVONPÄÄ, Paimio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PAIMIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PAIMIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PREITILÄ, Paimio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21555",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TAATILA, Paimio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "OLLILA, Marttila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SAUVO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21571",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SAUVO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KARUNA, Sauvo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PARAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PARAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KIRJALA, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KUUSISTO, Kaarina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LIELAHTI TL, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LILLANDET, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NAUVO, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NAUVO, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PÄRNÄINEN, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NÖTÖ, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KORPPOO, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KORPOSTRÖM, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "UTÖ, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NORRSKATA, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HOUTSKARI, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MOSSALA, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KYRÖ, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KYRÖ, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KUMILA, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KARINAINEN, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "AUVAINEN, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RIIHIKOSKI, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21871",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RIIHIKOSKI, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PÖYTYÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HAVERI, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLÄNE, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLÄNE, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "21930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "UUSIKARTANO, Pöytyä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MYNÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MYNÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MIETOINEN, Mynämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HIETAMÄKI, Mynämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VINKKILÄ, Vehmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VINKKILÄ, Vehmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VEHMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAUTILA, Vehmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TAIVASSALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23311",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TAIVASSALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KUSTAVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "INIÖ, Parainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LOKALAHTI, Uusikaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "UUSIKAUPUNKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "UUSIKAUPUNKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KALANTI, Uusikaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KALANTI, Uusikaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KALANTI AS, Uusikaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LAITILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LAITILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SOUKAINEN, Laitila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SUONTAKA, Laitila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PYHÄMAA, Uusikaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PYHÄRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "23960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SANTTIO, Pyhäranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SALO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HALIKKO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HALIKKO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "24910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HALIKKO AS, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KRUUSILA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MUURLA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TUOHITTU, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOTALATO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERTTELI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERTTELI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VARTSALA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ANGELNIEMI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HAJALA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MÄRYNUMMI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VASKIO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "RAATALA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KUUSJOKI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KANUNKI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERTTELI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERTTELI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "REKIJOKI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KIIKALA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SUOMUSJÄRVI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LAHNAJÄRVI, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KETTULA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KISKO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KISKO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERNIÖ, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERNIÖ, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PERNIÖ AS, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KNAAPILA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "AIJALA, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOSKI AS, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TEIJO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLÖNKYLÄ, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SÄRKISALO, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "FÖRBY, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "STRÖMMA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MATHILDEDAL, Salo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KEMIÖ, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KEMIÖ, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VRETA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MJÖSUND, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KIILA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MARK, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VESTLAX, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VÄSTANFJÄRD, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NIVELAX, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "BJÖRKBODA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "DRAGSFJÄRD, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TAALINTEHDAS, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VÄNOXA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KASNÄS, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HIITTINEN, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ROSALA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "25960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HÖGSÅRA, Kemiönsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAARO, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KOLLA, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "MONNANUMMI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VASARAINEN, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RAUMA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KORTELA, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "UNAJA, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VERMUNTILA, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "26950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VOILUOTO, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAPPI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAPPI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAPPI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAPPI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAPPI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KODISJOKI, Rauma",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "IHODE, Pyhäranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "REILA, Pyhäranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KIUKAINEN, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KIUKAINEN, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PANELIA AS, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PANELIA, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HAROLA, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAUTTUA, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAUTTUA, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "EURA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HINNERJOKI, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HONKILAHTI KK, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HONKILAHTI, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "MANNILA, Eura",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KÖYLIÖ, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "TUISKULA, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VOITOINEN, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KÖYLIÖ, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÄKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÄKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÄKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KÖYLIÖ, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KÖYLIÖ, Säkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÄKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "27920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÄKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HARJUNPÄÄ, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28361",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "ULVILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "ULVILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28407",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NOUTOPISTE, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VANHA-ULVILA, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "28900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PORI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LUVIA, Eurajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LUVIA, Eurajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PERÄNKYLÄ, Eurajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HARJAVALTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HARJAVALTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NAKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NAKKILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HORMISTO, Nakkila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "JÄRVIMAA, Nakkila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAASMARKKU, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LEINEPERI, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KULLAA, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PALUS, Ulvila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SÖÖRMARKKU, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NOORMARKKU, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NOORMARKKU, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "POMARKKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29631",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "POMARKKU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HONKAKOSKI, Pomarkku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LASSILA, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "AHLAINEN, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAMPPI, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "ETELÄMAA, Merikarvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "POHJANSAHA, Merikarvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KÖÖRTILÄ, Merikarvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "TUORILA, Merikarvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SIIKAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29811",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SIIKAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SAMMI, Siikainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "OTAMO, Siikainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LEVÄSJOKI, Siikainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "MERIKARVIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "MERIKARVIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "29940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KUVASKANGAS, Merikarvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "FORSSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "FORSSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30107",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "NOUTOPISTE, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30108",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PAKETTIAUTOMAATTI, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "FORSSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "FORSSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "30421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "FORSSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VASTAUSLÄHETYS, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "MATKU, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "KOIJÄRVI, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MENONEN, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NUUTAJÄRVI, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "SAVIJOKI, Forssa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "SUSIKAS, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TEURO, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "TAMMELA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "MUSTIALA, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "PORRAS, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LIESJÄRVI, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "EERIKKILÄN URHEILUOPISTO, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LETKU, Tammela",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SOMERO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SOMERO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLÖPIRTTI, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HÄNTÄLÄ, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "HIRSJÄRVI, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "SOMERNIEMI, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TERTTILÄ, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOSKI TL",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOSKI TL",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PITKÄJÄRVI, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "PYÖLI, Somero",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "JOKIOINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "JOKIOINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VAULAMMI, Jokioinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "LATOVAINIO, Jokioinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "MINKIÖ, Jokioinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HUMPPILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31641",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "HUMPPILA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "VENÄJÄNKANGAS, Humppila",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "URJALA AS, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "URJALANKYLÄ, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HONKOLA, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KEHRO, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "URJALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31761",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "URJALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ORINIEMI, Punkalaidun",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HALKIVAHA, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOSKIOINEN, Punkalaidun",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TURSA, Urjala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PUNKALAIDUN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PUNKALAIDUN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VANTTILA, Punkalaidun",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SADONMAA, Punkalaidun",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ORISUO, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "31970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANTEENMAA, Punkalaidun",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "YPÄJÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1493,
+    "state_code": "06",
+    "locality_name": "YPÄJÄ AS, Ypäjä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LOIMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LOIMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LOIMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOJONKULMA, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "KOJONPERÄ, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "METSÄMAA, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "METSÄKORPI, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "MELLILÄ, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "NIINIJOKI, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "YLHÄINEN, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ALASTARO, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32441",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ALASTARO, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "TAMMIAINEN, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "ORIPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "LATVA, Oripää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1507,
+    "state_code": "19",
+    "locality_name": "VIRTTAA, Loimaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VAMPULA, Huittinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RUTAVA, Huittinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HUITTINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HUITTINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SAMPU, Huittinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32741",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SUTTILA, Huittinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HUHTAMO, Huittinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KOKEMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KOKEMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "PEIPOHJA, Kokemäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "RISTE, Kokemäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KORKEAOJA, Kokemäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAUVATSA AS, Kokemäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "32920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KAUVATSA, Kokemäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33013",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "FIMLAB, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPEREEN YLIOPISTO, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33032",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TYÖTERVEYSLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33107",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOUTOPISTE, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33108",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOUTOPISTE, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33251",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33271",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33311",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33331",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33341",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33411",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VUORENTAUSTA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SIIVIKKALA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLÖJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33471",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLÖJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLÖJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33541",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33561",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33581",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33587",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOUTOPISTE, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33711",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33721",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33731",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33821",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33841",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33851",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33881",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TAMPERE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33961",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "33980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LAKIALA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LAKIALA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLINEN, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MUTALA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KYRÖNLAHTI, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LÄNSI-TEISKO, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KÄMMENNIEMI, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TERÄLAHTI, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VELAATTA, Tampere",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KURU, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KURU, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PARKKUU, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "POIKELUS, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MUROLE, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MUROLEEN KANAVA, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KEKKONEN, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "JÄMINKIPOHJA, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LUODE, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LÄNSI-AURE, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ITÄ-AURE, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RUOVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RUOVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MUSTAJÄRVI, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VASKIVESI, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VASKUU, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KORO, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KURJENKYLÄ, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VIRRAT",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VIRRAT",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VISUVESI, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ÄIJÄNNEVA, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LIEDENPOHJA, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "OHTOLA, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TOISVESI, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "34980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KILLINKOSKI, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ORIVESI AS, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ERÄJÄRVI, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RISTAKALLIO, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HOIVAMÄKI, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VÄSTILÄ, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ORIVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ORIVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HIRSILÄ, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LÄNGELMÄKI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TALVIAINEN, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LÄNGELMÄKI, Orivesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KORKEAKOSKI, Juupajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIRTTIKANGAS, Juupajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LYLY, Juupajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "JUUPAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SALOKUNTA, Juupajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HALLI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HALLI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PIHLAISTO, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUOREVESI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VILPPULA, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VILPPULA, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLÄ-VÄÄRI, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VÄÄRINMAJA, Ruovesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MÄNTTÄ, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MÄNTTÄ, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "MÄNTTÄ, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "35990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOLHO, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA AS, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RUUTANA, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SUINULA, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KANGASALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PIKONLINNA, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TOHKALA, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SAHALAHTI, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SAHALAHTI, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SALMENTAKA, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RAIKKU, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KAIVANTO, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PÄLKÄNE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PÄLKÄNE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ILTASMÄKI, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LAITIKKALA, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AITOO, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LUOPIOINEN, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KUHMALAHTI, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "POHJA, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VEHKAJÄRVI, Kangasala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RAUTAJÄRVI, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "36930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KYYNÄRÖ, Pälkäne",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37121",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "NOKIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SARKOLA, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SIURO, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KULOVESI, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LINNAVUORI, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37241",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LINNAVUORI, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TOTTIJÄRVI, Nokia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESILAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESILAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESILAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESILAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESILAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37551",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LEMPÄÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VALKEAKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VALKEAKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VALKEAKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SÄÄKSMÄKI, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RITVALA, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HAUKILA, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TARTTILA, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "METSÄKANSA, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KÄRJENNIEMI, Valkeakoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37911",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "37960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TERVAHAUTA, Sastamala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HAUKIJÄRVI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASTAMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAVIA, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAVIA, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "YLI-PUTTO, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KALLIALA, Pori",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "TUUNAJÄRVI, Pomarkku",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KANKAANPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KANKAANPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KANKAANPÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VIHTELJÄRVI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HAPUOJA, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VENESKOSKI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VENESJÄRVI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LOHIKKO, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "JÄMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NIINISALO, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38841",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "NIINISALO, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SUURIMAA, Jämijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "ALA-HONKAJOKI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "VATAJANKOSKI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HONKAJOKI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38951",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "HONKAJOKI, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "38970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "LAUHALA, Kankaanpää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HÄMEENKYRÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HÄMEENKYRÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SIMUNA, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SASI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PINSIÖ, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "JULKUJÄRVI, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "JUMESNIEMI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "HERTTUALA, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39195",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KAIPIO, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KYRÖSKOSKI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "OSARA, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VESAJÄRVI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "VILJAKKALA, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KARHE, Ylöjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOMI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LAVAJÄRVI, Hämeenkyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LUHALAHTI, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RÖYHIÖ, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "SISÄTTÖ, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "IKAALINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "IKAALINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KILVAKKALA, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "RIITIALA, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "TEVANIEMI, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOVELAHTI, Ikaalinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOVESJOKI, Parkano",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LAPINNEVA, Parkano",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PARKANO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "PARKANO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KUIVASJÄRVI, Parkano",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "AURESKOSKI, Parkano",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "ALASKYLÄ, Parkano",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "LINNANKYLÄ, Kihniö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KIHNIÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KIHNIÖ AS, Kihniö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SUOMIJÄRVI, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KARVIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KANTTI, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SARVELA, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39965",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "KARVIANKYLÄ, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "SARA, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "39990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1501,
+    "state_code": "17",
+    "locality_name": "ALKKIA, Karvia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40011",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HEEROS PALVELUT, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄN YLIOPISTO, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40049",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VALTERI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40056",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KELA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PALOKKA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40271",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PALOKKA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40321",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40341",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40351",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYSKÄ, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JYVÄSKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VAAJAKOSKI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VAAJAKOSKI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HAAPANIEMI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SÄYNÄTSALO, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KINKOMAA, Muurame",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MUURAME",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "40951",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MUURAME",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VASTAUSLÄHETYS, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PUUPPOLA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUIKKA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TIKKAKOSKI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41161",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TIKKAKOSKI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VEHNIÄ, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JOKIHAARA, Uurainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HÖYTIÄ, Uurainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "UURAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "UURAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KYYNÄMÖINEN, Uurainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HOIKANKYLÄ, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LANNEVESI, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KANGASHÄKKI, Uurainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LEPPÄVESI, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41325",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LAUKKAVIRTA, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VIHTAVUORI, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41331",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VIHTAVUORI, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LAUKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41341",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LAUKAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LAUKAA AS, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VALKOLA, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUUSA, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄIJÄLÄ, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LIEVESTUORE, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LIEVESTUORE, Laukaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KANKAINEN, Toivakka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RUUHIMÄKI, Toivakka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LEPPÄLAHTI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "NIEMISJÄRVI, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HANKASALMI AS, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HANKASALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41521",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HANKASALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VENERANTA, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RISTIMÄKI, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HANNULA, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SÄKINMÄKI, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAUVAMÄKI, Hankasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ORAVASAARI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TOIVAKKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41661",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TOIVAKKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RUTALAHTI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KIVISUO, Joutsa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HAVUMÄKI, Joutsa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LEIVONMÄKI, Joutsa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KORPILAHTI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KORPILAHTI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAAKOSKI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MOKSI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TIKKALA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PUTKILAHTI, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "OITTILA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PETÄJÄVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PETÄJÄVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KINTAUS, Petäjävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41925",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "YLÄ-KINTAUS, Petäjävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUOHU, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VESANKA, Jyväskylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HUTTULA, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "41980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUIVASMÄKI, Petäjävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42011",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "YRITYSLOKERO, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JÄMSÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JÄMSÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JUOKSLAHTI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KAIPOLA, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JÄMSÄNKOSKI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "JÄMSÄNKOSKI, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HAAVISTO, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KOSKENPÄÄ, Jämsä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ASUNTA, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "POHJOISJÄRVI, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MULTIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MULTIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAHRAJÄRVI, Multia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEURUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEURUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEURUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42721",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEURUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HAAPAMÄKI, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RIIHO, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "YLÄ-KOLKKI, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOLKKI, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "POHJASLAHTI, Mänttä-Vilppula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1506,
+    "state_code": "11",
+    "locality_name": "KOTALA, Virrat",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PIHLAJAVESI, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "42930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KATAJAMÄKI, Keuruu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAARIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAARIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "TARVAALA, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HÄKKILÄ, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MAHLU, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LEHTOLA, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KOLKANLAHTI, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KALMARI, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KANNONKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KANNONJÄRVI, Kannonkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LOKAKYLÄ, Kivijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUKKO, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VÄÄTÄISKYLÄ, Multia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PYLKÖNMÄKI, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PÄÄJÄRVI, Saarijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KANGASAHO, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KARSTULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KARSTULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KIMINKI, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RANTAKYLÄ, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VAHANKA, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "AHO, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HUMPPI, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VASTINKI, Karstula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KYYJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KYYJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUMPULAINEN, Kyyjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KIVIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SOMPALA, Kivijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KINNULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KINNULA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MUHOLA, Kinnula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "43960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SAARENSALMI, Kinnula",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄÄNEKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄÄNEKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄÄNEKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄÄNEKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HUUTOMÄKI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HIETAMA, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PARANTALA, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SUOLAHTI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SUOLAHTI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SUOLAHTI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ÄÄNEKOIVISTO, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VIHIJÄRVI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SUMIAINEN, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KONNEVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SIRKKAMÄKI, Konnevesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HYTÖLÄ, Konnevesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ISTUNMÄKI, Konnevesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KONNEVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KONGINKANGAS, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KONGINKANGAS, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LIIMATTALA, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "RÄIHÄ, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KALANIEMI, Äänekoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "NIINILAHTI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VIITASAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VIITASAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ILMOLAHTI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "HUOPANANKOSKI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "VUORILAHTI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KÄRNÄ, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KUMPUMÄKI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KYMÖNKOSKI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "SUOVANLAHTI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LAHNANEN, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "LÖYTÄNÄ, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEITELEPOHJA, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KEIHÄRINKOSKI, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KOTVALA, Viitasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PIHTIPUDAS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PIHTIPUDAS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ALVAJÄRVI, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "MUURASJÄRVI, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "ELÄMÄJÄRVI, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "PENINKI, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KÄRVÄSJÄRVI, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "44970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1511,
+    "state_code": "08",
+    "locality_name": "KORPPINEN, Pihtipudas",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOUVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HARJU, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VALKEALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VALKEALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45371",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VALKEALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "UTTI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45411",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "UTTI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SAVERO, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KORIA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KORIA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KUUSANKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KUUSANKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KUUSANKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KUUSANKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SAIRAALAMÄKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "PILKANMAA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VOIKKAA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45911",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VOIKKAA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "45940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ORAVALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "TUOHIKOTTI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VEKARANJÄRVI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VALKEALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KAIPIAINEN, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "TIRVA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ENÄJÄRVI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KANNUSKOSKI, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SAARAMAA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SIPPOLA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "RUOTILA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "LIIKKALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MYLLYKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MYLLYKOSKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "UMMELJOKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KELTAKANGAS, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "INKEROINEN, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "INKEROINEN, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ANJALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HURUKSELA, Kotka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "AHVIO, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "46960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MUHNIEMI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "LÖYTTY, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "RAUSSILA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ELIMÄKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ELIMÄKI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "RATULA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HAAPA-KIMOLA, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "KIMONKYLÄ, Lapinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KAUSALA, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KAUSALA, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "SÄÄSKJÄRVI, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "PERHENIEMI, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "HIISIÖ, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "MANKALA, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "IITTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "LYÖTTILÄ, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1502,
+    "state_code": "16",
+    "locality_name": "KYMENTAKA, Iitti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KIMOLA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "JAALA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HUHDASJÄRVI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SELÄNPÄÄ, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HASULA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VERLA, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VUOHIJÄRVI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "47910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HILLOSENSALMI, Kouvola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48771",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "48930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KOTKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HEINLAHTI, Pyhtää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HUUTJÄRVI, Pyhtää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SILTAKYLÄ, Pyhtää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "PUROLA, Pyhtää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "PYHTÄÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VASTILA, Pyhtää",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "TAVASTILA, Kotka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "JUURIKORPI, Kotka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HAMINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HAMINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "POITSILA, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49411",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "POITSILA, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HAMINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HAMINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49461",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HAMINA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SUMMA, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "NEUVOTON, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HUSULA, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "REITKALLI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "METSÄKYLÄ, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KANNUSJÄRVI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SIVATTI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VEHKAJOKI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "PAIJÄRVI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "PYHÄLTÖ, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MIEHIKKÄLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "HURTTALA, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MUURIKKALA, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KALLIOKOSKI, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SUUR-MIEHIKKÄLÄ, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "SALO-MIEHIKKÄLÄ, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ONKAMAA, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "MÄNTLAHTI, Hamina",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "KLAMILA, Virolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VIROLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VIROLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "VAALIMAA, Virolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "ALA-PIHLAJA, Virolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "49980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "RAVIJOKI, Virolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50049",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VALTERI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NOROLA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "OTAVA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KORPIKOSKI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "50970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MIKKELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VANHAMÄKI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KANGASNIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KANGASNIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TAHKOMÄKI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUTEMAJÄRVI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LEVÄ, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51335",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KAIHLAMÄKI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HÄNNILÄ, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KOIVULA, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SYNSIÖ, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HARJUMAA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LÄSÄKOSKI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VUOJALAHTI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PAJULANKYLÄ, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LUUSNIEMI, Kangasniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HIIROLA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KALVITSA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HAUKIVUORI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HAUKIVUORI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PITKÄAHO, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NYKÄLÄ, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RAHULA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HUUHANAHO, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NUUTILANMÄKI, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUOSMALA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MAIVALA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HATSOLA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VUORENMAA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NARILA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KOIKKALA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RISULAHTI, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "JUVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "JUVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PAATELA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HÄRKÄLÄ, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "51980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LAUTEALA, Juva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52020",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "WOIKOSKI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "ANTTOLA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MAJAVESI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HAUHALA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUUMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUUMALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HURISSALO, Puumala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RYHÄLÄ, Puumala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RISTIINA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RISTIINA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VITSIÄLÄ, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HEIMARI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HANGASTENMAA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SOMEENJÄRVI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PELLOSNIEMI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HIETANEN, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SYVÄSMÄKI, Hirvensalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HIRVENSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52551",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HIRVENSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TUUKKALA, Hirvensalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUITULA, Hirvensalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MÄNTYHARJU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MÄNTYHARJU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KARANKAMÄKI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KOIRAKIVI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TUUSTAIPALE, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MYNTTILÄ, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUOMIOKOSKI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SUOMENNIEMI, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HALMENIEMI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KÄÄVÄNKYLÄ, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VOIKOSKI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NURMAA, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PANKALAHTI, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "52980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "AHVENAINEN, Mäntyharju",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53851",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "53950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "JOUTSENO, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "JOUTSENO, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAMPIKANGAS, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PULP, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KONNUNSUO, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "NUIJAMAA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RAPATTILA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "VAINIKKALA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAPPEENRANTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "HYTTI, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SIMOLA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PULSA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "YLÄMAA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "HUJAKKALA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "YLIJÄRVI, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1512,
+    "state_code": "09",
+    "locality_name": "AHOMÄKI, Miehikkälä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "TAAVETTI, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "TAAVETTI, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "URO, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LUUMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SUO-ANTTILA, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SOMERHARJU, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KAITJÄRVI, Luumäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAKSIAINEN, Savitaipale",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "VÄLIJOKI, Savitaipale",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "HEITUINLAHTI, Savitaipale",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAVITAIPALE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAVITAIPALE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KOTIMÄKI, Lemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KUUKANNIEMI, Lemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54915",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAIMAANHARJU, Taipalsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "TAIPALSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LEVÄNEN, Taipalsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SOLKEI, Taipalsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PETTILÄ, Savitaipale",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "54960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "VEHKATAIPALE, Taipalsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55121",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RAUHA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RAUHA, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "TIURUNIEMI, Lappeenranta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "55910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "IMATRA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RUOKOLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RUOKOLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SALOSAARI, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "ÄITSAARI, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "VIRMUTJOKI, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SYYSPOHJA, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "UTULA, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KYLÄNIEMI, Taipalsaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KAITURINPÄÄ, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "POHJALANKILA, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PUNTALA, Ruokolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "NISKA-PIETILÄ, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "RAUTJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PURNUJÄRVI, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "MIETTILÄ, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "LAIKKO, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SIMPELE, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "56801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SIMPELE, Rautjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57090",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VISMA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "57810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONLINNA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "ORAVI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "AHVENSALMI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MAKKOLA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KARVILA, Enonkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SIMANALA, Enonkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58175",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "ENONKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "IHAMANIEMI, Enonkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KERIMÄKI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KERIMÄKI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LOUHI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KUMPURANTA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SAVONRANTA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RAIKUU, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VILLALA, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SÄIMEN, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RÖNKÖNVAARA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HAAPAKALLIO, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SILVOLA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KULENNOINEN, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUNKAHARJU, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUNKAHARJU, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUNKAHARJU, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HIUKKAJOKI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PUTIKKO, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RUHVANA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VUORINIEMI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TELAKANAVA, Sulkava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LOHILAHTI, Sulkava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KIVIAPAJA, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIOJÄRVI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "ALA-SÄRKILAHTI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SULKAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SULKAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KAARTILANKOSKI, Sulkava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIHLAJALAHTI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KALLISLAHTI, Savonlinna",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PARKUMÄKI, Rantasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HILTULA, Rantasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RANTASALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RANTASALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "RANTASALMI AS, Rantasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KOLKONTAIPALE, Rantasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "58940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TUUSMÄKI, Rantasalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PARIKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "PARIKKALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KOITSANLAHTI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "MELKONIEMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SÄRKISALMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "HAAPAOJA, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "KIRJAVALA, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAARI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAARI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "SAARI KK, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "MIKKOLANNIEMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "TARNALA, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "UUKUNIEMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "UUKUNIEMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1497,
+    "state_code": "02",
+    "locality_name": "UUKUNIEMI, Parikkala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KESÄLAHTI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SUURIKYLÄ, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "59820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PURUJÄRVI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60060",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ATRIA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60061",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ATRIA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60157",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NOUTOPISTE, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MUNAKKA, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HYLLYKALLIO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HYLLYKALLIO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NURMO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HALKOSAARI, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOKOSKI, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TUOMIKYLÄ, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "POJANLUOMA, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ILMAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "60801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ILMAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PERÄSEINÄJOKI, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VUOLLE, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LOUKO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PASTO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SYDÄNMAA, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KOURA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SÄÄSKINIEMI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HAAPALUOMA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MYLLYSALO, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LUOPA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JALASTO, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LUOPAJÄRVI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JOKIPII, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TAIVALMAA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KURIKKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KURIKKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PANTTILA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KOSKENKORVA, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NOPANKYLÄ, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HUISSI, Ilmajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MIETO, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LOHILUOMA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "POLVENKYLÄ, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLISTARO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLISTARO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLISTARO AS, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOREHTO, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "UNTAMALA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KYLÄNPÄÄ, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HANHIKOSKI, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KITINOJA, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOKYRÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOKYRÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEHMÄJOKI, Isokyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ORISMALA, Isokyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ORISBERG, Isokyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JALASJÄRVI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JALASJÄRVI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HIRVIJÄRVI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALA-VALLI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KALAKOSKI, Seinäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MANTILA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PENTINMÄKI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KOSKUE, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLI-VALLI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ILVESJOKI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LUOMANKYLÄ, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAINASTO, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NORINKYLÄ, Teuva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAJOKI AS, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HARJA, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "IKKELÄJÄRVI, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NUMMIJÄRVI, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NUMMIKOSKI, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HYYPPÄ, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JUONIKYLÄ, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KYRÖNLATVA, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "61980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PÄNTÄNE, Kauhajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAPUA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAPUA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HELLANMAA, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RINTAKANGAS, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KARHUNKYLÄ, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62165",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TIISTENJOKI, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAKALUOMA, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62175",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLIKYLÄ, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62185",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MÄKI-PAAVOLA, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RUHA, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PERNAA, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JYLHÄ, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HUHMARKOSKI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HIRVIJOKI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MUSTAMAA, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HIRVIKYLÄ, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62295",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUHAJÄRVI, Lapua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HÄRMÄ, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HÄRMÄ, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VOLTTI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUOPPA, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "EKOLA, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KANGASTO, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62375",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "YLIHÄRMÄ, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KOSOLANKYLÄ, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62395",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PETTERINMÄKI, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RINTALA, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KORTESJÄRVI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KORTESJÄRVI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PELTOTUPA, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62435",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PIRTTINEN, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PERKIÖMÄKI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PURMOJÄRVI, Kauhava",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "EVIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "EVIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUOPPA-AHO, Evijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KAUTIAINEN, Evijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VASIKKA-AHO, Evijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SÄRKILÄ, Evijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAPPAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAPPAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TARVOLA, Lappajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALA-SEPPÄ, Lappajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KARVALA, Lappajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SAVONKYLÄ, Lappajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ITÄKYLÄ, Lappajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUREJOKI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SISSALA, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HAUKKALA, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KOSKENVARSI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SAUKONKYLÄ, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MENKIJÄRVI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VIMPELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SAVONJOKI, Vimpeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LUOMA-AHO, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LAKANIEMI, Vimpeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SAHI, Vimpeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VINNI, Vimpeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SÄÄKSVESI, Vimpeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEVIJOKI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HOISKO, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PAALIJÄRVI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "62990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MÖKSY, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUORTANE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUORTANE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEPPÄLÄNKYLÄ, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MÄYRY, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RUONA, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SALMI, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NIINIMAA, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LENTILÄ, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RANTALA, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALAVUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALAVUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KATTELUS, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PAHAJOKI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SAPSALAMPI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SULKAVANKYLÄ, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63355",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SEINÄJÄRVI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUIVASKYLÄ, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TAIPALUS, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALAVUS AS, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RANTATÖYSÄ, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KÄTKÄNJOKI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LÖYÄ, Kuortane",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEHTIMÄKI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEHTIMÄKI, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LEHTIMÄKI KK, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "LÄNSIKYLÄ, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HERNESMAA, Alajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TÖYSÄ, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TUURI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "RITOLA, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ÄHTÄRINRANTA, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HAKOJÄRVI, Alavus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ÄHTÄRI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ÄHTÄRI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PERÄNNE, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ALASTAIPALE, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SOINI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KEISALA, Soini",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KUKONKYLÄ, Soini",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HAUTAKYLÄ, Soini",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MYLLYMÄKI, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "INHAN TEHTAAT, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "INHA, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "63950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VEHUNKYLÄ, Ähtäri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KRISTIINANKAUPUNKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KRISTIINANKAUPUNKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "TIUKKA, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NÄRPIÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NÄRPIÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KALAX, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "YTTERMARK, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NÄRPIÖ AS, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BÖLE, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PJELAX, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KASKINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LAPVÄÄRTTI, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "DAGSMARK, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KARIJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MYRKKY, Karijoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "METSÄLÄ, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KALLTRÄSK, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "HÄRKMERI, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SKAFTUNG, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SIIPYY, Kristiinankaupunki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NÄMPNÄS, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NORRNÄS, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "RANGSBY, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "YLIMARKKU, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TEUVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TEUVA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PERÄLÄ, Teuva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HORO, Teuva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "PELTOLA, Teuva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ÄYSTÖ, Teuva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VANHAKYLÄ, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KÄRJENKOSKI, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "VILLAMO, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HEIKKILÄNJOKI, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "MÖYKKY, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "ISOJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "64930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KODESJÄRVI, Isojoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65231",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VAASA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SUNDOM, Vaasa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SULVA, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "TÖLBY, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "RIMAL, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VIKBY, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "HELSINGBY, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MUSTASAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65611",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MUSTASAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KARPERÖ, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOSKÖ, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SINGSBY, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "JUNGSUND, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ISKMO, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "RAIPPALUOTO, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BJÖRKÖBY, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NORRA VALLGRUND, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SÖDRA VALLGRUND, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "65970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SÖDERUDDEN, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MAALAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ÖVERMALAX, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66141",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ÖVERMALAX, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LÅNGÅMINNE, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KORSNÄS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KORSNÄS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MOLPE, Korsnäs",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BERGÖ, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KORSBÄCK, Korsnäs",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PETOLAHTI, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SVARVAR, Maalahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIRTTIKYLÄ, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "TAKLAX, Korsnäs",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "HARRSTRÖM, Korsnäs",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66295",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "TÖJBY, Närpiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JURVA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "JURVA, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NIEMENKYLÄ, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "HAKKO, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "SARVIJOKI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TAINUS, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "KESTI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "NÄRVIJOKI, Kurikka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LAIHIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LAIHIA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "RUTO, Laihia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VEDENOJA, Vaasa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TERVAJOKI, Isokyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66441",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1498,
+    "state_code": "03",
+    "locality_name": "TERVAJOKI, Isokyrö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "JAKKULA, Laihia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "HAAPALA, Laihia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "JUKAJA, Laihia",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VÄHÄKYRÖ, Vaasa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VÄHÄKYRÖ, Vaasa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MERIKAARTO, Vaasa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VEIKKAALA, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOIVULAHTI, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOIVULAHTI, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PETSMO, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VÄSTERHANKMO, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ÖSTERHANKMO, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KUNI, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VASSOR, Mustasaari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "VÖYRI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MAKSAMAA, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BERTBY, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KAURAJÄRVI, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KAITSOR, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "OXKANGAR, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ORAVAINEN, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ORAVAINEN, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KIMO, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOMOSSA, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ORAVAISTEN TEHDAS, Vöyri",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PENSALA, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "JEPUA, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "UUSIKAARLEPYY",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "UUSIKAARLEPYY",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SOKALUOTO, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOVJOKI, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MUNSALA, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "HIRVLAX, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "66980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "MONÅ, Uusikaarlepyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "67900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KOKKOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HIMANKA, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HILLILÄ, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "MARINKAINEN, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KARHI, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "LOHTAJA, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "ALA-VIIRRE, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KÄLVIÄ, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "RUOTSALO, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "ULLAVA, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "YLI-ULLAVA, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "RAHKONEN, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ALAVETELI, Kruunupyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KRUUNUPYY",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KRUUNUPYY",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LEPPLAX, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "ÖJA, Kokkola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68555",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BOSUND, Luoto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "EUGMO, Luoto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LUOTO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LARSMO, Luoto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIETARSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIETARSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIETARSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIETARSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PIETARSAARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SUNDBY, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "TEERIJÄRVI, Kruunupyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "SMÅBÖNDERS, Kruunupyy",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "KOLPPI, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "YTTERESSE, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ÄHTÄVÄ, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "BÄCKBY, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "NEDERLAPPFORS, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "EDSEVÖ, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PÄNNÄINEN, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "FORSBY, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "PURMO, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "LILLBY, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "68970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1508,
+    "state_code": "12",
+    "locality_name": "ÖVERPURMO, Pedersöre",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KANNUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KANNUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "ESKOLA, Kannus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "YLI-KANNUS, Kannus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "TOHOLAMPI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "TOHOLAMPI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "LAITALA, Toholampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "MÄÄTTÄLÄ, Toholampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "PURONTAKA, Toholampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "SYKÄRÄINEN, Toholampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "SYRI, Lestijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "LESTIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "YLI-LESTI, Lestijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "HALSUA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KANALA, Halsua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KARVONEN, Halsua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KAUSTINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KAUSTINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KÖYHÄJOKI, Kaustinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "VETELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "VETELI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "TUNKKARI, Veteli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "SILLANPÄÄ, Veteli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "RÄYRINKI, Veteli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "PULKKINEN, Veteli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "PATANA, Veteli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "KIVIKANGAS, Perho",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "OKSAKOSKI, Perho",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "PERHO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69951",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "PERHO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "SALAMAJÄRVI, Perho",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "69980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1494,
+    "state_code": "07",
+    "locality_name": "MÖTTÖNEN, Perho",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70010",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LUJA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70029",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KYS, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70032",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TYÖTERVEYSLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70049",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VALTERI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70090",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MONETRA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70111",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70151",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70461",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70621",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70781",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70821",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HILTULANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70871",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HILTULANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TOIVALA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TOIVALA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VUORELA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70911",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VUORELA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "70940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JÄNNEVIRTA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VASTAUSLÄHETYS, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KORTEJOKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARTIALA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RIISTAVESI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAUKKA-AHO, Tuusniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TUUSNIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TUUSNIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TUUSJÄRVI, Tuusniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PAAKKILA, Tuusniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JUURIKKAMÄKI, Tuusniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOSULA, Tuusniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VEHMERSALMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RÄSÄLÄ, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LITMANIEMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MUSTINLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PAUKARLAHTI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ORAVIKOSKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KURKIMÄKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "AIRAKSELA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUOPIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SYVÄNNIEMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SALONKULMA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TALLUSKYLÄ, Tervo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HIRVILAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LEINOLANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUROLANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PULKONKOSKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARPASMAA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KÄÄRMELAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KINNULANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TAVINSALMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71745",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HAATALA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MAANINKA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "AHKIONLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71775",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TUOVILANLAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SIILINJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SIILINJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PÖLJÄ, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUUSLAHTI, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LEPPÄKAARRE, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HARJAMÄKI, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HAMULA, Siilinjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ALAPITKÄ, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PAJUJÄRVI, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAMMASAHO, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "71960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LUKKARILA, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KARTTULA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KARTTULA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ITÄ-KARTTULA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TERVO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72211",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TERVO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ELIAKSELA, Tervo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VESANTO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NIINIVESI, Vesanto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TIITILÄNKYLÄ, Vesanto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PIENOLA, Vesanto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NÄRHILÄ, Vesanto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HORONTAIPALE, Vesanto",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PIELAVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PIELAVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PIELAVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SAARINEN, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JOKIJÄRVI, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SÄVIÄNTAIPALE, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SÄVIÄ, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MÄNTYLÄ, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KEITELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KEITELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUUSELA, Keitele",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VAARASLAHTI, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAUKKALA, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JYLHÄNKYLÄ, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SAARELA, Pielavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TOSSAVANLAHTI, Keitele",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PORTTILA, Keitele",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "72980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PETÄJÄKYLÄ, Keitele",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAPINLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAPINLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MÄNTYLAHTI, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NERKOO, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARPAISJÄRVI, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARPAISJÄRVI, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SYVÄRINPÄÄ, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KORPIJÄRVI, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NILSIÄ, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NILSIÄ, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TAHKOVUORI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NILSIÄ, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HALUNA, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PAJULAHTI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PIEKSÄNKOSKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MUURUVESI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VÄSTINNIEMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JUANKOSKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JUANKOSKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KAAVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KAAVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KORTTEINEN, Kaavi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SIVAKKAVAARA, Kaavi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73645",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NIINIVAARA, Kaavi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LUIKONLAHTI, Kaavi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VIITANIEMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LOSOMÄKI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SÄYNEINEN, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PALONURMI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SIIKAJÄRVI, Kuopio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ALA-LUOSTA, Rautavaara",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RAUTAVAARA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RAUTAVAARA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RIITASALO, Rautavaara",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "73990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KANGASLAHTI, Rautavaara",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74121",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VIEREMÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SALAHMI, Vieremä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MARTTISENJÄRVI, Vieremä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NISSILÄ, Vieremä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KAUPPILANMÄKI, Vieremä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SONKAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SONKAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SUKEVA, Sonkajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74345",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KALLIOSUO, Sonkajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SONKAKOSKI, Sonkajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JYRKKÄ, Sonkajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "LAAKAJÄRVI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HERNEJÄRVI, Iisalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PALOINEN, Lapinlahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOIRAKOSKI, Sonkajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOTIKYLÄ, Iisalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PÖRSÄNMÄKI, Iisalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KURENPOLVI, Iisalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74595",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RUNNI, Iisalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HONKARANTA, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HEINÄKYLÄ, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SULKAVANJÄRVI, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RAPAKKOJOKI, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MYLLYNIEMI, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KIURUVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KIURUVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NIEMISKYLÄ, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "AITTOJÄRVI, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KALLIOKYLÄ, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOPPELOHARJU, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "REMESKYLÄ, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "74980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TIHILÄNKANGAS, Kiuruvesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NURMES",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NURMES",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NURMES",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75531",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NURMES",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SAVIKYLÄ, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "YLÄ-LUOSTA, Rautavaara",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VALTIMO, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VALTIMO, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KARHUNPÄÄ, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PAJUKOSKI, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PUUKARI, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RUMO, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "YLÄ-VALTIMO, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SARAMO, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PETÄISKYLÄ, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MUJEJÄRVI, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOHTAVAARA, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "75990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HÖLJÄKKÄ, Nurmes",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIEKSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIEKSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIEKSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIEKSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PIEKSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PARTAHARJU, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PYHITTY, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "LAMMINMÄKI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NAARAJÄRVI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "76940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NENONPELTO, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "PALTANEN, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VENETMÄKI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VANAJA, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "NEUVOLA, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HALKOKUMPU, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HURSKAALA, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "VIRTASALMI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "MONTOLA, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "KANTALA, Mikkeli",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "SIIKAMÄKI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MAAVESI, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SAVUNIEMI, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "HAAPAKOSKI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "JÄPPILÄ, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1495,
+    "state_code": "04",
+    "locality_name": "TIHUSNIEMI, Pieksämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SUONENJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SUONENJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LEMPYY, Suonenjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SUONTEE, Suonenjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "RAUTALAMPI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MYHINPÄÄ, Rautalampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "IISVESI, Suonenjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VAAJASALMI, Rautalampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KERKONJOENSUU, Rautalampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "77960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PAKARILA, Rautalampi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78307",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NOUTOPISTE, Varkaus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TIMOLA, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KUVANSI, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "78900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VARKAUS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LEPPÄVIRTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LEPPÄVIRTA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SORSAKOSKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOTALAHTI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KONNUSLAHTI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "SAAMAISKYLÄ, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "TUPPURINMÄKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VALKEAMÄKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "MONINMÄKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79255",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KURJALA, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79265",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "PUPONMÄKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NÄÄDÄNMAA, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "ITÄ-SOISALO, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "NIINIMÄKI, Leppävirta",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KANGASLAMPI, Varkaus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "VILJOLAHTI, Varkaus",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JOROINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "JOROINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "HUUTOKOSKI, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KOLMA, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KERISALO, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "LAHNALAHTI, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1503,
+    "state_code": "15",
+    "locality_name": "KAITAINEN, Joroinen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HEINÄVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HEINÄVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KARVIONKANAVA, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VARISTAIPALE, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PALOKKI, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "UUSI-VALAMO, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SUURAHO, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79885",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ETELÄ-PETRUMA, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79895",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SARVIKUMPU, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KERMA, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "79940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VIHTARI, Heinävesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80020",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOLLEKTOR SCAN, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80141",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80161",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80221",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JOENSUU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "REIJOLA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "YLÄMYLLY, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "YLÄMYLLY, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ONTTOLA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80511",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ONTTOLA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LEHMO, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIOLAHTI AS, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIONIEMI, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIORANTA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80791",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIORANTA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PAIHOLA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "80910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KULHO, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIOLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KONTIOLAHTI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KATAJARANTA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ROMPPALA, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ENO, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ENO, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LOUHIOJA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JAKOKOSKI, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MÖNNI, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81235",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LEHTOI, Kontiolahti",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "AHVENINEN, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PAUKKAJA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "UIMAHARJU, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81281",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "UIMAHARJU, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "UKKOLA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81295",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HAAPALAHTI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KUISMAVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LUHTAPOHJA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TOKRAJÄRVI, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SARVINKI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "REVONKYLÄ, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TYRJÄNSAARI, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KIVILAHTI, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HUHUS, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KÄENKOSKI, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NAARVA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VUONISJÄRVI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KELVÄ, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VUONISLAHTI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HATTUVAARA, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LEHMIKYLÄ, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LIEKSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LIEKSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LIEKSA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PANKAKOSKI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JAMALI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KYLÄNLAHTI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MÄTÄSVAARA, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VIEKIJÄRVI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PANKAJÄRVI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "81970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JONGUNJOKI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HEINÄVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KESKIJÄRVI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KIIHTELYSVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "OSKOLA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "USKALI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HUHTILAMPI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HAMMASLAHTI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HAMMASLAHTI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SUHMURA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NIITTYLAHTI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NIEMINEN, Rääkkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RÄÄKKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RÄÄKKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ORAVISALO, Rääkkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82335",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RASIVAARA, Rääkkylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TIKKALA, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ONKAMO, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TOLOSENMÄKI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82395",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HAARAJÄRVI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PUHOS, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HUMMOVAARA, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HEINONIEMI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KITEE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KITEE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KITEENLAHTI, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JUURIKKA, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NÄRSÄKKÄLÄ, Kitee",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TOHMAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TOHMAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82655",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VÄRTSILÄ, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "UUSI-VÄRTSILÄ, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KAURILA, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82675",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NIIRALA, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82685",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LITTILÄ, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOVERO, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TUUPOVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ÖLLÖLÄ, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HOILOLA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KAUSTAJÄRVI, Tohmajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82815",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MARJOVAARA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MAUKKULA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HAUKIVAARA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PIRTTIAHO, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KINNASNIEMI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82865",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOKINVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LUUTALAHTI, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MANNERVAARA, Joensuu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ILOMANTSI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ILOMANTSI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82915",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SONKAJA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LEHTOVAARA, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82967",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HATTU, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "82980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MÖHKÖ, Ilomantsi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LIPERI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "LIPERI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SALOKYLÄ, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PUROMÄKI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "ROUKALAHTI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TUTJUNNIEMI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RISTI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KAATAMO, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KAARNALAMPI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VIINIJÄRVI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KÄSÄMÄ, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VAIVIO, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HARINJÄRVI, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "AHONKYLÄ, Liperi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "OUTOKUMPU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "OUTOKUMPU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOKONVAARA, Outokumpu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KUUSJÄRVI, Outokumpu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "VARISLAHTI, Outokumpu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "POLVIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "POLVIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KUOREVAARA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SOTKUMA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SOLA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HORSMANAHO, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83825",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KINAHMO, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "HUKKALA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83835",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "RUVASLAHTI, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "SAARIVAARA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83855",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "MARTONVAARA, Polvijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "POLVELA, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KAJOO, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JUUKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "JUUKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "PAALASMAA, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "NUNNANLAHTI, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "AHMOVAARA, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "KOLI, Lieksa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "83985",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1504,
+    "state_code": "13",
+    "locality_name": "TUOPANJOKI, Juuka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "84880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KALAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KALAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "METSÄ, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TYNKÄ, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TYPPÖ, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAUTIO, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAHJA, Kalajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ALAVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ALAVIESKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KÄHTÄVÄ, Alavieska",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TALUS, Alavieska",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI AS, Sievi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIEVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NIVALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PARKKILA, Haapajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TULPPO, Haapajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAAPAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAAPAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OKSAVA, Haapajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUONA, Haapajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "REISJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KANGASKYLÄ, Reisjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RÄISÄLÄNMÄKI, Reisjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "85980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KÖYHÄNPERÄ, Reisjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PARHALAHTI, Pyhäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PIRTTIKOSKI, Pyhäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YPPÄRI, Pyhäjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PETÄJÄSKOSKI, Oulainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MERIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIPÄÄ, Merijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄNKOSKI, Merijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULAINEN",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KILPUA, Oulainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ILVESKORPI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VIHANTI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VIHANTI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LAMPINSAARI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ALPUA, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LUMIMETSÄ, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KARHUKANGAS, Haapavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MATKANIVA, Oulainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ANNONEN, Oulainen",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MIELUSKYLÄ, Haapavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAAPAVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAAPAVESI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KYTÖKYLÄ, Haapavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VATJUSJÄRVI, Haapavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KARSIKAS, Haapavesi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KÄRSÄMÄKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VENETPALO, Kärsämäki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄSALMI, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄSALMI, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HIIDENNIEMI, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VESIKOSKI, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄKUMPU, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "86980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VÄLIAHO, Pyhäjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87070",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAINUU, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87788",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "S-RYHMÄ, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "NAKERTAJA, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PALTANIEMI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAJAANI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "LINNANTAUS, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SALMIJÄRVI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KULUNTALAHTI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "87970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "JORMUA, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "TUHKAKYLÄ, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "OTANMÄKI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "OTANMÄKI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "VUOLIJOKI, Kajaani",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PALTAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "MELALAHTI, Paltamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MANAMANSALO, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KIVESJÄRVI, Paltamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "MIESLAHTI, Paltamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "RISTIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "RISTIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "JOKIKYLÄ, Ristijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "HIISIJÄRVI, Ristijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KONTIOMÄKI, Paltamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "POHJAVAARA, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PAAKKI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SOTKAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SOTKAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "VUOKATTI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KORHOLANMÄKI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "ONTOJOKI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "JUURIKKALAHTI, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "MAANSELKÄ, Sotkamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "YLÄ-VIEKSI, Kuhmo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "HÄRMÄNKYLÄ, Kuhmo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "IIVANTIIRA, Kuhmo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KUHMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KUHMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "LENTIIRA, Kuhmo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "88940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KUUMU, Kuhmo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "TÖRMÄNMÄKI, Puolanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KOTILA, Puolanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PUOLANKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PUOLANKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PUOKIOVAARA, Puolanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "JOUKOKYLÄ, Puolanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SUOLIJÄRVI, Puolanka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "HYRYNSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "HYRYNSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "HOIKKA, Hyrynsalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SAKARA, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "MOISIOVAARA, Hyrynsalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KARHUVAARA, Hyrynsalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SUOMUSSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SUOMUSSALMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "JUMALISKYLÄ, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PESIÖKYLÄ, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "TAKALO, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "NÄLJÄNKÄ, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "VAARANNIVA, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "AHJOLA, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KIANTA, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PIISPAJÄRVI, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "PERANKA, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "KAIKKONEN, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "SUOMUSSALMI KK, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "ALA-VUOKKI, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "YLI-VUOKKI, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "89920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1496,
+    "state_code": "05",
+    "locality_name": "RUHTINANSALMI, Suomussalmi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "VASTAUSLÄHETYS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90014",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULUN YLIOPISTO, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90015",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULUN KAUPUNKI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90029",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "POHDE, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90032",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "TYÖTERVEYSLAITOS, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90049",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VALTERI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90050",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TALENOM, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90221",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90311",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KEMPELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90441",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KEMPELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KEMPELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90451",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KEMPELE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULUNSALO, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VARJAKKA, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90480",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAILUOTO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90571",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90621",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90651",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OULU",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KIVINIEMI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KELLO, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAUKIPUDAS, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90831",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAUKIPUDAS, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HAUKIPUDAS, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MARTINNIEMI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HALOSENNIEMI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KIIMINKI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KIIMINKI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KONTIO, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "90940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JÄÄLI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91006",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VASTAUSLÄHETYS, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "II",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "II",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "II AS, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OLHAVA, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLI-OLHAVA, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLI-II, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JAKKUKYLÄ, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TANNILA, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PAHKAKOSKI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLIKIIMINKI, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ARKALA, Oulu",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JOKIRINNE, Muhos",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LEPPINIEMI, Muhos",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MUHOS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MUHOS",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ROVA, Muhos",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KYLMÄLÄNKYLÄ, Muhos",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "UTAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "UTAJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SANGINKYLÄ, Utajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JUORKUNA, Utajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SÄRKIJÄRVI, Utajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "AHMAS, Utajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ROKUA, Utajärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VAALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VAALA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JYLHÄMÄ, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OTERMA, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91730",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KANKARI, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JAALANKA, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LIMINPURO, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SÄRÄISNIEMI, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NEITTÄVÄ, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "NUOJUA, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TYRNÄVÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LIMINKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LIMINKA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TUPOS, Liminka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ALA-TEMMES, Liminka",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TEMMES, Tyrnävä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "91980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LUMIJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAAHE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAAHE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAAHE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAAHE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PATTIJOKI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RAAHE",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SALOINEN, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LAPALUOTO, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ARKKUKARI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PIEHINKI, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MATTILANPERÄ, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LASIKANGAS, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KOPSA, Raahe",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIIKAJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KARINKANTA, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "REVONLAHTI, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RUUKKI, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RUUKKI, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PAAVOLA, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SAARIKOSKI, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LUOHUA, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TUOMIOJA, Siikajoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RANTSILA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RANTSILA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SIPOLA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "MANKILA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PULKKILA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VORNA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PIIPPOLA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LESKELÄ, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LAAKKOLA, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KESTILÄ, Siikalatva",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PELSONSUO, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VENEHEITTO, Vaala",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TAVASTKENKÄ, Pyhäntä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "AHOKYLÄ, Pyhäntä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "92930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PYHÄNTÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PUDASJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PUDASJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KIPINÄ, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HETEJÄRVI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PUDASJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "IKOSENNIEMI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93187",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "ALA-SIURUA, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "YLI-SIURUA, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93195",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KOKKOKYLÄ, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LIVO, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93225",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PÄRJÄNSUO, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RYTINKI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SARAJÄRVI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SOTKAJÄRVI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93277",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "IINATTIJÄRVI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "SYÖTE, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PINTAMO, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JAURAKKAJÄRVI, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "PUHOSKYLÄ, Pudasjärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TAIVALKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TAIVALKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "JURMU, Taivalkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "LOUKUSA, Taivalkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "INGET, Taivalkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "TYRÖVAARA, Taivalkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "VANHALA, Taivalkoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUUSAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUUSAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUUSAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUUSAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "RUKATUNTURI, Kuusamo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "93900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUUSAMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMINMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMINMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMINMAA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LAUTIOSAARI, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "94900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUIVANIEMI, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "KUIVANIEMI KK, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "HYRYOJA, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1505,
+    "state_code": "14",
+    "locality_name": "OIJÄRVI, Ii",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIMO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95210",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "FILPUS, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIMONIEMI, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95225",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VIANTIE, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MAKSNIEMI, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95255",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ALANIEMI, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95260",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TAINIONJOKI, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLIKÄRPPÄ, Simo",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TERVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LIEDAKKALA, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95315",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TÖRMÄ, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95325",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PAAKKOLA, Tervola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TERVOLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOUE, Tervola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PEURA, Tervola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95355",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KOIVU, Tervola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95365",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MAULA, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ITÄKOSKI, Keminmaa",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95375",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLI-PAAKKOLA, Tervola",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95407",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NOUTOPISTE, Tornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95421",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLITORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLITORNIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KAINUUNKYLÄ, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95615",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PEKANPÄÄ, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "AAVASAKSA, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUIVAKANGAS, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95635",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KAULINRANTA, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JUOKSENKI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95645",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TURTOLA, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95655",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ETELÄ-PORTIMOJÄRVI, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KANTOMAANPÄÄ, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PESSALOMPOLO, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95675",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MELTOSJÄRVI, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOHIJÄRVI, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MELLAKOSKI, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PELLO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PELLO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NAAMIJOKI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JARHOINEN, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ORAJÄRVI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KONTTAJÄRVI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LANKOJÄRVI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIRKKAKOSKI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LAMPSIJÄRVI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIEPPIJÄRVI, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VAATTOJÄRVI, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VENEJÄRVENKYLÄ, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RUOKOJÄRVI, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PASMAJÄRVI, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KOLARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KOLARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARIPUDAS, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ÄKÄSJOENSUU, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TAPOJÄRVI, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KIHLANKI, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ÄKÄSLOMPOLO, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLLÄSJÄRVI, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "95990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KURTAKKO, Kolari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96086",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1510,
+    "state_code": "18",
+    "locality_name": "MAAHANMUUTTOVIRASTO, Helsinki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96200",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96201",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96501",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARENKYLÄ, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NAPAPIIRI ROVANIEMI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "96961",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ROVANIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAUTIOSAARI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "HIRVAS, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MUUROLA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97145",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TOTONVAARA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PETÄJÄINEN, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JAATILA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97220",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SINETTÄ, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SONKA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAANUJÄRVI, Ylitornio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TAPIO, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MARRASKOSKI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PATOKOSKI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MARRASJÄRVI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RATTOSJÄRVI, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97335",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RUUHIVAARA, Pello",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MELTAUS, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97370",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "UNARIN-LUUSUA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97380",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUKASRANTA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97390",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KIERINKI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOHINIVA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ALAKYLÄ, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VIKAJÄRVI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NAMPA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLI-NAMPA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TIAINEN, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MISI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97590",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAAJÄRVI, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "OIKARAINEN, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97615",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TENNIROVA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VIIRI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97625",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VANTTAUSKOSKI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PEKKALA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97635",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JUUNIEMI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97645",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JUUJÄRVI, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JUOTAS, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97655",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "AUTTI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97665",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "POHJASPERÄ, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KIVITAIPALE, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97675",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NARKAUS, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97680",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARI-KÄMÄ, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97685",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIIKA-KÄMÄ, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SULAOJA, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97700",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RANUA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97701",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RANUA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97715",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAISKIO, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLI-SIMO, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARIHARJU, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97765",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "IMPIÖ, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUUKASJÄRVI, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97785",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KELANKYLÄ, Ranua",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SUORSA, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97815",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PERNU, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PERÄ-POSIO, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LEHTINIEMI, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RISTILÄ, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JUMISKO, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97880",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NOLIMO, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97890",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KARJALAISENNIEMI, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97895",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MOURUJÄRVI, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "POSIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "POSIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SUONNANKYLÄ, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97925",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TOLVA, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOHIRANTA, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SÄIKKÄ, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KULOHARJU, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97965",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KYNSILÄ, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97967",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NOUTOPISTE, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIRNIÖ, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "97980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ANETJÄRVI, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LUUSUA, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KEMIJÄRVI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98350",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TAPIONNIEMI, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VUOSTIMO, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ISOKYLÄ, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RYTI-LEHTOLA, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KALLAANVAARA, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KOSTAMO, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98500",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PELKOSENNIEMI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAUNAVAARA, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PYHÄTUNTURI, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SUVANTO, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KAIRALA, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98570",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "AAPAJÄRVI, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98580",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LUIRO, Pelkosenniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KURSU, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PAHKAKUMPU, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98630",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "AHVENSELKÄ, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SALMIVAARA, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JOUTSIJÄRVI, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SUOMUTUNTURI, Kemijärvi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "HIRVASVAARA, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "AHOLANVAARA, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98780",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MAANINKAVAARA, Posio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98790",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PALOPERÄ, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAVUKOSKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98810",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LUNKKAUS, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98820",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VÄRRIÖ, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MARTTI, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98840",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RUUVAOJA, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98850",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUOSKU, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98900",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SALLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98901",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SALLA",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98920",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KELLOSELKÄ, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KOTALANKYLÄ, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAIJA, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98960",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NARUSKA, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ONKAMOJÄRVI, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KALLUNKI, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "98995",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "HAUTAJÄRVI, Salla",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99100",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KITTILÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99101",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KITTILÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99110",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KAUKONEN, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99120",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KALLO, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99130",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIRKKA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99131",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIRKKA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99135",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAUHALA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99140",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KÖNGÄS, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99150",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TEPASTO, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99160",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOMPOLO, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99170",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PULJU, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99180",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAUTUSJÄRVI, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99190",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "HANHIMAA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99195",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "POKKA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99230",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JEESIÖJÄRVI, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99240",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUIVASALMI, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99250",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KIISTALA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99270",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "HORMAKUMPU, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99280",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TEPSA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99290",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KELONTEKEMÄ, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99300",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MUONIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99301",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MUONIO",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99310",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "YLI-MUONIO, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99320",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KÄTKÄSUVANTO, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99330",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PALLASTUNTURI, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99340",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAATTAMA, Kittilä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99360",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KANGOSJÄRVI, Muonio",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99400",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ENONTEKIÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99401",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ENONTEKIÖ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99410",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VUONTISJÄRVI, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99420",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PELTOVUOMA, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99430",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NUNNANEN, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99440",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LEPPÄJÄRVI, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99450",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PALOJOENSUU, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99460",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KUTTANEN, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99470",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KARESUVANTO, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99490",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KILPISJÄRVI, Enontekiö",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99510",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RAUDANJOKI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99520",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SEIPÄJÄRVI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99530",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VUOJÄRVI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99540",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TORVINEN, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99550",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ASKA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99555",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LUOSTO, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99560",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "ORAKYLÄ, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99600",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SODANKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99601",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SODANKYLÄ",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99610",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SIURUNMAA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99620",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KELUJÄRVI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99640",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TANHUA, Savukoski",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99645",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "LOKKA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99650",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SATTANEN, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99655",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SATTASVAARA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99660",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KERSILÖ, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99665",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "MOSKUVAARA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99670",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "PETKULA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99690",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VUOTSO, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99695",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "TANKAVAARA, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99710",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "VAALAJÄRVI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99720",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "RIIPI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99740",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SYVÄJÄRVI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99750",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SASSALI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99760",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "UIMANIEMI, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99770",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "JEESIÖ, Sodankylä",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99800",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "IVALO, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99801",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "IVALO, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99830",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARISELKÄ, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99831",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SAARISELKÄ, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99860",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NELLIM, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99870",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "INARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99871",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "INARI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99910",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KAAMANEN, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99930",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "SEVETTIJÄRVI, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99940",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NÄÄTÄMÖ, Inari",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99950",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KARIGASNIEMI, Utsjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99970",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NUVVUS, Utsjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99980",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "UTSJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99981",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "UTSJOKI",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99990",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "NUORGAM, Utsjoki",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  },
+  {
+    "code": "99999",
+    "country_id": 74,
+    "country_code": "FI",
+    "state_id": 1500,
+    "state_code": "10",
+    "locality_name": "KORVATUNTURI, Rovaniemi",
+    "type": "full",
+    "source": "posti-fi-pcf"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Finland's official 5-digit Posti postcodes (3,748) for #1039
- 100% state FK resolution across all 18 mainland Finnish maakunta
- Resolves the research-doc Tier B note `Posti's PCF_*.dat file is canonical but URL is date-stamped — known difficult per memory`

## Source
- **Posti.fi PCF** — Finland's official daily postal code file (canonical)
- URL pattern: `https://www.posti.fi/webpcode/unzip/PCF_<YYYYMMDD>.dat`
- The importer probes back ~30 days from today via HEAD requests to find the freshest available file
- License: Posti's terms — free redistribution permitted with attribution (Tier 5 per #1039 policy)

## Format
Fixed-width ISO-8859-1, 220 chars/record. Importer parses positional fields per Posti's published spec (record id, postal code, postal name FI/SV, abbreviations, effective date, region code, region names FI/SV, municipality code, municipality names FI/SV, language).

## State FK strategy
18-entry `FI_REGION_TO_ISO2` maps Finnish maakunta names to CSC iso2:
- Direct match for 17 mainland regions
- `Helsinki-Uusimaa` (NUTS sub-region) → CSC `18` Uusimaa per ISO 3166-2:FI

## Åland is shipped separately
The 37 source records with region `FI200 / Ahvenanmaa` belong to **Åland Islands**, which is a separate CSC country (`AX`, country_id=2). They will be shipped via a companion AX importer.

## Distribution (top 5)
| iso2 | region | rows |
|---|---|---|
| 18 | Uusimaa | 673 |
| 10 | Lapland | 305 |
| 11 | Pirkanmaa | 291 |
| 14 | Northern Ostrobothnia | 261 |
| 15 | Northern Savonia | 253 |

All 18 mainland regions covered.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_finland_postcodes.py`
- [x] All 3,748 codes match `^(?:FI)*\d{5}$`
- [x] 100% state_id valid; state.country_id == 74; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)