### PR TITLE
fix(ES): retag 6,920 mistyped admin rows to type=city (#1498 follow-up)

### DIFF
--- a/.github/fixes-docs/FIX_1498_PR_A_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1498_PR_A_SUMMARY.md
@@ -1,0 +1,76 @@
+# FIX #1498 — Spain: drop admin-level placeholders from cities (PR-A of 2)
+
+**Issue:** [#1498 — Bug ES: GetCity returns province-level admin entries as cities](https://github.com/dr5hn/countries-states-cities-database/issues/1498)
+**Scope:** Drop 22 placeholder rows from `contributions/cities/ES.json`.
+**Sibling PR:** PR-B retags ~6,920 mistyped admin-level rows (currently `type` in `adm1`/`adm2`/`adm3`) to `type='city'`. PR-B closes #1498.
+**Date:** 2026-05-04
+
+## Problem
+
+The reporter flagged that `GetCity(country=ES, state=Madrid)` returns "Provincia de Madrid" as a city, with the same pattern across other Spanish provinces, plus a cross-province leak ("Provincia de Alicante" inside Valencia's city list). These are admin-level placeholder rows, not municipalities.
+
+Spain's `states.json` already lists the 50 provinces as proper states, so the "Provincia de X" pseudo-cities are duplicate concepts and can be dropped without re-parenting any other data.
+
+## Drops (22 rows)
+
+### 21 "Provincia de X" / "Província de X" placeholders
+
+| id | name | state_code | type |
+|----|------|-----------|------|
+| 36362 | Provincia de Alicante | V | city |
+| 36364 | Provincia de Burgos | LE | adm2 |
+| 36365 | Provincia de Cantabria | S | adm3 |
+| 36373 | Provincia de Huesca | HU | adm3 |
+| 36375 | Provincia de La Rioja | LO | adm3 |
+| 36376 | Provincia de Las Palmas | GC | city |
+| 36377 | Provincia de León | LE | adm3 |
+| 36379 | Provincia de Madrid | M | section |
+| 36381 | Provincia de Navarra | NA | adm1 |
+| 36383 | Provincia de Palencia | LE | adm3 |
+| 36385 | Provincia de Salamanca | LE | adm3 |
+| 36386 | Provincia de Santa Cruz de Tenerife | GC | city |
+| 36387 | Provincia de Segovia | LE | adm3 |
+| 36389 | Provincia de Soria | LE | adm3 |
+| 36390 | Provincia de Teruel | HU | adm3 |
+| 36391 | Provincia de Valladolid | LE | city |
+| 36392 | Provincia de Zamora | LE | adm3 |
+| 36393 | Provincia de Zaragoza | HU | adm3 |
+| 36394 | Provincia de Ávila | LE | adm3 |
+| 36396 | Província de Castelló | V | adm3 |
+| 36400 | Província de València | V | city |
+
+The state_code values are themselves messy (e.g. "Provincia de Burgos" sits under `LE`/León, "Provincia de Zaragoza" under `HU`/Huesca) — further evidence these rows are stub data, not curated municipality records.
+
+### 1 cross-state Alicante stub
+
+| id | name | state_code | reason |
+|----|------|-----------|--------|
+| 32244 | Alicante | V (Valencia) | Wrong province; missing Valencian endonym |
+
+The canonical Alicante row is **id 152158** (`Alicante/Alacant`, state_code `A`) under the Alicante province. Row 32244 is a legacy duplicate from when Valencia community was the parent of three provinces, and its `state_code='V'` is what the issue reporter flagged as the cross-province leak.
+
+## Counts
+
+| | Before | After |
+|---|--:|--:|
+| `ES.json` rows | 8,427 | 8,405 |
+| Rows named `Provincia *` / `Província *` | 21 | 0 |
+| Rows where `state_code='V'` and name='Alicante' | 1 | 0 |
+
+## Implementation
+
+`bin/scripts/fixes/spain_drop_provincia_placeholders.py` — explicit id allowlist + name/state verification per id. Refuses to touch rows in the allowlist if their name/state has shifted from what was audited. Idempotent: a second run on cleaned data writes nothing and exits 0.
+
+## Validation (mirrors `.github/scripts/validate-*`)
+
+- Schema: 0 errors. All rows still have name/state_id/state_code/country_id/country_code/lat/lon. country_code/country_id consistent (ES/207).
+- Cross-reference: 0 errors. Every `state_id` resolves to an ES state and `state_code` matches the resolved state's `iso2`.
+- Coordinates: 127 rows out of `country-bounds.json` ES box (down from 129 on master — the drop reduced OOB by 2). The 127 remaining are all Canary Islands (state_codes `TF`, `GC`) — pre-existing, same pattern as IT/Lampedusa noted in #1395.
+- Duplicate scan (same name + ≤5km): 45 pairs, **unchanged from master**.
+- `python3 -m json.tool` parses cleanly; `normalize_json.py` is a no-op.
+
+## Scope
+
+- Touches **only** the 22 placeholder rows.
+- Does **not** modify `states.json` or `countries.json`.
+- Does **not** close #1498. PR-B (the type-field retag of ~6,920 mistyped rows) is the closing PR.

--- a/.github/fixes-docs/FIX_1498_PR_B_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1498_PR_B_SUMMARY.md
@@ -1,0 +1,69 @@
+# FIX #1498 — Spain: retag mistyped admin rows to type=city (PR-B of 2)
+
+**Issue:** [#1498 — Bug ES: GetCity returns province-level admin entries as cities](https://github.com/dr5hn/countries-states-cities-database/issues/1498)
+**Scope:** Bulk-retag 6,920 rows in `contributions/cities/ES.json` whose `type` is `adm1`/`adm2`/`adm3` to `type='city'`. Touches only the `type` field.
+**Sibling PR:** PR-A (already merged / in review) dropped 22 admin-level placeholder rows.
+**Closes:** #1498.
+**Date:** 2026-05-04
+
+## Problem
+
+After PR-A removed the 22 admin-level placeholders, ES.json still carried 6,920 records whose `type` field was set to `adm1`, `adm2`, or `adm3` even though the rows themselves are real Spanish municipalities. Consuming apps that filter on `type='city'` (or sort city-vs-admin records) treat these as administrative regions and exclude them from city dropdowns — exactly the failure mode the reporter described.
+
+## Spot-check (why these are real cities)
+
+A 60-row random sample (20 of each adm type) gave:
+
+- **adm1 (20 rows total in file):** every sample is a major Spanish city — Barcelona, Valencia, Sevilla, Zaragoza, Murcia, Pamplona, Valladolid, Las Palmas de Gran Canaria, Santiago de Compostela, Santander, Toledo, Mérida, Logroño, Vitoria-Gasteiz, Oviedo, Palma, etc.
+- **adm2 (40 rows total):** every sample is a provincial capital or municipality — Córdoba, Málaga, Lleida, Girona, Soria, Segovia, Jaén, Lugo, Albacete, Guadalajara, Palencia, Zamora, Castelló de la Plana, Ciudad Real, Alicante/Alacant (id 152158, the canonical Alicante), etc.
+- **adm3 (6,860 rows total):** every sample is a real Spanish municipality with coordinates and (mostly) population data.
+
+Aggregate quality signals across the 6,920 candidates:
+
+| Type | Count | Has wikiDataId | Has population > 0 | Has coords |
+|------|------:|---------------:|-------------------:|-----------:|
+| adm1 | 20    | 20/20          | 20/20              | 20/20      |
+| adm2 | 40    | 39/40          | 38/40              | 40/40      |
+| adm3 | 6,860 | 6,854/6,860    | 6,458/6,860        | 6,860/6,860 |
+
+## Counts (post PR-A → post PR-B)
+
+| Type | Before | After |
+|------|--:|--:|
+| city | 1,416 | **8,336** |
+| section | 60 | 60 |
+| adm3 | 6,860 | 0 |
+| adm2 | 40 | 0 |
+| adm1 | 20 | 0 |
+| locality | 6 | 6 |
+| historical_capital | 1 | 1 |
+| capital | 1 | 1 |
+| adm4 | 1 | 1 |
+| **Total** | **8,405** | **8,405** |
+
+(Note: the brief gave a back-of-envelope estimate of "6,936 to retag → 8,357 city". The actual numbers are 6,920 → 8,336, because 16 of the 22 rows PR-A dropped were themselves typed adm1/adm2/adm3.)
+
+## Out of scope (deliberately not touched)
+
+- **`type='section'` (60 rows):** mixed quality — some are real neighbourhoods of Barcelona/Madrid that should stay typed `section` (they're already correctly excluded from city dropdowns), some look like real towns. Needs row-by-row review, not bulk retag.
+- **`type='locality'` (6 rows):** small, defensible category; left alone.
+- **`type='capital'`, `type='historical_capital'`, `type='adm4'` (1 each):** not city-equivalents in this dataset's vocabulary. Left alone.
+
+## Implementation
+
+`bin/scripts/fixes/spain_retag_admin_types.py` — single-pass mutation, only touches the `type` field, only for ES rows whose current type is in `{adm1, adm2, adm3}`. Asserts row count is preserved and no admin-typed rows remain. Idempotent.
+
+## Validation (mirrors `.github/scripts/validate-*`)
+
+- Schema: 0 errors.
+- Cross-reference: 0 errors. Every `state_id` resolves to an ES state and `state_code` matches the resolved state's `iso2`.
+- Coordinate-bounds: 127 out-of-box (Canary Islands, `TF`/`GC` — pre-existing, identical to PR-A head).
+- Same-name + ≤5km duplicate pairs: 45 — **identical to PR-A head**. The retag only changed the `type` field; coordinates and names are byte-for-byte unchanged.
+- Diff inspection: 6,920 rows changed, every change is exactly one field (`type`), source value in `{adm1, adm2, adm3}`, target value `'city'`. Zero collateral changes.
+- Idempotent re-run: 0 candidates remaining.
+
+## Constraints honoured
+
+- Touches **only** the `type` field of `country_code='ES'` rows.
+- Does **not** touch `state_code`, `state_id`, coordinates, or any other field.
+- Does **not** modify `states.json` or `countries.json`.

--- a/bin/scripts/fixes/spain_drop_provincia_placeholders.py
+++ b/bin/scripts/fixes/spain_drop_provincia_placeholders.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Drop admin-level placeholder rows from contributions/cities/ES.json.
+
+Issue #1498. The reporter flagged that `GetCity(...)` returns province-level
+admin entries inside Spanish city dropdowns ("Provincia de Madrid" etc.).
+This is the city-level cleanup PR — drops 22 rows that are not real cities:
+
+  - 21 "Provincia de X" / "Província de X" rows (ids 36362, 36364, 36365,
+    36373, 36375, 36376, 36377, 36379, 36381, 36383, 36385, 36386, 36387,
+    36389, 36390, 36391, 36392, 36393, 36394, 36396, 36400). All are admin
+    placeholders that duplicate concepts already represented by entries in
+    contributions/states/states.json. The 50 Spanish provinces are already
+    states, so a separate "Provincia de X" pseudo-city is redundant.
+
+  - 1 cross-state placeholder (id 32244, name "Alicante", state_code=V).
+    The real Alicante city lives at id 152158 ("Alicante/Alacant",
+    state_code=A) under the Alicante province (iso2=A). Row 32244 is a
+    legacy stub from when Valencia community was the parent of three
+    provinces (Valencia, Alicante, Castellon) — Alicante now has its own
+    state, so the stub is wrong both in name (missing the Valencian
+    endonym) and in parentage.
+
+The 21 "Provincia ..." ids are an explicit allowlist rather than a name-
+prefix filter, because two real Spanish municipalities also begin with
+"Provincia" in obscure forms — using ids guarantees we touch only what we
+mean to. The script verifies each id's current name still matches the
+expected prefix before dropping, refusing to touch rows that don't.
+
+Idempotent: a second run on already-cleaned data writes nothing and exits 0.
+
+Usage:
+    python3 bin/scripts/fixes/spain_drop_provincia_placeholders.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CITIES_JSON = REPO_ROOT / "contributions/cities/ES.json"
+
+# 21 admin-placeholder ids, expected to start with "Provincia " or "Província ".
+PROVINCIA_IDS = frozenset({
+    36362, 36364, 36365, 36373, 36375, 36376, 36377, 36379, 36381, 36383,
+    36385, 36386, 36387, 36389, 36390, 36391, 36392, 36393, 36394, 36396,
+    36400,
+})
+
+# 1 cross-state placeholder. id, expected name, expected wrong state_code.
+CROSS_STATE_ALICANTE_ID = 32244
+CROSS_STATE_ALICANTE_NAME = "Alicante"
+CROSS_STATE_ALICANTE_STATE_CODE = "V"
+
+EXPECTED_DROP_COUNT = len(PROVINCIA_IDS) + 1  # 22
+EXPECTED_PRE_COUNT = 8427
+EXPECTED_POST_COUNT = EXPECTED_PRE_COUNT - EXPECTED_DROP_COUNT  # 8405
+
+
+def load_cities(path: Path) -> List[dict]:
+    """Read the cities JSON file and verify the top-level shape."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise SystemExit(f"Expected JSON array at {path}, got {type(data).__name__}")
+    return data
+
+
+def matches_provincia(row: dict) -> bool:
+    """Row is one of the 21 'Provincia ...' admin placeholders, name verified."""
+    if row.get("id") not in PROVINCIA_IDS:
+        return False
+    name = row.get("name", "")
+    return isinstance(name, str) and (
+        name.startswith("Provincia ") or name.startswith("Província ")
+    )
+
+
+def matches_cross_state_alicante(row: dict) -> bool:
+    """Row is the cross-state Alicante stub (id 32244, name 'Alicante', state V)."""
+    return (
+        row.get("id") == CROSS_STATE_ALICANTE_ID
+        and row.get("name") == CROSS_STATE_ALICANTE_NAME
+        and row.get("state_code") == CROSS_STATE_ALICANTE_STATE_CODE
+    )
+
+
+def is_target(row: dict) -> bool:
+    """True if this row is on the drop list."""
+    return matches_provincia(row) or matches_cross_state_alicante(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be dropped without rewriting the file.",
+    )
+    args = parser.parse_args()
+
+    if not CITIES_JSON.exists():
+        raise SystemExit(f"Cities file not found: {CITIES_JSON}")
+
+    cities = load_cities(CITIES_JSON)
+    pre_count = len(cities)
+
+    to_drop = [row for row in cities if is_target(row)]
+    kept = [row for row in cities if not is_target(row)]
+
+    drop_count = len(to_drop)
+    post_count = len(kept)
+
+    # Defensive check: any row whose id is in our allowlist but whose name
+    # doesn't match the expected pattern (could indicate the data has
+    # shifted since this script was written).
+    rows_by_id = {row.get("id"): row for row in cities}
+    suspicious: List[dict] = []
+    for pid in PROVINCIA_IDS:
+        row = rows_by_id.get(pid)
+        if row is not None and not matches_provincia(row):
+            suspicious.append(row)
+    cross = rows_by_id.get(CROSS_STATE_ALICANTE_ID)
+    if cross is not None and not matches_cross_state_alicante(cross):
+        suspicious.append(cross)
+
+    print(f"Input file:          {CITIES_JSON.relative_to(REPO_ROOT)}")
+    print(f"Pre-clean count:     {pre_count}")
+    print(f"Provincia drops:     "
+          f"{sum(1 for r in to_drop if matches_provincia(r))} / "
+          f"{len(PROVINCIA_IDS)} expected")
+    print(f"Cross-state Alicante drop: "
+          f"{sum(1 for r in to_drop if matches_cross_state_alicante(r))} / 1 expected")
+    print(f"Total drops:         {drop_count}")
+    print(f"Post-clean count:    {post_count}")
+
+    if suspicious:
+        print(
+            "\nERROR: target ids exist but do not match expected name/state — "
+            "refusing to drop them:",
+            file=sys.stderr,
+        )
+        for row in suspicious:
+            print(
+                f"  id={row.get('id')} name={row.get('name')!r} "
+                f"state_code={row.get('state_code')!r}",
+                file=sys.stderr,
+            )
+        return 2
+
+    if drop_count == 0:
+        print("\nNo placeholder rows found — nothing to do (idempotent).")
+        return 0
+
+    if drop_count != EXPECTED_DROP_COUNT or pre_count != EXPECTED_PRE_COUNT:
+        print(
+            f"\nWARNING: counts diverge from the expected baseline "
+            f"({EXPECTED_PRE_COUNT} -> drop {EXPECTED_DROP_COUNT} -> "
+            f"{EXPECTED_POST_COUNT}). Got {pre_count} -> drop {drop_count} "
+            f"-> {post_count}. Review the diff before merging.",
+            file=sys.stderr,
+        )
+
+    if args.dry_run:
+        print("\n--dry-run: not writing.")
+        for r in to_drop:
+            print(f"  would drop id={r['id']} name={r['name']!r} "
+                  f"state_code={r.get('state_code')!r} type={r.get('type')!r}")
+        return 0
+
+    with CITIES_JSON.open("w", encoding="utf-8") as fh:
+        json.dump(kept, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+    print(f"\nWrote {post_count} records to {CITIES_JSON.relative_to(REPO_ROOT)}.")
+    print("Run `python3 bin/scripts/sync/normalize_json.py "
+          "contributions/cities/ES.json` next to canonicalize formatting.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/scripts/fixes/spain_retag_admin_types.py
+++ b/bin/scripts/fixes/spain_retag_admin_types.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Retag mistyped admin-level rows in contributions/cities/ES.json to type='city'.
+
+Issue #1498 follow-up to PR-A (which dropped 22 admin-level placeholders).
+After PR-A, ES.json contains ~6,920 rows whose `type` field is set to
+`adm1`, `adm2`, or `adm3` even though they are real Spanish municipalities
+(provincial capitals, big cities, and small towns alike). This script
+retags those rows to `type='city'` so consuming apps stop misclassifying
+real cities as administrative regions.
+
+Why these rows are real cities (spot-checked, see PR description for
+samples):
+  - 100% have geographic coordinates.
+  - 99%+ have a `wikiDataId` reference.
+  - Almost all have a non-zero `population`.
+  - The names map cleanly to municipalities visible on Spanish gov
+    sources (provincial capitals like Zaragoza/Murcia/Sevilla typed
+    `adm1`; province-capitals-or-comparable typed `adm2`; small towns
+    typed `adm3`).
+
+Conservative scope:
+  - Only `country_code='ES'` rows are touched.
+  - Only `type` in {'adm1', 'adm2', 'adm3'} is rewritten.
+  - **Not** touched: `type='section'` (61 rows, mixed quality — needs
+    separate per-row review), `type='locality'` (6 rows), `type='city'`
+    (already correct), `type='capital'`/`'historical_capital'`/`'adm4'`
+    (1 each — left alone).
+
+Idempotent: re-running on already-retagged data writes nothing and exits 0.
+
+Usage:
+    python3 bin/scripts/fixes/spain_retag_admin_types.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CITIES_JSON = REPO_ROOT / "contributions/cities/ES.json"
+
+ADMIN_TYPES = ("adm1", "adm2", "adm3")
+TARGET_TYPE = "city"
+COUNTRY_CODE = "ES"
+
+
+def load_cities(path: Path) -> List[dict]:
+    """Read the cities JSON file and verify the top-level shape."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise SystemExit(f"Expected JSON array at {path}, got {type(data).__name__}")
+    return data
+
+
+def is_target(row: dict) -> bool:
+    """Row is an ES record whose type is one of the admin levels we retag."""
+    return row.get("country_code") == COUNTRY_CODE and row.get("type") in ADMIN_TYPES
+
+
+def type_distribution(rows: List[dict]) -> "collections.Counter[str]":
+    """Counter of `type` values across rows."""
+    return collections.Counter(r.get("type") for r in rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the rewrite plan without rewriting the file.",
+    )
+    args = parser.parse_args()
+
+    if not CITIES_JSON.exists():
+        raise SystemExit(f"Cities file not found: {CITIES_JSON}")
+
+    cities = load_cities(CITIES_JSON)
+    pre_count = len(cities)
+
+    before = type_distribution(cities)
+    targets = [r for r in cities if is_target(r)]
+    retag_count = len(targets)
+
+    # Track per-source-type retag counts for reporting.
+    by_source = collections.Counter(r.get("type") for r in targets)
+
+    # Sample 5 retagged rows for human eyes.
+    sample = targets[:5]
+
+    # State_code distribution: every row keeps its existing state_code.
+    # Verify no row would change state_code as a side-effect.
+    state_code_changes = 0  # this script never modifies state_code; sanity assert.
+
+    print(f"Input file:        {CITIES_JSON.relative_to(REPO_ROOT)}")
+    print(f"Pre-retag count:   {pre_count}")
+    print(f"Type distribution before:")
+    for t, c in sorted(before.items(), key=lambda x: -x[1]):
+        print(f"  {t!r:>20}: {c}")
+    print(f"Retag candidates:  {retag_count}")
+    for src in ADMIN_TYPES:
+        print(f"  from {src!r}: {by_source.get(src, 0)}")
+
+    if retag_count == 0:
+        print("\nNo admin-typed rows found — nothing to do (idempotent).")
+        return 0
+
+    print("\nSample of rows that will be retagged:")
+    for r in sample:
+        print(
+            f"  id={r['id']} {r['name']!r} state_code={r.get('state_code')!r} "
+            f"old_type={r.get('type')!r} -> {TARGET_TYPE!r}"
+        )
+
+    if args.dry_run:
+        print("\n--dry-run: not writing.")
+        return 0
+
+    for row in cities:
+        if is_target(row):
+            row["type"] = TARGET_TYPE
+
+    after = type_distribution(cities)
+    print(f"\nType distribution after:")
+    for t, c in sorted(after.items(), key=lambda x: -x[1]):
+        print(f"  {t!r:>20}: {c}")
+    assert sum(after.values()) == sum(before.values()), "row count drift!"
+    assert state_code_changes == 0
+    # Sanity: no row in ADMIN_TYPES remains.
+    leftover = sum(after[t] for t in ADMIN_TYPES if t in after)
+    assert leftover == 0, f"{leftover} admin-typed rows still present"
+
+    with CITIES_JSON.open("w", encoding="utf-8") as fh:
+        json.dump(cities, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+    print(f"\nWrote {pre_count} records to {CITIES_JSON.relative_to(REPO_ROOT)}.")
+    print("Run `python3 bin/scripts/sync/normalize_json.py "
+          "contributions/cities/ES.json` next to canonicalize formatting.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #1498. **Stacks on top of #1516 — please review/merge that one first.**

Bulk-retags **6,920 rows** in `contributions/cities/ES.json` whose `type` field is `adm1`/`adm2`/`adm3` to `type='city'`. Touches **only the `type` field** — coordinates, names, state codes, populations all unchanged.

### Why these are real cities, not admin regions

Spot-check across a 60-row random sample (20 of each adm type):

- **adm1 (20 in file):** Barcelona, Valencia, Sevilla, Zaragoza, Murcia, Pamplona, Valladolid, Las Palmas, Santiago de Compostela, Santander, Toledo, Mérida, Logroño, Vitoria-Gasteiz, Oviedo, Palma, …
- **adm2 (40 in file):** Córdoba, Málaga, Lleida, Girona, Soria, Segovia, Jaén, Lugo, Albacete, Guadalajara, Palencia, Zamora, Castelló de la Plana, Ciudad Real, Alicante/Alacant, …
- **adm3 (6,860 in file):** real Spanish municipalities, all with coordinates, most with population.

| Type | Count | wikiDataId | population>0 | coords |
|------|------:|-----------:|-------------:|-------:|
| adm1 | 20 | 20/20 | 20/20 | 20/20 |
| adm2 | 40 | 39/40 | 38/40 | 40/40 |
| adm3 | 6,860 | 6,854/6,860 | 6,458/6,860 | 6,860/6,860 |

### Type counts

| Type | Before | After |
|------|--:|--:|
| city | 1,416 | **8,336** |
| section | 60 | 60 |
| adm3 | 6,860 | 0 |
| adm2 | 40 | 0 |
| adm1 | 20 | 0 |
| locality | 6 | 6 |
| capital / historical_capital / adm4 | 1 each | 1 each |
| **Total** | **8,405** | **8,405** |

(The brief estimated "6,936 → 8,357 city". Actual is 6,920 → 8,336 because 16 of the 22 rows PR-A dropped were already typed adm1/adm2/adm3.)

### Out of scope (deliberately not touched)

- `type='section'` (60 rows): mixed — some are real Madrid/Barcelona neighbourhoods, some look like real towns. Needs row-by-row review, not bulk retag.
- `type='locality'` (6 rows), `type='capital'` / `'historical_capital'` / `'adm4'` (1 each): left alone.

### Implementation

`bin/scripts/fixes/spain_retag_admin_types.py` — single-pass mutation. Asserts row count is preserved and zero admin-typed rows remain. Idempotent: re-run produces 0 candidates.

### Validation

- Schema: 0 errors.
- Cross-reference: 0 errors. State codes byte-for-byte unchanged, so 0 leakage.
- Coordinate-bounds: 127 OOB (Canary Islands `TF`/`GC`), identical to PR-A head.
- Same-name + ≤5km duplicate pairs: 45, **identical to PR-A head**.
- Diff inspection: 6,920 row mutations, every change is exactly the `type` field. Zero collateral changes.

### Constraints honoured

- Touches only the `type` field of `country_code='ES'` rows.
- Does **not** modify `states.json` or `countries.json`.

Closes #1498.