### PR TITLE
feat(postcodes/IR): 193 Iran Post area codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_iran_postcodes.py
+++ b/bin/scripts/sync/import_iran_postcodes.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Iran -> contributions/postcodes/IR.json importer for issue #1039.
+
+Source data
+-----------
+The community ``saeidi-dev/Postal-Code-Iran`` PHP library encodes
+193 5-digit postal-code area ranges as PHP ``case`` branches, each
+returning a (state, city) tuple in Persian. Each range is the
+fixed-prefix (first 5 digits) of an Iran Post 10-digit postcode
+covering an entire delivery area.
+
+Source URL: https://raw.githubusercontent.com/saeidi-dev/Postal-Code-Iran/master/PostalCode.php
+
+What this script does
+---------------------
+1. Fetches the PHP file via urllib (curl is blocked).
+2. Parses the 193 ``case (\\\$postalCode >= LOW && \\\$postalCode <= HIGH)``
+   blocks via regex extraction.
+3. Resolves state FK by direct Persian-name match against CSC's IR
+   state ``native`` field (20 of 31 CSC states are represented in
+   source).
+4. Emits one row per range using the LOW boundary as the canonical
+   area code, with the source's Persian city name as locality.
+5. Writes contributions/postcodes/IR.json idempotently.
+
+Coverage upgrade
+----------------
+Resolves the research-doc Tier B note `Range-based PHP switch only —
+produces no canonical list of 10-digit codes, just prefix→state
+lookup`. Iran's national postal authority does not publish a full
+10-digit code list publicly; the 5-digit area-prefix list is the
+deepest publicly redistributable form.
+
+Regex fix
+---------
+Before this PR, countries.json had IR regex `^\\d{10}$` (Iran Post's
+canonical 10-digit form). Updated to `^\\d{5}(\\d{5})?$` to also
+accept the 5-digit area-prefix shipped by this dataset, matching the
+mixed granularity already permitted for other prefix-only countries
+(GB, TW, CA).
+
+License & attribution
+---------------------
+- Source: saeidi-dev/Postal-Code-Iran (MIT-licensed PHP utility,
+  with the range table compiled from Iran Post public lookups)
+- Each row: ``source: "iran-post-via-saeidi-dev"``
+
+Tier 5 per #1039 license-tier policy.
+
+Usage
+-----
+    python3 bin/scripts/sync/import_iran_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/saeidi-dev/Postal-Code-Iran/"
+    "master/PostalCode.php"
+)
+
+# Regex extracts each PHP case block:
+#   case ($postalCode >= 57131 && $postalCode <= 57591):
+#       return array('state' => 'آذربایجان غربی', 'city' => 'ارومیه');
+RANGE_PATTERN = re.compile(
+    r"case\s*\(\s*\$postalCode\s*>=\s*(\d+)\s*&&\s*\$postalCode\s*<=\s*(\d+)\s*\)\s*:"
+    r"\s*\n\s*return\s+array\(\s*'state'\s*=>\s*'([^']+)'\s*,\s*'city'\s*=>\s*'([^']+)'",
+    re.M,
+)
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local PHP (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_text(SOURCE_URL)
+    )
+    ranges = RANGE_PATTERN.findall(text)
+    print(f"Source ranges: {len(ranges):,}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    ir_country = next((c for c in countries if c.get("iso2") == "IR"), None)
+    if ir_country is None:
+        print("ERROR: IR not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(ir_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    ir_states = [s for s in states if s.get("country_id") == ir_country["id"]]
+    # Iran state-name match is via the Persian native field
+    state_by_native: Dict[str, dict] = {
+        (s.get("native") or "").strip(): s for s in ir_states if s.get("native")
+    }
+    print(
+        f"Country: Iran (id={ir_country['id']}); "
+        f"states indexed by native name: {len(state_by_native)}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_states: Dict[str, int] = {}
+
+    for low, high, state_fa, city_fa in ranges:
+        code = str(low).strip()
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        state = state_by_native.get(state_fa.strip())
+        if state is None:
+            unknown_states[state_fa] = unknown_states.get(state_fa, 0) + 1
+            skipped_no_state += 1
+
+        locality = city_fa.strip()
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(ir_country["id"]),
+            "country_code": "IR",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "area"
+        record["source"] = "iran-post-via-saeidi-dev"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_states:
+        print("Unknown states (not found in CSC native field):")
+        for s, n in sorted(unknown_states.items(), key=lambda x: -x[1]):
+            print(f"  {s!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/IR.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -6974,8 +6974,8 @@
     "subregion_id": 14,
     "nationality": "Iranian, Persian",
     "area_sq_km": 1648000.0,
-    "postal_code_format": "##########",
-    "postal_code_regex": "^(\\d{10})$",
+    "postal_code_format": "#####|##########",
+    "postal_code_regex": "^(\\d{5}(?:\\d{5})?)$",
     "timezones": [
       {
         "zoneName": "Asia/Tehran",

--- a/contributions/postcodes/IR.json
+++ b/contributions/postcodes/IR.json
@@ -1,0 +1,1932 @@
+[
+  {
+    "code": "11111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 11",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "13111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 13",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "14111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 14",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "15111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 15",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "16111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 16",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "17111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 17",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "18111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 18",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "19111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3945,
+    "state_code": "23",
+    "locality_name": "تهران منطقه 19",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "34131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3941,
+    "state_code": "26",
+    "locality_name": "قزوين",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "34151",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3941,
+    "state_code": "26",
+    "locality_name": "البرز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "34411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3941,
+    "state_code": "26",
+    "locality_name": "آبيك",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "34491",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3941,
+    "state_code": "26",
+    "locality_name": "بوئين زهرا",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "34561",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3941,
+    "state_code": "26",
+    "locality_name": "تاكستان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "35131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3940,
+    "state_code": "20",
+    "locality_name": "سمنان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "35811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3940,
+    "state_code": "20",
+    "locality_name": "گرمسار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "36131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3940,
+    "state_code": "20",
+    "locality_name": "شاهرود",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "36711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3940,
+    "state_code": "20",
+    "locality_name": "دامغان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "37131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3922,
+    "state_code": "25",
+    "locality_name": "قم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "43511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "فومن",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "43541",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "شفت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "43611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "صومعه سرا",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "43711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "طوالش",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "43811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "ماسال",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "44131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "لاهيجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "44391",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "سياهكل",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "44711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3920,
+    "state_code": "01",
+    "locality_name": "لنگرود",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "زنجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "ايجرود",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "ماهنشان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "ابهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "خرمدره",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45771",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "خدابنده",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "45911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3925,
+    "state_code": "19",
+    "locality_name": "طارم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "48711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "بندر گز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "48911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "تركمن",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "گرگان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "آق قلا",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "كردكوی",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "راميان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "آزاد شهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49691",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "گنبد كاووس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "مينو دشت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "49851",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3933,
+    "state_code": "27",
+    "locality_name": "كلاله",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "51331",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "تبریز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "میانه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "اسکو",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53616",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "سردرود",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53661",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "باسمنج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "آذرشهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "شبستر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "53911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "هریس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "مرند",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "جلفا",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54491",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "اهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "کلیبر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "سراب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "54911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "بستان آباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "مراغه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "عجبشیر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "بناب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "ملکان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "هشترود",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "55791",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3944,
+    "state_code": "03",
+    "locality_name": "چاراویماق",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "57131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "ارومیه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "57611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "نقده",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "57711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "اشنویه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "57811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "پیرانشهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "58131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "خوی",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "58611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "ماکو",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "58641",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "چالدران",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "58811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "سلماس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "59131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "مهاباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "59351",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "میاندوآب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "59431",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "بوکان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "59611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "سردشت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "59916",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3924,
+    "state_code": "04",
+    "locality_name": "تکاب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "63511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "ماهشهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "63591",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "هنديجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "63811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "رامهرمز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "شادگان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "دشت آزادگان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "شوشتر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "دزفول",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "شوش",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "مسجد سليمان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "64941",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3917,
+    "state_code": "06",
+    "locality_name": "لالي",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "همدان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "بهار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "اسد آباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "كبودر آهنگ",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65661",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "رزن",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "ملاير",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "تويسركان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "65911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 4920,
+    "state_code": "13",
+    "locality_name": "نهاوند",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "سنندج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "كامياران",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "ديواندره",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "بيجار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "قروه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "مريوان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66771",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "سروآباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "سقز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "66911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3935,
+    "state_code": "12",
+    "locality_name": "بانه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "71331",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "شيراز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "كازرون",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73431",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "مرودشت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "ممسني",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "سپيدان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73731",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "ارسنجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73741",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "پاسارگاد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73751",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "خرمبيد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73781",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "بوانات",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "اقليد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "73911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "آباده",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74111",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "داراب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "جهرم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "لارستان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74341",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "لامرد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74414",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "مهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74431",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "خنج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74461",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "استهبان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "فسا",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "فيروزآباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74714",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "قیروکارزین",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74771",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "فراشبند",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74814",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "زرین دشت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "74911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3939,
+    "state_code": "07",
+    "locality_name": "ني ريز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "76131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "كرمان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "76511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "راور",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "77131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "رفسنجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "77511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "شهر بابك",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "77611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "زرند",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "77711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "کوهبنان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "سيرجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78719",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "عنبرآباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "كهنوج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78831",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "رودبار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78841",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "قلعه گنج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "78851",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3943,
+    "state_code": "08",
+    "locality_name": "منوجان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "بندر عباس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79371",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "حاجي آباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79413",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "بندر لنگه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79461",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "ميناب",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79481",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "جاسک",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "قشم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79591",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "ابوموسي",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "بستک",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "79911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3937,
+    "state_code": "22",
+    "locality_name": "رودان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "ابركوه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "يزد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "صدوق",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "اردكان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "ميبد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "بافق",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "مهريز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89871",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "خاتم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "89911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "تفت",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "91331",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "مشهد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "93131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "نيشابور",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "93711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "كلات",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "93811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "سرخس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "93911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "فريمان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "بجنورد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "جاجرم",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94341",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "مانه و سملقان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "شيروان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "قوچان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "فاروج",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "94911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "درگز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "95411",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "رشتخوار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "95611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "خواف",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "96131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "سبزوار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "96611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3942,
+    "state_code": "28",
+    "locality_name": "اسفراين",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "96711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "كاشمر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "96911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3927,
+    "state_code": "09",
+    "locality_name": "گناباد",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "بيرجند",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "سربيشه",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97441",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "درمیان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "نهبندان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97611",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "قائنات",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "فردوس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97761",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3930,
+    "state_code": "29",
+    "locality_name": "سرايان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "97911",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3936,
+    "state_code": "21",
+    "locality_name": "طبس",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "98131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "زاهدان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "98511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "زابل",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "98811",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "خاش",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99131",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "ايرانشهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99311",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "سرباز",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99331",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "نيكشهر",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99471",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "دلگان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99511",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "سراوان",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99661",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "زابلی",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  },
+  {
+    "code": "99711",
+    "country_id": 103,
+    "country_code": "IR",
+    "state_id": 3931,
+    "state_code": "11",
+    "locality_name": "چابهار",
+    "type": "area",
+    "source": "iran-post-via-saeidi-dev"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports 193 Iran Post 5-digit area-prefix codes for #1039
- 100% state FK resolution across 20 of 31 CSC IR provinces (provinces with at least one mapped range; remaining 11 absent from source data)
- Resolves the research-doc Tier B note `Range-based PHP switch only — produces no canonical list of 10-digit codes`

## Source
- [`saeidi-dev/Postal-Code-Iran`](https://github.com/saeidi-dev/Postal-Code-Iran) — MIT-licensed PHP utility that encodes 193 5-digit area-prefix ranges as PHP `case` branches
- Each branch maps a postcode range to a (state, city) tuple in Persian
- Iran Post does not publish a full 10-digit postcode list publicly; this 5-digit area-prefix list is the deepest publicly redistributable form

## State FK strategy
Direct Persian-name match against CSC's `native` field (CSC ships both English and Persian names for IR states). All 20 source state labels match CSC native names verbatim — no aliases needed.

## Regex fix
Old: `^\d{10}$` (Iran Post canonical form, but source ships 5-digit prefixes)
New: `^\d{5}(\d{5})?$` — accepts both 5-digit area-prefix and full 10-digit, matching the mixed-granularity pattern already permitted for GB / TW / CA.

## Distribution (top 5)
| iso2 | province | rows |
|---|---|---|
| 07 | Fars | 24 |
| 03 | East Azerbaijan | 20 |
| 04 | West Azarbaijan | 13 |
| 08 | Kerman | 12 |
| 09 | Razavi Khorasan | 12 |

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_iran_postcodes.py`
- [x] All 193 codes match `^\d{5}(\d{5})?$`
- [x] 100% state_id valid; state.country_id == 103; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)